### PR TITLE
Add a bunch of mli's

### DIFF
--- a/atd/src/atd_check.mli
+++ b/atd/src/atd_check.mli
@@ -1,0 +1,1 @@
+val check : [ `Type of Atd_ast.type_def ] list -> unit

--- a/atd/src/atd_predef.mli
+++ b/atd/src/atd_predef.mli
@@ -1,0 +1,3 @@
+val list : (string * int * Atd_ast.type_def option) list
+
+val make_table : unit -> (string, int * Atd_ast.type_def option) Hashtbl.t

--- a/atdgen/src/ag_biniou.mli
+++ b/atdgen/src/ag_biniou.mli
@@ -1,0 +1,35 @@
+type biniou_int =
+    [ `Svint | `Uvint | `Int8 | `Int16 | `Int32 | `Int64 ]
+
+type biniou_float = [ `Float32 | `Float64 ]
+
+type biniou_list = [ `Array | `Table ]
+
+type biniou_field = { biniou_unwrapped : bool }
+
+type biniou_repr =
+    [
+    | `Unit
+    | `Bool
+    | `Int of biniou_int
+    | `Float of biniou_float
+
+    | `String
+    | `Sum
+    | `Record
+    | `Tuple
+    | `List of biniou_list
+    | `Option
+    | `Nullable
+    | `Wrap
+    | `External
+
+    | `Cell
+    | `Field of biniou_field
+    | `Variant
+    | `Def
+    ]
+
+val get_biniou_float : Atd_annot.t -> biniou_float
+val get_biniou_int : Atd_annot.t -> biniou_int
+val get_biniou_list : Atd_annot.t -> biniou_list

--- a/atdgen/src/ag_doc_lexer.mli
+++ b/atdgen/src/ag_doc_lexer.mli
@@ -1,0 +1,5 @@
+
+val parse_string
+  : string
+  -> [> `Paragraph of [> `Code of string | `Text of string ] list
+     | `Pre of string ] list

--- a/atdgen/src/ag_error.mli
+++ b/atdgen/src/ag_error.mli
@@ -1,0 +1,11 @@
+val error : Atd_ast.loc -> string -> 'a
+
+val error2 : Atd_ast.loc -> string -> Atd_ast.loc -> string -> 'a
+
+val error3
+  : Atd_ast.loc
+  -> string
+  -> Atd_ast.loc
+  -> string
+  -> Atd_ast.loc
+  -> string -> 'a

