### PR TITLE
move package declarations to aliases

### DIFF
--- a/atd/test/jbuild
+++ b/atd/test/jbuild
@@ -2,10 +2,10 @@
 
 (executables
  ((libraries (atd))
-  (names (unit_tests))
-  (package atd)))
+  (names (unit_tests))))
 
 (alias
  ((name   runtest)
+  (package atd)
   (deps   (unit_tests.exe))
   (action (run ${<}))))

--- a/atdgen/test/jbuild
+++ b/atdgen/test/jbuild
@@ -58,10 +58,10 @@
     testv
     test_atdgen_main
     test_atdgen_type_conv
-    test_lib))
-  (package atd)))
+    test_lib))))
 
 (alias
  ((name   runtest)
+  (package atd)
   (deps   (test_atdgen_main.exe))
   (action (run ${<}))))


### PR DESCRIPTION
This removes a warning