### PR TITLE
Fix recipe prerequisites for multi-job builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,17 +117,19 @@ VERSION: Makefile
 %.cmx: %.ml
 	ocamlfind ocamlopt $(OCAMLFLAGS) -c -package "$(OCAMLPACKS)" $<
 
-atd_parser.mli: atd_parser.mly
+atd_parser.mli: atd_parser.mly atd_ast.cmi
 	menhir $<
 
 atd_parser.ml: atd_parser.mly
 	menhir $<
 
-atd_lexer.ml: atd_lexer.mll
+atd_lexer.ml: atd_lexer.mll atd_parser.mli atd_parser.cmi
 	ocamllex $<
 
 atd_doc_lexer.ml: atd_doc_lexer.mll
 	ocamllex $<
+
+atd_util.ml: atd_lexer.ml
 
 dep: $(SOURCES) Makefile
 	ocamlfind ocamldep -package "$(OCAMLPACKS)" $(MLI) $(ML) > dep


### PR DESCRIPTION
Some prerequisites for recpes are missing for multi-job builds to work.

Example output with a multi-job build with the current makefile:
```sh
echo 'let version = "1.2.0"' > atd_version.ml
menhir atd_parser.mly
ocamlfind ocamldep -package "easy-format unix str" atd_ast.mli atd_annot.mli atd_parser.mli atd_doc.mli atd_print.mli atd_expand.mli atd_inherit.mli atd_util.mli atd_reflect.mli atd_indent.mli atd_version.ml atd_ast.ml atd_annot.ml atd_parser.ml atd_lexer.ml atd_doc_lexer.ml atd_doc.ml atd_print.ml atd_predef.ml atd_check.ml atd_expand.ml atd_inherit.ml atd_sort.ml atd_util.ml atd_reflect.ml atd_indent.ml > dep
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_version.ml
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_ast.mli
ocamllex atd_lexer.mll
ocamllex atd_doc_lexer.mll
72 states, 1997 transitions, table size 8420 bytes
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_predef.ml
46 states, 313 transitions, table size 1528 bytes
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_check.ml
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_expand.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_inherit.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_sort.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_util.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_reflect.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_indent.mli
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_ast.ml
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_lexer.ml
ocamlfind ocamlc -dtypes -g -c -package "easy-format unix str" atd_doc_lexer.ml
File "atd_lexer.mll", line 5, characters 7-17:
Error: Unbound module Atd_parser
make: *** [Makefile:115: atd_lexer.cmo] Error 2
make: *** Waiting for unfinished jobs....
```