--- a/atdgen/src/ag_mapping.mli
+++ b/atdgen/src/ag_mapping.mli
@@ -1,0 +1,74 @@
+type loc = Atd_ast.loc
+
+type loc_id = string
+
+type ('a, 'b) mapping =
+    [ `Unit of loc * 'a * 'b
+    | `Bool of loc * 'a * 'b
+    | `Int of loc * 'a * 'b
+    | `Float of loc * 'a * 'b
+    | `String of loc * 'a * 'b
+    | `Sum of loc * ('a, 'b) variant_mapping array * 'a * 'b
+    | `Record of loc * ('a, 'b) field_mapping array * 'a * 'b
+    | `Tuple of loc * ('a, 'b) cell_mapping array * 'a * 'b
+    | `List of loc * ('a, 'b) mapping * 'a * 'b
+    | `Option of loc * ('a, 'b) mapping * 'a * 'b
+    | `Nullable of loc * ('a, 'b) mapping * 'a * 'b
+    | `Wrap of loc * ('a, 'b) mapping * 'a * 'b
+    | `Name of loc * string * ('a, 'b) mapping list * 'a option * 'b option
+    | `External of loc * string * ('a, 'b) mapping list * 'a * 'b
+    | `Tvar of loc * string ]
+
+and ('a, 'b) cell_mapping = {
+  cel_loc : loc;
+  cel_value : ('a, 'b) mapping;
+  cel_arepr : 'a;
+  cel_brepr : 'b
+}
+
+and ('a, 'b) field_mapping = {
+  f_loc : loc;
+  f_name : string;
+  f_kind : Atd_ast.field_kind;
+  f_value : ('a, 'b) mapping;
+  f_arepr : 'a;
+  f_brepr : 'b
+}
+
+and ('a, 'b) variant_mapping = {
+  var_loc : loc;
+  var_cons : string;
+  var_arg : ('a, 'b) mapping option;
+  var_arepr : 'a;
+  var_brepr : 'b
+}
+
+type ('a, 'b) def = {
+  def_loc : loc;
+  def_name : string;
+  def_param : string list;
+  def_value : ('a, 'b) mapping option;
+  def_arepr : 'a;
+  def_brepr : 'b;
+}
+
+val as_abstract
+  : [> `Name of 'a * (Atd_ast.loc * string * 'b list) * 'c ]
+  -> (loc * 'c) option
+
+val is_abstract :
+  [> `Name of 'a * (Atd_ast.loc * string * 'b list) * 'c ] -> bool
+
+val loc_of_mapping : ('a, 'b) mapping -> loc
+
+val flatten : ('a * 'b list) list -> 'b list
+
+val make_deref
+  : (bool * ('a, 'b) def list) list
+  -> ('a, 'b) mapping
+  -> ('a, 'b) mapping
+
+val unwrap
+  : (('a, 'b) mapping -> ('a, 'b) mapping)
+  -> ('a, 'b) mapping
+  -> ('a, 'b) mapping

--- a/atdgen/src/ag_ob_emit.mli
+++ b/atdgen/src/ag_ob_emit.mli
@@ -1,0 +1,15 @@
+
+val make_ocaml_files
+  : opens:string list
+  -> with_typedefs:bool
+  -> with_create:bool
+  -> with_fundefs:bool
+  -> all_rec:bool
+  -> pos_fname:string option
+  -> pos_lnum:int option
+  -> type_aliases:string option
+  -> force_defaults:'a
+  -> name_overlap:bool
+  -> ocaml_version:(int * int) option
+  -> pp_convs:[ `Camlp4 of string list | `Ppx of string list ]
+  -> string option -> [< `Files of string | `Stdout ] -> unit

--- a/atdgen/src/ag_ob_mapping.mli
+++ b/atdgen/src/ag_ob_mapping.mli
@@ -1,0 +1,13 @@
+
+type ob_mapping =
+    (Ag_ocaml.atd_ocaml_repr, Ag_biniou.biniou_repr) Ag_mapping.mapping
+
+
+val defs_of_atd_modules :
+  ('a *
+   [< `Type of
+        Atd_ast.loc * (string * string list * Atd_annot.t) * Atd_ast.type_expr ]
+     list)
+    list ->
+  ('a * (Ag_ocaml.atd_ocaml_repr, Ag_biniou.biniou_repr) Ag_mapping.def list)
+    list

--- a/atdgen/src/ag_ob_mapping.mli
+++ b/atdgen/src/ag_ob_mapping.mli
@@ -1,3 +1,6 @@
+(** The type signatures in this module are not yet for public consumption.
+
+    Please don't rely on them in any way.*)
 
 type ob_mapping =
     (Ag_ocaml.atd_ocaml_repr, Ag_biniou.biniou_repr) Ag_mapping.mapping

--- a/atdgen/src/ag_ob_run.mli
+++ b/atdgen/src/ag_ob_run.mli
@@ -1,0 +1,75 @@
+exception Error of string
+
+
+val missing_fields : int array -> string array -> 'a
+val missing_tuple_fields : int -> int list -> 'a
+
+
+val write_untagged_option
+  : (Bi_outbuf.t -> 'a -> unit)
+  -> Bi_outbuf.t
+  -> 'a option
+  -> unit
+
+val write_untagged_list
+  : Bi_io.node_tag
+  -> (Bi_outbuf.t -> 'a -> 'b)
+  -> Bi_outbuf.t
+  -> 'a list
+  -> unit
+
+val write_untagged_array
+  : Bi_io.node_tag
+  -> (Bi_outbuf.t -> 'a -> 'b)
+  -> Bi_outbuf.t
+  -> 'a array
+  -> unit
+
+val get_list_reader
+  : (Bi_io.node_tag -> Bi_inbuf.t -> 'a)
+  -> Bi_io.node_tag
+  -> Bi_inbuf.t
+  -> 'a list
+
+val get_array_reader
+  : (Bi_io.node_tag -> Bi_inbuf.t -> 'a)
+  -> Bi_io.node_tag
+  -> Bi_inbuf.t
+  -> 'a array
+
+val read_list : (Bi_io.node_tag -> Bi_inbuf.t -> 'a) -> Bi_inbuf.t -> 'a list
+
+val unsupported_variant : int -> bool -> 'a
+
+val read_error_at : Bi_inbuf.t -> 'a
+
+
+val read_int : Bi_inbuf.t -> int
+val read_char : Bi_inbuf.t -> char
+val read_bool : Bi_inbuf.t -> bool
+val read_string : Bi_inbuf.t -> string
+val read_float32 : Bi_inbuf.t -> float
+val read_float64 : Bi_inbuf.t -> float
+val read_int64 : Bi_inbuf.t -> int64
+val read_int32 : Bi_inbuf.t -> int32
+val read_array : (Bi_io.node_tag -> Bi_inbuf.t -> 'a) -> Bi_inbuf.t -> 'a array
+val read_array_value
+  : (Bi_io.node_tag -> Bi_inbuf.t -> 'a)
+  -> Bi_inbuf.t
+  -> 'a array
+
+val get_unit_reader : Bi_io.node_tag -> Bi_inbuf.t -> unit
+val get_char_reader : Bi_io.node_tag -> Bi_inbuf.t -> char
+val get_bool_reader : Bi_io.node_tag -> Bi_inbuf.t -> bool
+val get_string_reader : Bi_io.node_tag -> Bi_inbuf.t -> string
+val get_float64_reader : Bi_io.node_tag -> Bi_inbuf.t -> float
+val get_float32_reader : Bi_io.node_tag -> Bi_inbuf.t -> float
+val get_int64_reader : Bi_io.node_tag -> Bi_inbuf.t -> int64
+val get_int32_reader : Bi_io.node_tag -> Bi_inbuf.t -> int32
+val get_int_reader : Bi_io.node_tag -> Bi_inbuf.t -> int
+
+val read_error : unit -> 'a
+
+
+val array_iter2 : ('a -> 'b -> 'c) -> 'a -> 'b array -> unit
+val array_init2 : int -> 'a -> (int -> 'a -> 'b) -> 'b array

--- a/atdgen/src/ag_oj_mapping.mli
+++ b/atdgen/src/ag_oj_mapping.mli
@@ -1,3 +1,6 @@
+(** The type signatures in this module are not yet for public consumption.
+
+    Please don't rely on them in any way.*)
 
 type o = Ag_ocaml.atd_ocaml_repr
 type j = Ag_json.json_repr

--- a/atdgen/src/ag_oj_mapping.mli
+++ b/atdgen/src/ag_oj_mapping.mli
@@ -1,0 +1,14 @@
+
+type o = Ag_ocaml.atd_ocaml_repr
+type j = Ag_json.json_repr
+
+type oj_mapping =
+    (Ag_ocaml.atd_ocaml_repr, Ag_json.json_repr) Ag_mapping.mapping
+
+val defs_of_atd_modules
+  : ('a *
+     [< `Type of
+          Atd_ast.loc * (string * string list * Atd_annot.t) * Atd_ast.type_expr ]
+       list
+    ) list
+  -> ('a * (Ag_ocaml.atd_ocaml_repr, Ag_json.json_repr) Ag_mapping.def list) list

--- a/atdgen/src/ag_ov_emit.mli
+++ b/atdgen/src/ag_ov_emit.mli
@@ -1,0 +1,15 @@
+
+val make_ocaml_files
+  : opens:string list
+  -> with_typedefs:bool
+  -> with_create:bool
+  -> with_fundefs:bool
+  -> all_rec:bool
+  -> pos_fname:string option
+  -> pos_lnum:int option
+  -> type_aliases:string option
+  -> force_defaults:'a
+  -> name_overlap:bool
+  -> ocaml_version:'b
+  -> pp_convs:[ `Camlp4 of string list | `Ppx of string list ]
+  -> string option -> [< `Files of string | `Stdout ] -> unit

--- a/atdgen/src/ag_ov_mapping.mli
+++ b/atdgen/src/ag_ov_mapping.mli
@@ -1,0 +1,14 @@
+
+type ov_mapping =
+    (Ag_ocaml.atd_ocaml_repr, Ag_validate.validate_repr) Ag_mapping.mapping
+
+val defs_of_atd_modules :
+  ('a *
+   [< `Type of
+        Atd_ast.loc * (string * string list * Atd_annot.t) * Atd_ast.type_expr &
+        'b * (string * 'c * 'd) * Atd_ast.type_expr ]
+     list)
+    list ->
+  ('a *
+   (Ag_ocaml.atd_ocaml_repr, Ag_validate.validate_repr) Ag_mapping.def list)
+    list

--- a/atdgen/src/ag_ov_mapping.mli
+++ b/atdgen/src/ag_ov_mapping.mli
@@ -1,3 +1,6 @@
+(** The type signatures in this module are not yet for public consumption.
+
+    Please don't rely on them in any way.*)
 
 type ov_mapping =
     (Ag_ocaml.atd_ocaml_repr, Ag_validate.validate_repr) Ag_mapping.mapping

--- a/atdgen/src/ag_ov_run.mli
+++ b/atdgen/src/ag_ov_run.mli
@@ -1,0 +1,14 @@
+
+val validate_list
+  : (([> `Index of int ] as 'a) list -> 'b -> 'c option)
+  -> 'a list
+  -> 'b list
+  -> 'c option
+
+val validate_array
+  : (([> `Index of int ] as 'a) list -> 'b -> 'c option)
+  -> 'a list
+  -> 'b array
+  -> 'c option
+
+val validate_option : ('a -> 'b -> 'c option) -> 'a -> 'b option -> 'c option

--- a/atdgen/src/ag_validate.mli
+++ b/atdgen/src/ag_validate.mli
@@ -1,0 +1,4 @@
+
+type validate_repr = (string option * bool)
+
+val get_validator : Atd_annot.t -> string option

--- a/atdgen/src/ag_xb_emit.mli
+++ b/atdgen/src/ag_xb_emit.mli
@@ -1,0 +1,5 @@
+
+type 'a def = ('a, Ag_biniou.biniou_repr) Ag_mapping.def
+type 'a grouped_defs = (bool * 'a def list) list
+
+val check : _ grouped_defs -> unit


### PR DESCRIPTION
The types aren't very pretty because they're mostly the inferred types but it's
a decent start. Now we have a clean separation of public/private functions
everywhere which means that we can add docs and start slowly removing dead
code (detectable with jbuilder build --dev)