### PR TITLE
Don't use ocaml syntax just to generate version numbers

### DIFF
--- a/atd/src/jbuild
+++ b/atd/src/jbuild
@@ -1,13 +1,3 @@
-(* -*- tuareg -*- *)
-#require "unix"
-
-let version =
-  let ic = open_in "../../VERSION" in
-  let version = input_line ic in
-  close_in ic;
-  version
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (jbuild_version 1)
 
 (ocamllex (atd_lexer atd_doc_lexer))
@@ -17,11 +7,10 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  ((targets (atd_version.ml))
   (action
    (with-stdout-to ${@}
-    (echo "let version = \"%s\"")))))
+    (echo "let version = \"${version:atd}\"")))))
 
 (library
  ((name atd)
   (public_name atd)
   (wrapped false)
   (libraries (easy-format unix str))))
-|} version

--- a/atdgen/src/jbuild
+++ b/atdgen/src/jbuild
@@ -1,13 +1,3 @@
-(* -*- tuareg -*- *)
-#require "unix"
-
-let version =
-  let ic = open_in "../../VERSION" in
-  let version = input_line ic in
-  close_in ic;
-  version
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (jbuild_version 1)
 
 (ocamllex (ag_doc_lexer))
@@ -16,11 +6,10 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  ((targets (ag_version.ml))
   (action
    (with-stdout-to ${@}
-    (echo "let version = \"%s\"")))))
+    (echo "let version = \"${version:atd}\"")))))
 
 (library
  ((name atdgen)
   (public_name atdgen)
   (wrapped false)
   (libraries (atd str biniou yojson))))
-|} version


### PR DESCRIPTION
jbuilder has a ${version:pkg} variable that can be used instead