### PR TITLE
Fix jbuilder errors

### DIFF
--- a/atd/test/jbuild
+++ b/atd/test/jbuild
@@ -3,6 +3,7 @@
 (executables
  ((libraries (atd))
   (names (unit_tests))
+  (public_names (unit_tests))  
   (package atd)))
 
 (alias

--- a/atdgen/test/jbuild
+++ b/atdgen/test/jbuild
@@ -49,6 +49,7 @@
 (executables
  ((libraries (atd atdgen))
   (names (test_atdgen_main))
+  (public_names (test_atdgen_main))
   (modules
    (test
     test3j_j


### PR DESCRIPTION
When I tried to build atd via make I got the following error:

`Error: this field is useless without a (public_names ...) field`

cc @rgrinberg 