### PR TITLE
Massive warnings clean up:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tests:
 check: tests
 
 clean:
-	rm -rf _build *.install
+	$(JBUILDER) clean
 
 .PHONY: all tests clean check
 

--- a/atd/src/atd_annot.ml
+++ b/atd/src/atd_annot.ml
@@ -35,7 +35,7 @@ let get_flag k k2 l =
       fun k1 ->
         try
           (* each section must be unique *)
-          let loc, l2 = List.assoc k1 l in
+          let _, l2 = List.assoc k1 l in
           let loc, o = List.assoc k2 l2 in
           match o with
               None -> Some true
@@ -57,12 +57,12 @@ let get_field parse default k k2 l =
       fun k1 ->
         try
           (* each section must be unique *)
-          let loc, l2 = List.assoc k1 l in
+          let _, l2 = List.assoc k1 l in
           let loc, o = List.assoc k2 l2 in
           match o with
               Some s ->
                 (match parse s with
-                     Some x as y -> y
+                     Some _ as y -> y
                    | None ->
                        error_at loc
                          (sprintf "Invalid annotation <%s %s=%S>" k1 k2 s)
@@ -122,9 +122,9 @@ let collapse merge l =
   let l = List.sort (fun (i, _) (j, _) -> compare j i) l in
   List.map snd l
 
-let override_values x1 x2 = x1
+let override_values x1 _ = x1
 
-let override_fields (loc1, l1) (loc2, l2) =
+let override_fields (loc1, l1) (_, l2) =
   (loc1, collapse override_values (l1 @ l2))
 
 let merge l =

--- a/atd/src/atd_ast.ml
+++ b/atd/src/atd_ast.ml
@@ -173,52 +173,49 @@ let map_all_annot f ((head, body) : full_module) =
 let rec fold (f : type_expr -> 'a -> 'a) (x : type_expr) acc =
   let acc = f x acc in
   match x with
-      `Sum (loc, variant_list, annot) ->
+      `Sum (_, variant_list, _annot) ->
         List.fold_right (fold_variant f) variant_list acc
 
-    | `Record (loc, field_list, annot) ->
+    | `Record (_, field_list, _annot) ->
         List.fold_right (fold_field f) field_list acc
 
-    | `Tuple (loc, l, annot) ->
-        List.fold_right (fun (loc, x, _) acc -> fold f x acc) l acc
+    | `Tuple (_, l, _annot) ->
+        List.fold_right (fun (_, x, _) acc -> fold f x acc) l acc
 
-    | `List (loc, type_expr, annot) ->
+    | `List (_, type_expr, _annot) ->
         fold f type_expr acc
 
-    | `Option (loc, type_expr, annot) ->
+    | `Option (_, type_expr, _annot) ->
         fold f type_expr acc
 
-    | `Nullable (loc, type_expr, annot) ->
+    | `Nullable (_, type_expr, _annot) ->
         fold f type_expr acc
 
-    | `Shared (loc, type_expr, annot) ->
+    | `Shared (_, type_expr, _annot) ->
         fold f type_expr acc
 
-    | `Wrap (loc, type_expr, annot) ->
+    | `Wrap (_, type_expr, _annot) ->
         fold f type_expr acc
 
-    | `Name (loc, (loc2, name, type_expr_list), annot) ->
+    | `Name (_, (_2, _name, type_expr_list), _annot) ->
         List.fold_right (fold f) type_expr_list acc
 
-    | `Tvar (loc, string) ->
+    | `Tvar (_, _string) ->
         acc
 
 and fold_variant f x acc =
   match x with
-      `Variant (loc, _, Some type_expr) -> fold f type_expr acc
+      `Variant (_, _, Some type_expr) -> fold f type_expr acc
     | `Variant _ -> acc
-    | `Inherit (loc, type_expr) -> fold f type_expr acc
+    | `Inherit (_, type_expr) -> fold f type_expr acc
 
 and fold_field f x acc =
   match x with
-      `Field (loc, _, type_expr) -> fold f type_expr acc
-    | `Inherit (loc, type_expr) -> fold f type_expr acc
+      `Field (_, _, type_expr) -> fold f type_expr acc
+    | `Inherit (_, type_expr) -> fold f type_expr acc
 
 
 module Type_names = Set.Make (String)
-
-let union l =
-  List.fold_left Type_names.union Type_names.empty l
 
 let extract_type_names ?(ignorable = []) x =
   let ign s = List.mem s ignorable in
@@ -232,7 +229,7 @@ let extract_type_names ?(ignorable = []) x =
     fold (
       fun x acc ->
         match x with
-            `Name (loc, (loc2, name, l), a) -> add name acc
+            `Name (_, (_, name, _), _) -> add name acc
           | _ -> acc
     )
       x Type_names.empty

--- a/atd/src/atd_indent.ml
+++ b/atd/src/atd_indent.ml
@@ -12,7 +12,7 @@ let to_buffer ?(offset = 0) ?(indent = 2) buf l =
       `Block l -> List.iter (print (n + indent)) l
     | `Inline l -> List.iter (print n) l
     | `Line s ->
-        for i = 1 to n do
+        for _ = 1 to n do
           Buffer.add_char buf ' '
         done;
         Buffer.add_string buf s;

--- a/atd/src/atd_parser.mly
+++ b/atd/src/atd_parser.mly
@@ -103,7 +103,7 @@ type_expr:
      { let pos1 = $startpos in
        let pos2 = $endpos in
        let loc = (pos1, pos2) in
-       let loc2, name, args = x in
+       let _, name, args = x in
        match name, args with
            "list", [x] -> `List (loc, x, a)
          | "option", [x] -> `Option (loc, x, a)

--- a/atd/src/atd_print.ml
+++ b/atd/src/atd_print.ml
@@ -176,19 +176,19 @@ let make_closures format_annot =
             )
           )
 
-      | `List (loc, t, a) ->
+      | `List (_, t, a) ->
           format_type_name "list" [t] a
 
-      | `Option (loc, t, a) ->
+      | `Option (_, t, a) ->
           format_type_name "option" [t] a
 
-      | `Nullable (loc, t, a) ->
+      | `Nullable (_, t, a) ->
           format_type_name "nullable" [t] a
 
-      | `Shared (loc, t, a) ->
+      | `Shared (_, t, a) ->
           format_type_name "shared" [t] a
 
-      | `Wrap (loc, t, a) ->
+      | `Wrap (_, t, a) ->
           format_type_name "wrap" [t] a
 
       | `Name (_, (_, name, args), a) ->
@@ -205,7 +205,7 @@ let make_closures format_annot =
   and format_inherit t =
     horizontal_sequence [ make_atom "inherit"; format_type_expr t ]
 
-  and format_tuple_field (loc, x, a) =
+  and format_tuple_field (_, x, a) =
     prepend_colon_annots a (format_type_expr x)
 
   and format_field x =
@@ -238,7 +238,7 @@ let make_closures format_annot =
       | `Inherit (_, t) -> format_inherit t
   in
 
-  let format_full_module ((loc, an), l) =
+  let format_full_module ((_, an), l) =
     List (
       ("", "", "", rlist),
       List.map format_annot an @ List.map format_module_item l
@@ -253,7 +253,7 @@ let format ?(annot = default_annot) x =
   let f, _, _ = make_closures annot in
   f x
 
-let default_format, default_format_type_name, default_format_type_expr =
+let _default_format, default_format_type_name, default_format_type_expr =
   make_closures default_annot
 
 let string_of_type_name name args an =

--- a/atd/src/atd_reflect.ml
+++ b/atd/src/atd_reflect.ml
@@ -163,7 +163,7 @@ let %s_head : Atd_ast.module_head =
 "
     name print_annot_list an
 
-let print_full_module_def buf name ((loc, an), l) =
+let print_full_module_def buf name ((_, an), l) =
   print_module_head_def buf name an;
   print_module_body_def buf name l;
   bprintf buf "\

--- a/atd/src/atd_reflect.ml
+++ b/atd/src/atd_reflect.ml
@@ -4,7 +4,7 @@
 
 open Printf
 
-let print_loc buf (pos1, pos2) =
+let print_loc buf (_, _) =
   bprintf buf "loc"
 
 let print_list f buf l =

--- a/atd/src/atd_sort.ml
+++ b/atd/src/atd_sort.ml
@@ -56,10 +56,6 @@ struct
 
   let debug = ref false
 
-  let print msg =
-    if !debug then
-      printf "%s\n%!" msg
-
   let print_nodes msg nodes =
     if !debug then
       printf "%s: %s\n%!"
@@ -113,9 +109,6 @@ struct
       Some (v, S.remove v nodes)
     with Not_found ->
       None
-
-  let remove_list set l =
-    List.fold_left (fun set v -> S.remove v set) set l
 
   let add_list set l =
     List.fold_left (fun set v -> S.add v set) set l
@@ -271,7 +264,7 @@ struct
       ) l
     ) l;
     let graph = { forward; backward } in
-    let nodes = Hashtbl.fold (fun k v set -> S.add v set) node_tbl S.empty in
+    let nodes = Hashtbl.fold (fun _ v set -> S.add v set) node_tbl S.empty in
 
     let sorted_groups = sort_subgraph graph nodes in
 
@@ -296,7 +289,7 @@ end
 let rec in_order result a b =
   match result with
   | [] -> false
-  | (cyclic, l) :: ll ->
+  | (_, l) :: ll ->
       if List.mem b l then
         false
       else if List.mem a l then

--- a/atd/src/atd_util.ml
+++ b/atd/src/atd_util.ml
@@ -71,7 +71,7 @@ module Tsort = Atd_sort.Make (
     type id = string (* type name *)
 
     let id def =
-      let `Type (loc, (name, _, _), x) = def in
+      let `Type (_, (name, _, _), _) = def in
       name
 
     let to_string name = name
@@ -83,7 +83,7 @@ let tsort l0 =
   let l =
     List.map (
       fun def ->
-        let `Type (loc, (name, _, _), x) = def in
+        let `Type (_, (_, _, _), x) = def in
         let deps = Atd_ast.extract_type_names ~ignorable x in
         (def, deps)
     ) l0

--- a/atdcat/atdcat.ml
+++ b/atdcat/atdcat.ml
@@ -4,12 +4,12 @@ let html_of_doc loc s =
   let doc = Atd_doc.parse_text loc s in
   Atd_doc.html_of_doc doc
 
-let format_html_comments ((section, (loc, l)) as x) =
+let format_html_comments ((section, (_, l)) as x) =
   match section with
       "doc" ->
         (try
            match List.assoc "html" l with
-               (loc, Some s) ->
+               (_, Some s) ->
                  let comment = "(*html " ^ s ^ "*)" in
                  Easy_format.Atom (comment, Easy_format.atom)
              | _ -> raise Not_found
@@ -42,9 +42,9 @@ let print_ml ~name ast =
 let strip all sections x =
   let filter =
     if all then
-      fun l -> []
+      fun _ -> []
     else
-      List.filter (fun (name, fields) -> not (List.mem name sections))
+      List.filter (fun (name, _) -> not (List.mem name sections))
   in
   Atd_ast.map_all_annot filter x
 
@@ -64,7 +64,7 @@ let parse
   let first_head =
     (* heads in other files than the first one are tolerated but ignored *)
     match heads with
-        x :: l -> x
+        x :: _ -> x
       | [] -> (Atd_ast.dummy_loc, [])
   in
   let m = first_head, List.flatten bodies in

--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -392,7 +392,7 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
             | None ->
                 (match mode with
                      `B | `J | `V ->
-                       Some (String.capitalize (Filename.basename base) ^ "_t")
+                       Some (String.capitalize_ascii (Filename.basename base) ^ "_t")
                    | _ -> None
           )
   in

--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -56,7 +56,7 @@ let parse_ocaml_version () =
 
 let get_default_name_overlap ocaml_version =
   match ocaml_version with
-  | Some (major, minor) when major < 4 -> false
+  | Some (major, _) when major < 4 -> false
   | Some (4, 0) -> false
   | _ -> true
 

--- a/atdgen/src/ag_mapping.ml
+++ b/atdgen/src/ag_mapping.ml
@@ -4,9 +4,6 @@ open Ag_error
 
 type loc = Atd_ast.loc
 
-let annot_error loc =
-  Ag_error.error loc "Invalid annotation"
-
 type loc_id = string
 
 (*
@@ -97,11 +94,11 @@ module Env = Map.Make (String)
 
 let rec subst env (x : (_, _) mapping) =
   match x with
-      `Unit (loc, _, _)
-    | `Bool (loc, _, _)
-    | `Int (loc, _, _)
-    | `Float (loc, _, _)
-    | `String (loc, _, _) -> x
+      `Unit (_, _, _)
+    | `Bool (_, _, _)
+    | `Int (_, _, _)
+    | `Float (_, _, _)
+    | `String (_, _, _) -> x
     | `Sum (loc, ar, a, b) ->
         `Sum (loc, Array.map (subst_variant env) ar, a, b)
     | `Record (loc, ar, a, b) ->
@@ -120,7 +117,7 @@ let rec subst env (x : (_, _) mapping) =
         `Name (loc, name, List.map (subst env) args, a, b)
     | `External (loc, name, args, a, b) ->
         `External (loc, name, List.map (subst env) args, a, b)
-    | `Tvar (loc, s) ->
+    | `Tvar (_, s) ->
         try Env.find s env
         with Not_found ->
           invalid_arg (sprintf "Ag_mapping.subst_var: '%s" s)
@@ -188,23 +185,5 @@ let make_deref
 *)
 let rec unwrap (deref: ('a, 'b) mapping -> ('a, 'b) mapping) x =
   match deref x with
-  | `Wrap (loc, x, a, b) -> unwrap deref x
+  | `Wrap (_, x, _, _) -> unwrap deref x
   | x -> x
-
-(* This is for debugging *)
-let constructor : ('a, 'b) mapping -> string = function
-  | `Unit _ -> "Unit"
-  | `Bool _ -> "Bool"
-  | `Int _ -> "Int"
-  | `Float _ -> "Float"
-  | `String _ -> "String"
-  | `Sum _ -> "Sum"
-  | `Record _ -> "Record"
-  | `Tuple _ -> "Tuple"
-  | `List _ -> "List"
-  | `Option _ -> "Option"
-  | `Nullable _ -> "Nullable"
-  | `Wrap _ -> "Wrap"
-  | `Name (loc, name, _, _, _) -> "Name " ^ name
-  | `External _ -> "External"
-  | `Tvar _ -> "Tvar"

--- a/atdgen/src/ag_ob_emit.ml
+++ b/atdgen/src/ag_ob_emit.ml
@@ -1313,12 +1313,12 @@ let make_ocaml_biniou_writer ~original_types deref is_rec let1 let2 def =
   let write_untagged_expr = make_writer deref ~tagged:false x in
   let eta_expand = is_rec && not (Ag_ox_emit.is_function write_untagged_expr) in
   let needs_annot = Ag_ox_emit.needs_type_annot x in
-  let extra_param, extra_args, type_annot =
+  let extra_param, extra_args =
     match eta_expand, needs_annot with
-    | true, false -> " ob x", " ob x", None
-    | true, true -> sprintf " ob (x : %s)" type_constraint, " ob x", None
-    | false, false -> "", "", None
-    | false, true -> "", "", Some (sprintf "_ -> %s -> _" type_constraint)
+    | true, false -> " ob x", " ob x"
+    | true, true -> sprintf " ob (x : %s)" type_constraint, " ob x"
+    | false, false -> "", ""
+    | false, true -> "", ""
   in
   let type_annot =
     match Ag_ox_emit.needs_type_annot x with

--- a/atdgen/src/ag_ob_emit.ml
+++ b/atdgen/src/ag_ob_emit.ml
@@ -9,7 +9,6 @@ open Atd_ast
 open Ag_error
 open Ag_mapping
 open Ag_ob_mapping
-open Ag_ob_spe
 
 (*
   OCaml code generator (biniou readers and writers)

--- a/atdgen/src/ag_ob_emit.ml
+++ b/atdgen/src/ag_ob_emit.ml
@@ -122,7 +122,7 @@ val %s_of_string :%s
           s;
 
         if with_create && Ag_ox_emit.is_exportable x then
-          let create_record_intf, create_record_impl =
+          let create_record_intf, _create_record_impl =
             Ag_ox_emit.make_record_creator deref x
           in
           bprintf buf "%s" create_record_intf;
@@ -133,9 +133,9 @@ val %s_of_string :%s
 
 let rec get_biniou_tag (x : ob_mapping) =
   match x with
-      `Unit (loc, `Unit, `Unit) -> "Bi_io.unit_tag"
-    | `Bool (loc, `Bool, `Bool) -> "Bi_io.bool_tag"
-    | `Int (loc, `Int o, `Int b) ->
+      `Unit (_, `Unit, `Unit) -> "Bi_io.unit_tag"
+    | `Bool (_, `Bool, `Bool) -> "Bi_io.bool_tag"
+    | `Int (_, `Int _, `Int b) ->
         (match b with
              `Uvint -> "Bi_io.uvint_tag"
            | `Svint -> "Bi_io.svint_tag"
@@ -144,30 +144,30 @@ let rec get_biniou_tag (x : ob_mapping) =
            | `Int32 -> "Bi_io.int32_tag"
            | `Int64 -> "Bi_io.int64_tag"
         )
-    | `Float (loc, `Float, `Float b) ->
+    | `Float (_, `Float, `Float b) ->
         (match b with
             `Float32 -> "Bi_io.float32_tag"
           | `Float64 -> "Bi_io.float64_tag"
         )
-    | `String (loc, `String, `String) -> "Bi_io.string_tag"
-    | `Sum (loc, a, `Sum x, `Sum) -> "Bi_io.variant_tag"
-    | `Record (loc, a, `Record o, `Record) -> "Bi_io.record_tag"
-    | `Tuple (loc, a, `Tuple, `Tuple) -> "Bi_io.tuple_tag"
-    | `List (loc, x, `List o, `List b) ->
+    | `String (_, `String, `String) -> "Bi_io.string_tag"
+    | `Sum (_, _, `Sum _, `Sum) -> "Bi_io.variant_tag"
+    | `Record (_, _, `Record _, `Record) -> "Bi_io.record_tag"
+    | `Tuple (_, _, `Tuple, `Tuple) -> "Bi_io.tuple_tag"
+    | `List (_, _, `List _, `List b) ->
         (match b with
              `Array -> "Bi_io.array_tag"
            | `Table -> "Bi_io.table_tag"
         )
-    | `Option (loc, x, `Option, `Option)
-    | `Nullable (loc, x, `Nullable, `Nullable) -> "Bi_io.num_variant_tag"
-    | `Wrap (loc, x, `Wrap _, `Wrap) -> get_biniou_tag x
+    | `Option (_, _, `Option, `Option)
+    | `Nullable (_, _, `Nullable, `Nullable) -> "Bi_io.num_variant_tag"
+    | `Wrap (_, x, `Wrap _, `Wrap) -> get_biniou_tag x
 
-    | `Name (loc, s, args, None, None) -> sprintf "%s_tag" s
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `Name (_, s, _, None, None) -> sprintf "%s_tag" s
+    | `External (_, _, _,
+                 `External (_, main_module, ext_name),
                  `External) ->
         sprintf "%s.%s_tag" main_module ext_name
-    | `Tvar (loc, s) -> sprintf "%s_tag" (name_of_var s)
+    | `Tvar (_, s) -> sprintf "%s_tag" (name_of_var s)
     | _ -> assert false
 
 let nth name i len =
@@ -235,9 +235,9 @@ let rec get_writer_name
 
   let un = if tagged then "" else "untagged_" in
   match x with
-      `Unit (loc, `Unit, `Unit) ->
+      `Unit (_, `Unit, `Unit) ->
         sprintf "Bi_io.write_%sunit" un
-    | `Bool (loc, `Bool, `Bool) ->
+    | `Bool (_, `Bool, `Bool) ->
         sprintf "Bi_io.write_%sbool" un
     | `Int (loc, `Int o, `Int b) ->
         (match o, b with
@@ -252,25 +252,25 @@ let rec get_writer_name
                error loc "Unsupported combination of OCaml/Biniou int types"
         )
 
-    | `Float (loc, `Float, `Float b) ->
+    | `Float (_, `Float, `Float b) ->
         (match b with
             `Float32 -> sprintf "Bi_io.write_%sfloat32" un
           | `Float64 -> sprintf "Bi_io.write_%sfloat64" un
         )
-    | `String (loc, `String, `String) ->
+    | `String (_, `String, `String) ->
         sprintf "Bi_io.write_%sstring" un
 
-    | `Tvar (loc, s) ->
+    | `Tvar (_, s) ->
         sprintf "write_%s%s" un (name_of_var s)
 
-    | `Name (loc, s, args, None, None) ->
+    | `Name (_, s, args, None, None) ->
         let l = List.map get_writer_names args in
         let s = String.concat " " (name_f s :: l) in
         if paren && l <> [] then "(" ^ s ^ ")"
         else s
 
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `External (_, _, args,
+                 `External (_, main_module, ext_name),
                  `External) ->
         let f = main_module ^ "." ^ name_f ext_name in
         let l = List.map get_writer_names args in
@@ -339,9 +339,9 @@ let rec get_reader_name
       sprintf "Ag_ob_run.get_%s_reader" s
   in
   match x with
-      `Unit (loc, `Unit, `Unit) -> xreader "unit"
+      `Unit (_, `Unit, `Unit) -> xreader "unit"
 
-    | `Bool (loc, `Bool, `Bool) -> xreader "bool"
+    | `Bool (_, `Bool, `Bool) -> xreader "bool"
 
     | `Int (loc, `Int o, `Int b) ->
         (match o, b with
@@ -356,29 +356,29 @@ let rec get_reader_name
                error loc "Unsupported combination of OCaml/Biniou int types"
         )
 
-    | `Float (loc, `Float, `Float b) ->
+    | `Float (_, `Float, `Float b) ->
         (match b with
             `Float32 -> xreader "float32"
           | `Float64 -> xreader "float64"
         )
 
-    | `String (loc, `String, `String) -> xreader "string"
+    | `String (_, `String, `String) -> xreader "string"
 
-    | `Tvar (loc, s) ->
+    | `Tvar (_, s) ->
         let name = name_of_var s in
         if tagged then
           sprintf "read_%s" name
         else
           sprintf "get_%s_reader" name
 
-    | `Name (loc, s, args, None, None) ->
+    | `Name (_, s, args, None, None) ->
         let l = List.map get_reader_names args in
         let s = String.concat " " (name_f s :: l) in
         if paren && l <> [] then "(" ^ s ^ ")"
         else s
 
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `External (_, _, args,
+                 `External (_, main_module, ext_name),
                  `External) ->
         let f = main_module ^ "." ^ name_f ext_name in
         let l = List.map get_reader_names args in
@@ -417,7 +417,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Ag_indent.t list =
     | `External _
     | `Tvar _ -> [ `Line (get_writer_name ~tagged x) ]
 
-    | `Sum (loc, a, `Sum x, `Sum) ->
+    | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               `Classic -> ""
@@ -446,14 +446,14 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Ag_indent.t list =
           `Block body;
         ]
 
-    | `Record (loc, a, `Record o, `Record) ->
+    | `Record (_, a, `Record o, `Record) ->
         let body = make_record_writer deref tagged a o in
         [
           `Annot ("fun", `Line "fun ob x ->");
           `Block body;
         ]
 
-    | `Tuple (loc, a, `Tuple, `Tuple) ->
+    | `Tuple (_, a, `Tuple, `Tuple) ->
         let main =
           let len = Array.length a in
           let a =
@@ -486,7 +486,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Ag_indent.t list =
           `Block body;
         ]
 
-    | `List (loc, x, `List o, `List b) ->
+    | `List (_, x, `List o, `List b) ->
         (match o, b with
              `List, `Array ->
                let tag = get_biniou_tag x in
@@ -518,19 +518,19 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Ag_indent.t list =
                ]
         )
 
-    | `Option (loc, x, `Option, `Option)
-    | `Nullable (loc, x, `Nullable, `Nullable) ->
+    | `Option (_, x, `Option, `Option)
+    | `Nullable (_, x, `Nullable, `Nullable) ->
         [
           `Line (sprintf "Ag_ob_run.write_%soption (" un);
           `Block (make_writer ~tagged:true deref x);
           `Line ")";
         ]
 
-    | `Wrap (loc, x, `Wrap o, `Wrap) ->
+    | `Wrap (_, x, `Wrap o, `Wrap) ->
         let simple_writer = make_writer ~tagged deref x in
         (match o with
             None -> simple_writer
-          | Some { Ag_ocaml.ocaml_wrap_t; ocaml_wrap; ocaml_unwrap } ->
+          | Some { Ag_ocaml.ocaml_unwrap; _ } ->
               [
                 `Line "fun ob x -> (";
                 `Block [
@@ -595,7 +595,7 @@ and make_record_writer deref tagged a record_kind =
         `Line (sprintf "let len = ref %i in" min_len);
         `Inline (
           List.fold_right (
-            fun (x, ocaml_fname, default, opt, unwrap) l ->
+            fun (_, ocaml_fname, default, opt, _) l ->
               if opt then
                 let getfield =
                   sprintf "let x_%s = x%s%s in" ocaml_fname dot ocaml_fname in
@@ -753,7 +753,7 @@ let study_record ~ocaml_version deref fields =
   let init_fields, create_record_fields = List.split field_assignments in
   let n, mapping =
     List.fold_left (
-      fun (i, acc) (x, name, default, opt, unwrap) ->
+      fun (i, acc) (_, _, _, opt, _) ->
         if not opt then
           (i+1, (Some i :: acc))
         else
@@ -806,7 +806,7 @@ let study_record ~ocaml_version deref fields =
     let field_names =
       let l =
         List.fold_right (
-          fun (x, name, default, opt, unwrap) acc ->
+          fun (x, _, _, opt, _) acc ->
             if not opt then
               sprintf "%S" x.f_name :: acc
             else
@@ -905,7 +905,7 @@ let rec make_reader
     | `External _
     | `Tvar _ -> [ `Line (get_reader_name ~tagged x) ]
 
-    | `Sum (loc, a, `Sum x, `Sum) ->
+    | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               `Classic -> ""
@@ -944,8 +944,8 @@ let rec make_reader
         let body = make_record_reader deref ~ocaml_version ~tagged type_annot a o in
         wrap_body ~tagged Bi_io.record_tag body
 
-    | `Tuple (loc, a, `Tuple, `Tuple) ->
         let body = make_tuple_reader deref ~ocaml_version ~tagged a in
+    | `Tuple (_, a, `Tuple, `Tuple) ->
         wrap_body ~tagged Bi_io.tuple_tag body
 
     | `List (loc, x, `List o, `List b) ->
@@ -990,8 +990,8 @@ let rec make_reader
                                      Bi_io.array_tag, body2 ]
         )
 
-    | `Option (loc, x, `Option, `Option)
-    | `Nullable (loc, x, `Nullable, `Nullable) ->
+    | `Option (_, x, `Option, `Option)
+    | `Nullable (_, x, `Nullable, `Nullable) ->
         let body = [
           `Line "match Char.code (Bi_inbuf.read_char ib) with";
           `Block [
@@ -1013,11 +1013,11 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.num_variant_tag body
 
-    | `Wrap (loc, x, `Wrap o, `Wrap) ->
+    | `Wrap (_, x, `Wrap o, `Wrap) ->
         let simple_reader = make_reader deref ~tagged ~ocaml_version x in
         (match o with
             None -> simple_reader
-          | Some { Ag_ocaml.ocaml_wrap } ->
+          | Some { Ag_ocaml.ocaml_wrap ; _ } ->
               if tagged then
                 [
                   `Line "fun ib ->";
@@ -1146,7 +1146,7 @@ and make_tuple_reader deref ~tagged ~ocaml_version a =
     let n = ref (Array.length cells) in
     (try
        for i = Array.length cells - 1 downto 0 do
-         let x, default = cells.(i) in
+         let _, default = cells.(i) in
          if default = None then (
            n := i + 1;
            raise Exit
@@ -1428,11 +1428,11 @@ let make_ocaml_biniou_impl ~with_create ~original_types ~ocaml_version
 
   if with_create then
     List.iter (
-      fun (is_rec, l) ->
+      fun (_, l) ->
         let l = List.filter Ag_ox_emit.is_exportable l in
         List.iter (
           fun x ->
-            let intf, impl = Ag_ox_emit.make_record_creator deref x in
+            let _, impl = Ag_ox_emit.make_record_creator deref x in
             Buffer.add_string buf impl
         ) l
     ) defs

--- a/atdgen/src/ag_ob_emit.mli
+++ b/atdgen/src/ag_ob_emit.mli
@@ -8,7 +8,7 @@ val make_ocaml_files
   -> pos_fname:string option
   -> pos_lnum:int option
   -> type_aliases:string option
-  -> force_defaults:'a
+  -> force_defaults:_ (* not used *)
   -> name_overlap:bool
   -> ocaml_version:(int * int) option
   -> pp_convs:[ `Camlp4 of string list | `Ppx of string list ]

--- a/atdgen/src/ag_ob_mapping.ml
+++ b/atdgen/src/ag_ob_mapping.ml
@@ -2,15 +2,8 @@ open Atd_ast
 open Ag_error
 open Ag_mapping
 
-type o = Ag_ocaml.atd_ocaml_repr
-type b = Ag_biniou.biniou_repr
-
 type ob_mapping =
     (Ag_ocaml.atd_ocaml_repr, Ag_biniou.biniou_repr) Ag_mapping.mapping
-
-type ob_def =
-    (Ag_ocaml.atd_ocaml_repr, Ag_biniou.biniou_repr) Ag_mapping.def
-
 
 (*
   Translation of the types into the ocaml/biniou mapping.

--- a/atdgen/src/ag_ob_mapping.ml
+++ b/atdgen/src/ag_ob_mapping.ml
@@ -1,4 +1,3 @@
-open Printf
 open Atd_ast
 open Ag_error
 open Ag_mapping

--- a/atdgen/src/ag_ob_mapping.ml
+++ b/atdgen/src/ag_ob_mapping.ml
@@ -26,7 +26,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
                    (List.map (mapping_of_field ocaml_field_prefix) l),
                  ocaml_t, biniou_t)
 
-    | `Tuple (loc, l, an) ->
+    | `Tuple (loc, l, _) ->
         let ocaml_t = `Tuple in
         let biniou_t = `Tuple in
         `Tuple (loc, Array.of_list (List.map mapping_of_cell l),
@@ -37,17 +37,17 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
         let biniou_t = `List (Ag_biniou.get_biniou_list an) in
         `List (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-    | `Option (loc, x, an) ->
+    | `Option (loc, x, _) ->
         let ocaml_t = `Option in
         let biniou_t = `Option in
         `Option (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-    | `Nullable (loc, x, an) ->
+    | `Nullable (loc, x, _) ->
         let ocaml_t = `Nullable in
         let biniou_t = `Nullable in
         `Nullable (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-    | `Shared (loc, x, a) ->
+    | `Shared (_, _, _) ->
         failwith "Sharing is no longer supported"
 
     | `Wrap (loc, x, a) ->
@@ -55,7 +55,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
         let json_t = `Wrap in
         `Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Name (loc, (loc2, s, l), an) ->
+    | `Name (loc, (_, s, l), an) ->
         (match s with
              "unit" ->
                `Unit (loc, `Unit, `Unit)
@@ -161,7 +161,7 @@ let def_of_atd (loc, (name, param, an), x) =
   let doc = Ag_doc.get_doc loc an in
   let o =
     match as_abstract x with
-        Some (loc2, an2) ->
+        Some (_, _) ->
           (match Ag_ocaml.get_ocaml_module_and_t `Biniou name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->

--- a/atdgen/src/ag_ob_run.ml
+++ b/atdgen/src/ag_ob_run.ml
@@ -1,3 +1,4 @@
+[@@@ocaml.warning "-32"]
 
 (*
   Runtime library

--- a/atdgen/src/ag_ob_run.mli
+++ b/atdgen/src/ag_ob_run.mli
@@ -1,3 +1,5 @@
+[@@@ocaml.warning "-32"]
+
 exception Error of string
 
 
@@ -13,14 +15,14 @@ val write_untagged_option
 
 val write_untagged_list
   : Bi_io.node_tag
-  -> (Bi_outbuf.t -> 'a -> 'b)
+  -> (Bi_outbuf.t -> 'a -> unit)
   -> Bi_outbuf.t
   -> 'a list
   -> unit
 
 val write_untagged_array
   : Bi_io.node_tag
-  -> (Bi_outbuf.t -> 'a -> 'b)
+  -> (Bi_outbuf.t -> 'a -> unit)
   -> Bi_outbuf.t
   -> 'a array
   -> unit
@@ -71,5 +73,5 @@ val get_int_reader : Bi_io.node_tag -> Bi_inbuf.t -> int
 val read_error : unit -> 'a
 
 
-val array_iter2 : ('a -> 'b -> 'c) -> 'a -> 'b array -> unit
+val array_iter2 : ('a -> 'b -> unit) -> 'a -> 'b array -> unit
 val array_init2 : int -> 'a -> (int -> 'a -> 'b) -> 'b array

--- a/atdgen/src/ag_ob_spe.ml
+++ b/atdgen/src/ag_ob_spe.ml
@@ -3,9 +3,6 @@
   Optimization of the biniou representation
 *)
 
-open Ag_mapping
-open Ag_ob_mapping
-
 let get_table_info deref x =
   match deref x with
       `Record y -> y

--- a/atdgen/src/ag_ocaml.ml
+++ b/atdgen/src/ag_ocaml.ml
@@ -737,7 +737,7 @@ and format_variant kind (s, o, doc) =
   in
   append_ocamldoc_comment variant doc
 
-let format_module_items pp_convs is_rec (l : ocaml_module_body) =
+let format_module_items pp_convs (l : ocaml_module_body) =
   match l with
       x :: l ->
         format_module_item pp_convs true x ::
@@ -745,7 +745,7 @@ let format_module_items pp_convs is_rec (l : ocaml_module_body) =
     | [] -> []
 
 let format_module_bodies pp_conv (l : (bool * ocaml_module_body) list) =
-  List.flatten (List.map (fun (is_rec, x) -> format_module_items pp_conv is_rec x) l)
+  List.flatten (List.map (fun (_, x) -> format_module_items pp_conv x) l)
 
 let format_head (loc, an) =
   match Ag_doc.get_doc loc an with

--- a/atdgen/src/ag_ocaml.ml
+++ b/atdgen/src/ag_ocaml.ml
@@ -783,21 +783,21 @@ let unwrap_option deref x =
 
 let get_implicit_ocaml_default deref x =
   match deref x with
-      `Unit (loc, `Unit, _) -> Some "()"
-    | `Bool (loc, `Bool, _) -> Some "false"
-    | `Int (loc, `Int o, _) ->
+      `Unit (_, `Unit, _) -> Some "()"
+    | `Bool (_, `Bool, _) -> Some "false"
+    | `Int (_, `Int o, _) ->
         Some (match o with
                   `Int -> "0"
                 | `Char -> "'\000'"
                 | `Int32 -> "0l"
                 | `Int64 -> "0L"
                 | `Float -> "0.")
-    | `Float (loc, `Float, _) -> Some "0.0"
-    | `String (loc, `String, _) -> Some "\"\""
-    | `List (loc, x, `List `List, _) -> Some "[]"
-    | `List (loc, x, `List `Array, _) -> Some "[||]"
-    | `Option (loc, x, `Option, _) -> Some "None"
-    | `Nullable (loc, x, `Nullable, _) -> Some "None"
+    | `Float (_, `Float, _) -> Some "0.0"
+    | `String (_, `String, _) -> Some "\"\""
+    | `List (_, _, `List `List, _) -> Some "[]"
+    | `List (_, _, `List `Array, _) -> Some "[||]"
+    | `Option (_, _, `Option, _) -> Some "None"
+    | `Nullable (_, _, `Nullable, _) -> Some "None"
     | _ -> None
 
 

--- a/atdgen/src/ag_ocaml.ml
+++ b/atdgen/src/ag_ocaml.ml
@@ -95,19 +95,19 @@ let ocaml_sum_of_string s : atd_ocaml_sum option =
   match s with
       "classic" -> Some `Classic
     | "poly" -> Some `Poly
-    | s -> None
+    | _ -> None
 
 let ocaml_record_of_string s : atd_ocaml_record option =
   match s with
       "record" -> Some `Record
     | "object" -> Some `Object
-    | s -> None
+    | _ -> None
 
 let ocaml_list_of_string s : atd_ocaml_list option =
   match s with
       "list" -> Some `List
     | "array" -> Some `Array
-    | s -> None
+    | _ -> None
 
 let string_of_ocaml_list (x : atd_ocaml_list) =
   match x with
@@ -271,7 +271,7 @@ let omap f = function None -> None | Some x -> Some (f x)
 
 let rec map_expr (x : type_expr) : ocaml_expr =
   match x with
-      `Sum (loc, l, an) ->
+      `Sum (_, l, an) ->
         let kind = get_ocaml_sum an in
         `Sum (kind, List.map map_variant l)
     | `Record (loc, l, an) ->
@@ -281,26 +281,26 @@ let rec map_expr (x : type_expr) : ocaml_expr =
           Ag_error.error loc "Empty record (not valid in OCaml)"
         else
           `Record (kind, List.map (map_field field_prefix) l)
-    | `Tuple (loc, l, an) ->
+    | `Tuple (_, l, _) ->
         `Tuple (List.map (fun (_, x, _) -> map_expr x) l)
-    | `List (loc, x, an) ->
+    | `List (_, x, an) ->
         let s = string_of_ocaml_list (get_ocaml_list an) in
         `Name (s, [map_expr x])
-    | `Option (loc, x, an) ->
+    | `Option (_, x, _) ->
         `Name ("option", [map_expr x])
-    | `Nullable (loc, x, an) ->
+    | `Nullable (_, x, _) ->
         `Name ("option", [map_expr x])
-    | `Shared (loc, x, a) ->
+    | `Shared (_, _, _) ->
         failwith "Sharing is not supported"
     | `Wrap (loc, x, a) ->
         (match get_ocaml_wrap loc a with
             None -> map_expr x
-          | Some { ocaml_wrap_t } -> `Name (ocaml_wrap_t, [])
+          | Some { ocaml_wrap_t ; _ } -> `Name (ocaml_wrap_t, [])
         )
-    | `Name (loc, (loc2, s, l), an) ->
+    | `Name (_, (_2, s, l), an) ->
         let s = get_ocaml_type_path s an in
         `Name (s, List.map map_expr l)
-    | `Tvar (loc, s) ->
+    | `Tvar (_, s) ->
         `Tvar s
 
 and map_variant (x : variant) : ocaml_variant =
@@ -313,7 +313,7 @@ and map_variant (x : variant) : ocaml_variant =
 and map_field ocaml_field_prefix (x : field) : ocaml_field =
   match x with
       `Inherit _ -> assert false
-    | `Field (loc, (atd_fname, fkind, an), x) ->
+    | `Field (loc, (atd_fname, _, an), x) ->
         let ocaml_fname =
           get_ocaml_fname (ocaml_field_prefix ^ atd_fname) an in
         let fname =
@@ -332,7 +332,7 @@ let map_def
   let define_alias =
     if is_predef || is_abstract || type_aliases <> None then
       match get_ocaml_module_and_t target s an1, type_aliases with
-          Some (types_module, main_module, s), _ -> Some (types_module, s)
+          Some (types_module, _, s), _ -> Some (types_module, s)
         | None, Some types_module -> Some (types_module, s)
 
         | None, None -> None
@@ -393,31 +393,31 @@ let map_module ~target ~type_aliases (l : module_body) : ocaml_module_body =
 
 let rec ocaml_of_expr_mapping (x : (atd_ocaml_repr, _) mapping) : ocaml_expr =
   match x with
-      `Unit (loc, `Unit, _) -> `Name ("unit", [])
-    | `Bool (loc, `Bool, _) -> `Name ("bool", [])
-    | `Int (loc, `Int x, _) -> `Name (string_of_ocaml_int x, [])
-    | `Float (loc, `Float, _) -> `Name ("float", [])
-    | `String (loc, `String, _) -> `Name ("string", [])
-    | `Sum (loc, a, `Sum kind, _) ->
+      `Unit (_, `Unit, _) -> `Name ("unit", [])
+    | `Bool (_, `Bool, _) -> `Name ("bool", [])
+    | `Int (_, `Int x, _) -> `Name (string_of_ocaml_int x, [])
+    | `Float (_, `Float, _) -> `Name ("float", [])
+    | `String (_, `String, _) -> `Name ("string", [])
+    | `Sum (_, a, `Sum kind, _) ->
         let l = Array.to_list a in
         `Sum (kind, List.map ocaml_of_variant_mapping l)
-    | `Record (loc, a, `Record o, _) ->
+    | `Record (_, a, `Record _, _) ->
         let l = Array.to_list a in
         `Record (`Record, List.map ocaml_of_field_mapping l)
-    | `Tuple (loc, a, o, _) ->
+    | `Tuple (_, a, _, _) ->
         let l = Array.to_list a in
         `Tuple (List.map (fun x -> ocaml_of_expr_mapping x.cel_value) l)
-    | `List (loc, x, `List kind, _) ->
+    | `List (_, x, `List kind, _) ->
         `Name (string_of_ocaml_list kind, [ocaml_of_expr_mapping x])
-    | `Option (loc, x, `Option, _) ->
+    | `Option (_, x, `Option, _) ->
         `Name ("option", [ocaml_of_expr_mapping x])
-    | `Nullable (loc, x, `Nullable, _) ->
+    | `Nullable (_, x, `Nullable, _) ->
         `Name ("option", [ocaml_of_expr_mapping x])
     | `Wrap _ ->
         assert false
-    | `Name (loc, s, l, _, _) ->
+    | `Name (_, s, l, _, _) ->
         `Name (s, List.map ocaml_of_expr_mapping l)
-    | `Tvar (loc, s) ->
+    | `Tvar (_, s) ->
         `Tvar s
     | _ -> assert false
 
@@ -463,7 +463,6 @@ let shlist = { hlist with
                  stick_to_label = false;
                  space_after_opening = false;
                  space_before_closing = false }
-let shlist0 = { shlist with space_after_separator = false }
 
 let llist = {
   list with
@@ -478,13 +477,6 @@ let lplist = {
     space_before_closing = false
 }
 
-let vseq = {
-  list with
-    indent_body = 0;
-    wrap_body = `Force_breaks;
-}
-
-
 let vlist1 = { list with stick_to_label = false }
 
 let vlist = {
@@ -493,12 +485,9 @@ let vlist = {
 }
 
 
-let label0 = { label with space_after_label = false }
-
 let make_atom s = Atom (s, atom)
 
 let horizontal_sequence l = List (("", "", "", shlist), l)
-let horizontal_sequence0 l = List (("", "", "", shlist0), l)
 
 let rec insert sep = function
     [] | [_] as l -> l
@@ -564,7 +553,7 @@ let make_ocamldoc_block = function
 let make_ocamldoc_blocks (l : Ag_doc.block list) =
   let l =
     insert2 (
-      fun x y ->
+      fun _ y ->
         match y with
             `Paragraph _ -> [`Before_paragraph]
           | `Pre _ -> []

--- a/atdgen/src/ag_oj_emit.ml
+++ b/atdgen/src/ag_oj_emit.ml
@@ -1787,7 +1787,7 @@ let make_ocaml_json_impl
 
   if with_create then
     List.iter (
-      fun (is_rec, l) ->
+      fun (_, l) ->
         let l = List.filter Ag_ox_emit.is_exportable l in
         List.iter (
           fun x ->

--- a/atdgen/src/ag_oj_emit.ml
+++ b/atdgen/src/ag_oj_emit.ml
@@ -1007,7 +1007,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Ag_indent.t list =
         );
         [
           `Annot ("fun", `Line "fun p lb ->");
-          `Block (make_record_reader p type_annot loc a o j)
+          `Block (make_record_reader p type_annot loc a j)
         ]
 
     | `Tuple (_, a, `Tuple, `Tuple) ->

--- a/atdgen/src/ag_oj_emit.ml
+++ b/atdgen/src/ag_oj_emit.ml
@@ -106,7 +106,7 @@ val %s_of_string :%s
           s;
 
         if with_create && Ag_ox_emit.is_exportable x then
-          let create_record_intf, create_record_impl =
+          let create_record_intf, _ =
             Ag_ox_emit.make_record_creator deref x
           in
           bprintf buf "%s" create_record_intf;
@@ -128,7 +128,7 @@ let is_json_string deref x =
 
 let get_assoc_type deref loc x =
   match deref x with
-  | `Tuple (loc2, [| k; v |], `Tuple, `Tuple) ->
+  | `Tuple (_, [| k; v |], `Tuple, `Tuple) ->
       if not (is_json_string deref k.cel_value) then
         error loc "Due to <json repr=\"object\"> keys must be strings";
       (k.cel_value, v.cel_value)
@@ -160,7 +160,7 @@ type parse_field = {
 let implicit_field_name jname = "0jic_"^jname
 
 let get_fields p a =
-  let k, acc = Array.fold_left (fun (k,acc) (i, x) ->
+  let k, acc = Array.fold_left (fun (k,acc) (_, x) ->
     let ocamlf, default, jsonf, k =
       match x.f_arepr, x.f_brepr with
         `Field o, `Field j ->
@@ -205,7 +205,8 @@ let get_fields p a =
     with Not_found -> None
   in
   (* Add implicit fields and index the deconstructed/tag field relations *)
-  let _k = Hashtbl.fold (fun i { jsonf = {Ag_json.json_tag_field} } k ->
+  (* TODO why is a fold only being used for its side effect? *)
+  let (_ : int) = Hashtbl.fold (fun i { jsonf = {Ag_json.json_tag_field; _}; _ } k ->
     match json_tag_field with
     | None -> k
     | Some constr ->
@@ -271,9 +272,6 @@ let insert sep l =
 
 let make_json_string s = Yojson.Safe.to_string (`String s)
 
-let unopt = function None -> assert false | Some x -> x
-
-
 (*
   ('a, 'b) t            -> write_t write__a write__b
   ('a, foo) t           -> write_t write__a write_foo
@@ -284,11 +282,11 @@ let rec get_writer_name
     ?(name_f = fun s -> "write_" ^ s)
     p (x : oj_mapping) : string =
   match x with
-      `Unit (loc, `Unit, `Unit) ->
+      `Unit (_, `Unit, `Unit) ->
         "Yojson.Safe.write_null"
-    | `Bool (loc, `Bool, `Bool) ->
+    | `Bool (_, `Bool, `Bool) ->
         "Yojson.Safe.write_bool"
-    | `Int (loc, `Int o, `Int) ->
+    | `Int (_, `Int o, `Int) ->
         (match o with
              `Int -> "Yojson.Safe.write_int"
            | `Char -> "Ag_oj_run.write_int8"
@@ -297,7 +295,7 @@ let rec get_writer_name
            | `Float -> "Ag_oj_run.write_float_as_int"
         )
 
-    | `Float (loc, `Float, `Float j) ->
+    | `Float (_, `Float, `Float j) ->
         (match j with
             `Float None ->
               if p.std then "Yojson.Safe.write_std_float"
@@ -311,19 +309,19 @@ let rec get_writer_name
               "Ag_oj_run.write_float_as_int"
         )
 
-    | `String (loc, `String, `String) ->
+    | `String (_, `String, `String) ->
         "Yojson.Safe.write_string"
 
-    | `Tvar (loc, s) -> "write_" ^ name_of_var s
+    | `Tvar (_, s) -> "write_" ^ name_of_var s
 
-    | `Name (loc, s, args, None, None) ->
+    | `Name (_, s, args, None, None) ->
         let l = List.map (get_writer_name ~paren:true p) args in
         let s = String.concat " " (name_f s :: l) in
         if paren && l <> [] then "(" ^ s ^ ")"
         else s
 
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `External (_, _, args,
+                 `External (_, main_module, ext_name),
                  `External) ->
         let f = main_module ^ "." ^ name_f ext_name in
         let l = List.map (get_writer_name ~paren:true p) args in
@@ -350,9 +348,9 @@ let rec get_reader_name
     p (x : oj_mapping) : string =
 
   match x with
-      `Unit (loc, `Unit, `Unit) -> "Ag_oj_run.read_null"
-    | `Bool (loc, `Bool, `Bool) -> "Ag_oj_run.read_bool"
-    | `Int (loc, `Int o, `Int) ->
+      `Unit (_, `Unit, `Unit) -> "Ag_oj_run.read_null"
+    | `Bool (_, `Bool, `Bool) -> "Ag_oj_run.read_bool"
+    | `Int (_, `Int o, `Int) ->
         (match o with
              `Int -> "Ag_oj_run.read_int"
            | `Char -> "Ag_oj_run.read_int8"
@@ -361,20 +359,20 @@ let rec get_reader_name
            | `Float -> "Ag_oj_run.read_number"
         )
 
-    | `Float (loc, `Float, `Float j) -> "Ag_oj_run.read_number"
+    | `Float (_, `Float, `Float _) -> "Ag_oj_run.read_number"
 
-    | `String (loc, `String, `String) -> "Ag_oj_run.read_string"
+    | `String (_, `String, `String) -> "Ag_oj_run.read_string"
 
-    | `Tvar (loc, s) -> "read_" ^ name_of_var s
+    | `Tvar (_, s) -> "read_" ^ name_of_var s
 
-    | `Name (loc, s, args, None, None) ->
+    | `Name (_, s, args, None, None) ->
         let l = List.map (get_reader_name ~paren:true p) args in
         let s = String.concat " " (name_f s :: l) in
         if paren && l <> [] then "(" ^ s ^ ")"
         else s
 
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `External (_, _, args,
+                 `External (_, main_module, ext_name),
                  `External) ->
         let f = main_module ^ "." ^ name_f ext_name in
         let l = List.map (get_reader_name ~paren:true p) args in
@@ -396,7 +394,7 @@ let get_left_of_string_name p name param =
 
 let destruct_sum (x : oj_mapping) =
   match x with
-      `Sum (loc, a, `Sum x, `Sum) ->
+      `Sum (_, a, `Sum x, `Sum) ->
         let tick = match x with `Classic -> "" | `Poly -> "`" in
         tick, a
     | `Unit _ -> error (loc_of_mapping x) "Cannot destruct unit"
@@ -435,10 +433,10 @@ let make_sum_writer p sum f =
   ]
 
 let is_optional = function
-  | { default=Default _ } -> true
-  | { default=Checked _ } -> false
+  | { default=Default _ ; _ } -> true
+  | { default=Checked _ ; _ } -> false
 
-let unwrap p { jsonf=jsonf; mapping=mapping } =
+let unwrap p { jsonf=jsonf; mapping=mapping ; _} =
   if jsonf.Ag_json.json_unwrapped
   then Ag_ocaml.unwrap_option p.deref mapping.f_value
   else mapping.f_value
@@ -450,7 +448,7 @@ let string_expr_of_constr_field p v_of_field field =
     `String _ -> [ `Line v ]
   | _ ->
     ( `Line "(" )::
-      (make_sum_writer p f_value (fun p tick o j x ->
+      (make_sum_writer p f_value (fun _ tick o j x ->
         let ocaml_cons = o.Ag_ocaml.ocaml_cons in
         let json_cons = j.Ag_json.json_cons in
         match json_cons with
@@ -479,13 +477,13 @@ let rec make_writer p (x : oj_mapping) : Ag_indent.t list =
 
     | `Sum _ -> make_sum_writer p x make_variant_writer
 
-    | `Record (loc, a, `Record o, `Record j) ->
+    | `Record (_, a, `Record o, `Record _) ->
         [
           `Annot ("fun", `Line "fun ob x ->");
           `Block (make_record_writer p a o);
         ]
 
-    | `Tuple (loc, a, `Tuple, `Tuple) ->
+    | `Tuple (_, a, `Tuple, `Tuple) ->
         let len = Array.length a in
         let a =
           Array.mapi (
@@ -545,7 +543,7 @@ let rec make_writer p (x : oj_mapping) : Ag_indent.t list =
                ]
         )
 
-    | `Option (loc, x, `Option, `Option) ->
+    | `Option (_, x, `Option, `Option) ->
         [
           `Line (sprintf "Ag_oj_run.write_%soption ("
                    (if p.std then "std_" else ""));
@@ -553,17 +551,17 @@ let rec make_writer p (x : oj_mapping) : Ag_indent.t list =
           `Line ")";
         ]
 
-    | `Nullable (loc, x, `Nullable, `Nullable) ->
+    | `Nullable (_, x, `Nullable, `Nullable) ->
         [
           `Line "Ag_oj_run.write_nullable (";
           `Block (make_writer p x);
           `Line ")";
         ]
 
-    | `Wrap (loc, x, `Wrap o, `Wrap) ->
+    | `Wrap (_, x, `Wrap o, `Wrap) ->
         (match o with
             None -> make_writer p x
-          | Some { Ag_ocaml.ocaml_wrap_t; ocaml_wrap; ocaml_unwrap } ->
+          | Some { Ag_ocaml.ocaml_unwrap; _} ->
               [
                 `Line "fun ob x -> (";
                 `Block [
@@ -710,30 +708,30 @@ and make_record_writer p a record_kind =
   let constr_var constr = "constr_" ^ constr.mapping.f_name in
 
   let write_constr_ss = Array.map (function
-    | { payloads = payload_i :: _ } as field ->
+    | { payloads = payload_i :: _; _ } as field ->
       `Inline [
         `Line (sprintf "let %s =" (constr_var field));
         `Block (string_expr_of_constr_field p v_of_field
                   (if field.implicit then fields.(payload_i) else field));
         `Line "in";
       ]
-    | { payloads = [] } -> `Inline []
+    | { payloads = []; _ } -> `Inline []
   ) fields in
 
   let v_or_constr v field = if field.implicit then constr_var field else v in
 
   let write_fields =
     Array.mapi (
-      fun i field ->
+      fun _ field ->
         let json_fname = field.jsonf.Ag_json.json_fname in
         let app v =
           let f_value = unwrap p field in
           match field with
-            | { constructor = Some constr_i } ->
+            | { constructor = Some constr_i; _ } ->
               let constr = fields.(constr_i) in
               let cons_code json_cons_code =
                 (* Tag will be written. Check equality. *)
-                `Block (apply p (fun v ->
+                `Block (apply p (fun _ ->
                   [
                     `Line (sprintf "if %s <> %s then"
                              (constr_var constr) json_cons_code);
@@ -756,7 +754,7 @@ and make_record_writer p a record_kind =
                    ]
                   ) cons_code)
               )@[ `Line (sprintf ") ob %s;" (v_or_constr v field)) ]
-            | { constructor = None } ->
+            | { constructor = None; _ } ->
               [
                 `Inline sep;
                 `Line (write_field_tag json_fname);
@@ -816,8 +814,8 @@ let study_record p fields =
   let create_record = [ `Line "{"; `Block create_record_fields; `Line "}" ] in
 
   let n = Array.fold_left (fun n -> function
-    | { default = Checked k } -> max n (k + 1)
-    | { default = Default _ } -> n
+    | { default = Checked k; _ } -> max n (k + 1)
+    | { default = Default _; _ } -> n
   ) 0 fields in
 
   let k = n / 31 + (if n mod 31 > 0 then 1 else 0) in
@@ -884,7 +882,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Ag_indent.t list =
     | `External _
     | `Tvar _ -> [ `Line (get_reader_name p x) ]
 
-    | `Sum (loc, a, `Sum x, `Sum) ->
+    | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               `Classic -> ""
@@ -1012,7 +1010,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Ag_indent.t list =
           `Block (make_record_reader p type_annot loc a o j)
         ]
 
-    | `Tuple (loc, a, `Tuple, `Tuple) ->
+    | `Tuple (_, a, `Tuple, `Tuple) ->
         [
           `Annot ("fun", `Line "fun p lb ->");
           `Block (make_tuple_reader p a);
@@ -1071,7 +1069,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Ag_indent.t list =
         in
         make_reader p (Some "_ option") (`Sum (loc, a, `Sum `Classic, `Sum))
 
-    | `Nullable (loc, x, `Nullable, `Nullable) ->
+    | `Nullable (_, x, `Nullable, `Nullable) ->
         [
           `Line "fun p lb ->";
           `Block [
@@ -1083,10 +1081,10 @@ let rec make_reader p type_annot (x : oj_mapping) : Ag_indent.t list =
           ]
         ]
 
-    | `Wrap (loc, x, `Wrap o, `Wrap) ->
+    | `Wrap (_, x, `Wrap o, `Wrap) ->
         (match o with
             None -> make_reader p type_annot x
-          | Some { Ag_ocaml.ocaml_wrap_t; ocaml_wrap; ocaml_unwrap } ->
+          | Some { Ag_ocaml.ocaml_wrap; _ } ->
               [
                 `Line "fun p lb ->";
                 `Block [
@@ -1322,8 +1320,8 @@ and make_deconstructed_reader p loc fields set_bit =
 
   let toposorted_fields =
     toposort_fields [] (fst (Array.fold_left (fun (s, i) -> function
-    | { constructor = None   } -> (i :: s, i + 1)
-    | { constructor = Some _ } -> (s,      i + 1)
+    | { constructor = None ; _  } -> (i :: s, i + 1)
+    | { constructor = Some _; _ } -> (s,      i + 1)
     ) ([], 0) fields)) in
 
   List.fold_left (fun updates i ->
@@ -1358,7 +1356,7 @@ and make_deconstructed_reader p loc fields set_bit =
         ])::updates
   ) [] toposorted_fields
 
-and make_record_reader p type_annot loc a record_kind json_options =
+and make_record_reader p type_annot loc a json_options =
   let keep_nulls = json_options.json_keep_nulls in
   let fields = get_fields p a in
   let init_fields, init_bits, set_bit, check_bits, create_record =
@@ -1367,8 +1365,8 @@ and make_record_reader p type_annot loc a record_kind json_options =
 
   let read_field =
     let cases =
-      Array.mapi (fun i field ->
-        let { ocamlf = ocamlf; jsonf = jsonf; mapping = x } = field in
+      Array.map (fun field ->
+        let { ocamlf = ocamlf; jsonf = jsonf; mapping = x; _ } = field in
         let unwrapped = jsonf.Ag_json.json_unwrapped in
         let f_value =
           if unwrapped then Ag_ocaml.unwrap_option p.deref x.f_value
@@ -1469,8 +1467,8 @@ and make_record_reader p type_annot loc a record_kind json_options =
 
   let update_deconstructed_fields =
     if List.exists (function
-    | { constructor = Some _ } -> true
-    | { constructor = None   } -> false
+    | { constructor = Some _; _ } -> true
+    | { constructor = None ; _  } -> false
     ) (Array.to_list fields)
     then make_deconstructed_reader p loc fields set_bit
     else []
@@ -1522,7 +1520,7 @@ and make_tuple_reader p a =
     let n = ref (Array.length cells) in
     (try
        for i = Array.length cells - 1 downto 0 do
-         let x, default = cells.(i) in
+         let _, default = cells.(i) in
          if default = None then (
            n := i + 1;
            raise Exit

--- a/atdgen/src/ag_oj_emit.ml
+++ b/atdgen/src/ag_oj_emit.ml
@@ -1791,7 +1791,7 @@ let make_ocaml_json_impl
         let l = List.filter Ag_ox_emit.is_exportable l in
         List.iter (
           fun x ->
-            let intf, impl = Ag_ox_emit.make_record_creator deref x in
+            let _, impl = Ag_ox_emit.make_record_creator deref x in
             Buffer.add_string buf impl
         ) l
     ) defs

--- a/atdgen/src/ag_oj_mapping.ml
+++ b/atdgen/src/ag_oj_mapping.ml
@@ -1,4 +1,3 @@
-open Printf
 open Atd_ast
 open Ag_error
 open Ag_mapping

--- a/atdgen/src/ag_oj_mapping.ml
+++ b/atdgen/src/ag_oj_mapping.ml
@@ -8,10 +8,6 @@ type j = Ag_json.json_repr
 type oj_mapping =
     (Ag_ocaml.atd_ocaml_repr, Ag_json.json_repr) Ag_mapping.mapping
 
-type oj_def =
-    (Ag_ocaml.atd_ocaml_repr, Ag_json.json_repr) Ag_mapping.def
-
-
 (*
   Translation of the types into the ocaml/json mapping.
 *)

--- a/atdgen/src/ag_oj_mapping.ml
+++ b/atdgen/src/ag_oj_mapping.ml
@@ -29,7 +29,7 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
                    (List.map (mapping_of_field ocaml_field_prefix) l),
                  ocaml_t, json_t)
 
-    | `Tuple (loc, l, an) ->
+    | `Tuple (loc, l, _) ->
         let ocaml_t = `Tuple in
         let json_t = `Tuple in
         `Tuple (loc, Array.of_list (List.map mapping_of_cell l),
@@ -40,17 +40,17 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
         let json_t = `List (Ag_json.get_json_list an) in
         `List (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Option (loc, x, an) ->
+    | `Option (loc, x, _) ->
         let ocaml_t = `Option in
         let json_t = `Option in
         `Option (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Nullable (loc, x, an) ->
+    | `Nullable (loc, x, _) ->
         let ocaml_t = `Nullable in
         let json_t = `Nullable in
         `Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Shared (loc, x, an) ->
+    | `Shared (loc, _, _) ->
         error loc "Sharing is not supported by the JSON interface"
 
     | `Wrap (loc, x, an) ->
@@ -58,7 +58,7 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
         let json_t = `Wrap in
         `Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Name (loc, (loc2, s, l), an) ->
+    | `Name (loc, (_, s, l), an) ->
         (match s with
              "unit" ->
                `Unit (loc, `Unit, `Unit)
@@ -175,7 +175,7 @@ let def_of_atd (loc, (name, param, an), x) =
   let doc = Ag_doc.get_doc loc an in
   let o =
     match as_abstract x with
-        Some (loc2, an2) ->
+        Some (_, _) ->
           (match Ag_ocaml.get_ocaml_module_and_t `Json name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->

--- a/atdgen/src/ag_oj_run.ml
+++ b/atdgen/src/ag_oj_run.ml
@@ -4,6 +4,8 @@
 
 open Printf
 
+type 'a write = Bi_outbuf.t -> 'a -> unit
+
 exception Error of string
 
 (*
@@ -119,6 +121,8 @@ let write_float_as_int ob x =
       | FP_zero -> Bi_outbuf.add_string ob (Printf.sprintf "%.0f" x)
       | FP_infinite -> error "Cannot convert inf or -inf into a JSON int"
       | FP_nan -> error "Cannot convert NaN into a JSON int"
+
+type 'a read = Yojson.lexer_state -> Lexing.lexbuf -> 'a
 
 let read_null p lb =
   Yojson.Safe.read_space p lb;

--- a/atdgen/src/ag_oj_run.mli
+++ b/atdgen/src/ag_oj_run.mli
@@ -1,0 +1,39 @@
+exception Error of string
+
+type 'a write = Bi_outbuf.t -> 'a -> unit
+
+val error : string -> _
+
+val write_list : 'a write -> 'a list write
+val write_array : 'a write -> 'a array write
+val write_float_as_int : float write
+val write_assoc_list : 'a write -> 'b write -> ('a * 'b) list write
+val write_assoc_array : 'a write -> 'b write -> ('a * 'b) array write
+val write_option : 'a write -> 'a option write
+val write_std_option : 'a write -> 'a option write
+val write_nullable : 'a write -> 'a option write
+val write_int8 : char write
+val write_int32 : int32 write
+val write_int64 : int64 write
+
+type 'a read = Yojson.lexer_state -> Lexing.lexbuf -> 'a
+
+val read_null : unit read
+val read_bool : bool read
+val read_int : int read
+val read_int8 : char read
+val read_int32 : int32 read
+val read_int64 : int64 read
+val read_string : string read
+val read_array : 'a read -> 'a array read
+val read_assoc_list : 'a read -> 'b read -> ('a * 'b) list read
+val read_assoc_array : 'a read -> 'b read -> ('a * 'b) array read
+val read_until_field_value : unit read
+val read_list : 'a read -> 'a list read
+val read_number : float read
+val invalid_variant_tag : Yojson.Lexer_state.t -> string -> _
+
+
+val missing_tuple_fields : Yojson.lexer_state -> int -> int list -> _
+val missing_fields : Yojson.lexer_state -> int array -> string array -> _
+

--- a/atdgen/src/ag_ov_emit.ml
+++ b/atdgen/src/ag_ov_emit.ml
@@ -348,7 +348,7 @@ and make_record_validator a record_kind =
   in
   forall validate_fields
 
-let make_ocaml_validator ~original_types is_rec let1 let2 def =
+let make_ocaml_validator ~original_types is_rec let1 def =
   let x = match def.def_value with None -> assert false | Some x -> x in
   let name = def.def_name in
   let type_constraint = Ag_ox_emit.get_type_constraint ~original_types def in
@@ -394,8 +394,8 @@ let make_ocaml_validate_impl ~with_create ~original_types buf deref defs =
         let validators =
           map (
             fun is_first def ->
-              let let1, let2 = get_let ~is_rec ~is_first in
-              make_ocaml_validator ~original_types is_rec let1 let2 def
+              let let1, _ = get_let ~is_rec ~is_first in
+              make_ocaml_validator ~original_types is_rec let1 def
           ) l
         in
         List.flatten validators
@@ -405,11 +405,11 @@ let make_ocaml_validate_impl ~with_create ~original_types buf deref defs =
 
   if with_create then
     List.iter (
-      fun (is_rec, l) ->
+      fun (_, l) ->
         let l = List.filter Ag_ox_emit.is_exportable l in
         List.iter (
           fun x ->
-            let intf, impl = Ag_ox_emit.make_record_creator deref x in
+            let _, impl = Ag_ox_emit.make_record_creator deref x in
             Buffer.add_string buf impl
         ) l
     ) defs
@@ -463,9 +463,9 @@ let make_ocaml_files
     ~pos_fname
     ~pos_lnum
     ~type_aliases
-    ~force_defaults
+    ~force_defaults:_
     ~name_overlap
-    ~ocaml_version
+    ~ocaml_version:_
     ~pp_convs
     atd_file out =
   let ((head, m0), _) =

--- a/atdgen/src/ag_ov_emit.ml
+++ b/atdgen/src/ag_ov_emit.ml
@@ -5,7 +5,6 @@
 open Printf
 
 open Atd_ast
-open Ag_error
 open Ag_mapping
 open Ag_ov_mapping
 

--- a/atdgen/src/ag_ov_emit.ml
+++ b/atdgen/src/ag_ov_emit.ml
@@ -14,7 +14,7 @@ let make_ocaml_validate_intf ~with_create buf deref defs =
   List.iter (
     fun x ->
       if with_create && Ag_ox_emit.is_exportable x then (
-        let create_record_intf, create_record_impl =
+        let create_record_intf, _ =
           Ag_ox_emit.make_record_creator deref x
         in
         bprintf buf "%s" create_record_intf;
@@ -61,7 +61,7 @@ let get_fields a =
   in
   List.filter (
     function
-        { f_brepr = (None, shallow) }, name -> not shallow
+        { f_brepr = (None, shallow) ; _ }, _ -> not shallow
       | _ -> assert false
   ) all
 
@@ -80,14 +80,7 @@ let rec forall : Ag_indent.t list -> Ag_indent.t list = function
         ]
       ]
 
-let unopt = function None -> assert false | Some x -> x
-
-let return_true = "fun _ _ -> None"
 let return_true_paren = "(fun _ _ -> None)"
-
-let opt_validator_name = function
-    None -> return_true_paren
-  | Some s -> sprintf "( %s )" s
 
 let opt_validator = function
     None -> [ `Line "fun _ _ -> None" ]
@@ -155,19 +148,19 @@ let rec get_validator_name
     (x : ov_mapping) : string =
 
   match x with
-      `Unit (loc, `Unit, v)
-    | `Bool (loc, `Bool, v)
-    | `Int (loc, `Int _, v)
-    | `Float (loc, `Float, v)
-    | `String (loc, `String, v) ->
+      `Unit (_, `Unit, v)
+    | `Bool (_, `Bool, v)
+    | `Int (_, `Int _, v)
+    | `Float (_, `Float, v)
+    | `String (_, `String, v) ->
         (match v with
              (None, true) -> return_true_paren
            | (Some s, true) -> s
            | (_, false) -> assert false
         )
-    | `Tvar (loc, s) -> "validate_" ^ name_of_var s
+    | `Tvar (_, s) -> "validate_" ^ name_of_var s
 
-    | `Name (loc, s, args, None, opt) ->
+    | `Name (_, s, args, None, opt) ->
         let v1 =
           let l =
             List.map (get_validator_name ~paren:true) args in
@@ -181,8 +174,8 @@ let rec get_validator_name
            | Some (o, true) -> opt_validator_s o
         )
 
-    | `External (loc, s, args,
-                 `External (types_module, main_module, ext_name),
+    | `External (_, _, args,
+                 `External (_, main_module, ext_name),
                  v) ->
         (match v with
              (o, false) ->
@@ -214,7 +207,7 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
     | `External _
     | `Tvar _ -> [ `Line (get_validator_name x) ]
 
-    | `Sum (loc, a, `Sum x, (v, shallow)) ->
+    | `Sum (_, a, `Sum x, (v, shallow)) ->
         if shallow then
           opt_validator v
         else
@@ -240,7 +233,7 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
             `Block (prepend_validator v body);
           ]
 
-    | `Record (loc, a, `Record o, (v, shallow)) ->
+    | `Record (_, a, `Record o, (v, shallow)) ->
         if shallow then
           opt_validator v
         else
@@ -249,13 +242,13 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
             `Block (prepend_validator v (make_record_validator a o));
           ]
 
-    | `Tuple (loc, a, `Tuple, (v, shallow)) ->
+    | `Tuple (_, a, `Tuple, (v, shallow)) ->
         if shallow then
           opt_validator v
         else
           let len = Array.length a in
           let l = Array.to_list (Array.mapi (fun i x -> (i, x)) a) in
-          let l = List.filter (fun (i, x) -> not (snd x.cel_brepr)) l in
+          let l = List.filter (fun (_, x) -> not (snd x.cel_brepr)) l in
           let l =
             List.map (
               fun (i, x) ->
@@ -275,7 +268,7 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
             `Block (prepend_validator v l);
           ]
 
-    | `List (loc, x, `List o, (v, shallow)) ->
+    | `List (_, x, `List o, (v, shallow)) ->
         if shallow then
           opt_validator v
         else
@@ -290,8 +283,8 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
             `Line ")";
           ]
 
-    | `Option (loc, x, `Option, (v, shallow))
-    | `Nullable (loc, x, `Nullable, (v, shallow)) ->
+    | `Option (_, x, `Option, (v, shallow))
+    | `Nullable (_, x, `Nullable, (v, shallow)) ->
         if shallow then
           opt_validator v
         else
@@ -301,7 +294,7 @@ let rec make_validator (x : ov_mapping) : Ag_indent.t list =
             `Line ")";
           ]
 
-    | `Wrap (loc, x, `Wrap o, (v, shallow)) ->
+    | `Wrap (_, x, `Wrap _, (v, shallow)) ->
         if shallow then
           opt_validator v
         else

--- a/atdgen/src/ag_ov_emit.mli
+++ b/atdgen/src/ag_ov_emit.mli
@@ -8,8 +8,8 @@ val make_ocaml_files
   -> pos_fname:string option
   -> pos_lnum:int option
   -> type_aliases:string option
-  -> force_defaults:'a
+  -> force_defaults:_ (* TODO unused *)
   -> name_overlap:bool
-  -> ocaml_version:'b
+  -> ocaml_version:_ (* TODO unused *)
   -> pp_convs:[ `Camlp4 of string list | `Ppx of string list ]
   -> string option -> [< `Files of string | `Stdout ] -> unit

--- a/atdgen/src/ag_ov_mapping.ml
+++ b/atdgen/src/ag_ov_mapping.ml
@@ -1,4 +1,3 @@
-open Printf
 open Atd_ast
 open Ag_error
 open Ag_mapping

--- a/atdgen/src/ag_ov_mapping.ml
+++ b/atdgen/src/ag_ov_mapping.ml
@@ -17,12 +17,6 @@ type ov_mapping =
      on the type expressions is abstract, then the result is false.
 *)
 
-let ploc x =
-  eprintf "%s\n" (string_of_loc (loc_of_type_expr x))
-
-let print s =
-  eprintf "%s\n%!" s
-
 let get_def defs name : type_expr option =
   try Some (Hashtbl.find defs name)
   with Not_found -> None
@@ -96,7 +90,7 @@ let rec scan_expr
 
 and name_is_shallow defs visited results x =
   match x with
-      `Name (loc, (loc2, name, _), _) ->
+      `Name (_, (_, name, _), _) ->
         (match get_def defs name with
              None ->
                (match name with
@@ -110,7 +104,7 @@ and name_is_shallow defs visited results x =
            | Some x -> noval x && scan_expr defs visited results x
         )
 
-    | `Tvar (loc, _) -> false
+    | `Tvar (_, _) -> false
     | _ -> (* already verified in the call to scan_expr above *) true
 
 
@@ -138,7 +132,7 @@ let scan_top_expr
 let make_is_shallow defs =
   let results = H.create 100 in
   Hashtbl.iter (
-    fun name x -> scan_top_expr defs results x
+    fun _ x -> scan_top_expr defs results x
   ) defs;
   fun x ->
     try
@@ -187,7 +181,7 @@ let rec mapping_of_expr
         let ocaml_t = `Nullable in
         `Nullable (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
 
-    | `Shared (loc, x, an) ->
+    | `Shared (_, _, _) ->
         failwith "Sharing is not supported"
 
     | `Wrap (loc, x, an) ->
@@ -200,7 +194,7 @@ let rec mapping_of_expr
         in
         `Wrap (loc, mapping_of_expr is_shallow x, ocaml_t, validator)
 
-    | `Name (loc, (loc2, s, l), an) ->
+    | `Name (loc, (_, s, l), an) ->
         (match s with
              "unit" ->
                `Unit (loc, `Unit, (v an, true))
@@ -312,7 +306,7 @@ let def_of_atd is_shallow (loc, (name, param, an), x) =
   let doc = Ag_doc.get_doc loc an in
   let o =
     match as_abstract x with
-        Some (loc2, an2) ->
+        Some (_, an2) ->
           (match Ag_ocaml.get_ocaml_module_and_t `Validate name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->
@@ -337,29 +331,19 @@ let def_of_atd is_shallow (loc, (name, param, an), x) =
 
 let fill_def_tbl defs l =
   List.iter (
-    function `Type (loc, (name, param, an), x) -> Hashtbl.add defs name x
+    function `Type (_, (name, _, _), x) -> Hashtbl.add defs name x
   ) l
 
 let init_def_tbl () =
   Hashtbl.create 100
 
-let make_def_tbl l =
-  let defs = init_def_tbl () in
-  fill_def_tbl defs l;
-  defs
-
 let make_def_tbl2 l =
   let defs = init_def_tbl () in
-  List.iter (fun (is_rec, l) -> fill_def_tbl defs l) l;
+  List.iter (fun (_, l) -> fill_def_tbl defs l) l;
   defs
 
 let defs_of_atd_module_gen is_shallow l =
   List.map (function `Type def -> def_of_atd is_shallow def) l
-
-let defs_of_atd_module l =
-  let defs = make_def_tbl l in
-  let is_shallow = make_is_shallow defs in
-  defs_of_atd_module_gen is_shallow l
 
 let defs_of_atd_modules l =
   let defs = make_def_tbl2 l in

--- a/atdgen/src/ag_ov_mapping.ml
+++ b/atdgen/src/ag_ov_mapping.ml
@@ -2,14 +2,8 @@ open Atd_ast
 open Ag_error
 open Ag_mapping
 
-type o = Ag_ocaml.atd_ocaml_repr
-type v = Ag_validate.validate_repr
-
 type ov_mapping =
     (Ag_ocaml.atd_ocaml_repr, Ag_validate.validate_repr) Ag_mapping.mapping
-
-type ob_def =
-    (Ag_ocaml.atd_ocaml_repr, Ag_validate.validate_repr) Ag_mapping.def
 
 (*
   Determine whether a type expression does not need validation.

--- a/atdgen/src/ag_ox_emit.ml
+++ b/atdgen/src/ag_ox_emit.ml
@@ -57,19 +57,19 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
         else
           error loc "Anonymous record types are not allowed by OCaml."
 
-    | `Tuple (loc, ca, _, _) ->
+    | `Tuple (_, ca, _, _) ->
         Array.fold_left (extract_names_from_cell root_loc) acc ca
 
-    | `List (loc, x, _, _)
-    | `Option (loc, x, _, _)
-    | `Nullable (loc, x, _, _)
-    | `Wrap (loc, x, _, _) ->
+    | `List (_, x, _, _)
+    | `Option (_, x, _, _)
+    | `Nullable (_, x, _, _)
+    | `Wrap (_, x, _, _) ->
         extract_names_from_expr root_loc acc x
 
-    | `Name (loc, _, l, _, _) ->
+    | `Name (_, _, l, _, _) ->
         List.fold_left (extract_names_from_expr root_loc) acc l
 
-    | `External (loc, _, l, _, _) ->
+    | `External (_, _, l, _, _) ->
         List.fold_left (extract_names_from_expr root_loc) acc l
 
     | `Tvar _ -> acc
@@ -249,7 +249,7 @@ let is_exportable def =
 
 let make_record_creator deref x =
   match x.def_value with
-      Some (`Record (loc, a, `Record `Record, _)) ->
+      Some (`Record (_, a, `Record `Record, _)) ->
         let s = x.def_name in
         let full_name = get_full_type_name x in
         let l =

--- a/atdgen/src/ag_ox_emit.ml
+++ b/atdgen/src/ag_ox_emit.ml
@@ -128,7 +128,7 @@ let check_duplicate_names container_kind field_kind l =
           sprintf "\
 %s contains a %s that is already defined elsewhere
 and cannot be reused."
-            (String.capitalize container_kind) field_kind
+            (String.capitalize_ascii container_kind) field_kind
         in
         let msg2 = sprintf "First definition of %s %s." field_kind s in
         let msg3 = sprintf "\

--- a/atdgen/src/ag_string_match.ml
+++ b/atdgen/src/ag_string_match.ml
@@ -317,7 +317,7 @@ let make_ocaml_int_mapping
   in
   let int_matching_cases =
     Array.mapi (
-      fun i (s, x) ->
+      fun i (_, x) ->
         `Inline [
           `Line (sprintf "| %i ->" i);
           `Block x;

--- a/atdgen/src/ag_string_match.ml
+++ b/atdgen/src/ag_string_match.ml
@@ -182,7 +182,6 @@ type exit_with =
 let make_ocaml_expr_factored
     ?(string_id = "s")
     ?(pos_id = "pos")
-    ?(len_id = "len")
     ?(exit_with = `Exn "Exit")
     ~error_expr
     cases : Ag_indent.t list =
@@ -211,10 +210,10 @@ let make_ocaml_expr_factored
   ) [] cases)) in
   match cases with
       [] -> error_expr
-    | l ->
+    | _ ->
         catch (map_to_ocaml string_id pos_id exit_expr (make_tree cases))
 
-let test () =
+let test2 () =
   let l = [
     "abc";
     "abcd";
@@ -238,8 +237,6 @@ let test () =
 
 let make_ocaml_expr_naive
     ?(string_id = "s")
-    ?(pos_id = "pos")
-    ?(len_id = "len")
     ~error_expr
     cases =
   let map = function
@@ -264,17 +261,16 @@ let make_ocaml_expr
     ~optimized
     ?string_id
     ?pos_id
-    ?len_id
     ?exit_with
     ~error_expr
     cases : Ag_indent.t list =
 
   if optimized then
     make_ocaml_expr_factored
-      ?string_id ?pos_id ?len_id ?exit_with ~error_expr cases
+      ?string_id ?pos_id ?exit_with ~error_expr cases
   else
     make_ocaml_expr_naive
-      ?string_id ?pos_id ?len_id ~error_expr cases
+      ?string_id ~error_expr cases
 
 
 let make_ocaml_int_mapping
@@ -289,13 +285,12 @@ let make_ocaml_int_mapping
 
   let a = Array.of_list cases in
   let int_cases =
-    Array.mapi (fun i (s, x) -> (s, [ `Line (string_of_int i) ])) a
+    Array.mapi (fun i (s, _) -> (s, [ `Line (string_of_int i) ])) a
   in
   let int_mapping_body =
     make_ocaml_expr_factored
       ~string_id
       ~pos_id
-      ~len_id
       ?exit_with
       ~error_expr: error_expr1
       (Array.to_list int_cases)

--- a/atdgen/src/ag_string_match.mli
+++ b/atdgen/src/ag_string_match.mli
@@ -30,15 +30,12 @@ type exit_with =
 val make_ocaml_expr_factored :
   ?string_id: string ->
   ?pos_id: string ->
-  ?len_id: string ->
   ?exit_with: exit_with ->
   error_expr: Ag_indent.t list ->
   (string option * Ag_indent.t list) list -> Ag_indent.t list
 
 val make_ocaml_expr_naive :
   ?string_id: string ->
-  ?pos_id: string ->
-  ?len_id: string ->
   error_expr: Ag_indent.t list ->
   (string option * Ag_indent.t list) list -> Ag_indent.t list
 
@@ -46,7 +43,6 @@ val make_ocaml_expr :
   optimized: bool ->
   ?string_id: string ->
   ?pos_id: string ->
-  ?len_id: string ->
   ?exit_with: exit_with ->
   error_expr: Ag_indent.t list ->
   (string option * Ag_indent.t list) list -> Ag_indent.t list
@@ -79,3 +75,7 @@ val make_ocaml_int_mapping :
       The whole point is to read records or variants without
       creating new strings or closures.
     *)
+
+val test : unit -> string tree
+val test2 : unit -> unit
+(** For internal use only *)

--- a/atdgen/src/ag_util.ml
+++ b/atdgen/src/ag_util.ml
@@ -86,7 +86,7 @@ struct
 
   let stream_from_lexbuf ?(fin = fun () -> ()) read ls lexbuf =
     let stream = Some true in
-    let rec f i =
+    let f _ =
       try Some (from_lexbuf ?stream read ls lexbuf)
       with
           Yojson.End_of_input ->

--- a/atdgen/src/ag_xb_emit.ml
+++ b/atdgen/src/ag_xb_emit.ml
@@ -25,31 +25,31 @@ let rec extract_names_from_expr acc (x : 'a expr) =
     | `Int _
     | `Float  _
     | `String _ -> acc
-    | `Sum (loc, va, _, _) ->
+    | `Sum (_, va, _, _) ->
         let l, (fn, vn) =
           Array.fold_left extract_names_from_variant ([], acc) va
         in
         (fn, List.rev l :: vn)
 
-    | `Record (loc, fa, _, _) ->
+    | `Record (_, fa, _, _) ->
         let l, (fn, vn) =
           Array.fold_left extract_names_from_field ([], acc) fa
         in
         (List.rev l :: fn, vn)
 
-    | `Tuple (loc, ca, _, _) ->
+    | `Tuple (_, ca, _, _) ->
         Array.fold_left extract_names_from_cell acc ca
 
-    | `List (loc, x, _, _)
-    | `Option (loc, x, _, _)
-    | `Nullable (loc, x, _, _)
-    | `Wrap (loc, x, _, _) ->
+    | `List (_, x, _, _)
+    | `Option (_, x, _, _)
+    | `Nullable (_, x, _, _)
+    | `Wrap (_, x, _, _) ->
         extract_names_from_expr acc x
 
-    | `Name (loc, _, l, _, _) ->
+    | `Name (_, _, l, _, _) ->
         List.fold_left extract_names_from_expr acc l
 
-    | `External (loc, _, l, _, _) ->
+    | `External (_, _, l, _, _) ->
         List.fold_left extract_names_from_expr acc l
 
     | `Tvar _ -> acc

--- a/atdgen/test/github.atd
+++ b/atdgen/test/github.atd
@@ -1,3 +1,23 @@
+(* The following is take from:
+   https://github.com/rgrinberg/ocaml-github/blob/master/lib/github.atd *)
+
+(*
+ * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013-2016 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
 type error = {
   resource: string;
   ?field: string option;

--- a/atdgen/test/github.atd
+++ b/atdgen/test/github.atd
@@ -1,0 +1,1254 @@
+type error = {
+  resource: string;
+  ?field: string option;
+  code: string;
+  ?message: string option;
+} <ocaml field_prefix="error_">
+
+type message = {
+  message: string;
+  ~errors <ocaml default="[]">: error list;
+} <ocaml field_prefix="message_">
+
+type rate = {
+  limit: int;
+  remaining: int;
+  reset: float;
+} <ocaml field_prefix="rate_">
+
+type rate_resources = {
+  core: rate;
+  search: rate;
+} <ocaml field_prefix="rate_resources_">
+
+type rate_limit = {
+  resources: rate_resources;
+} <ocaml field_prefix="rate_limit_">
+
+type scope = [
+  | User <json name="user">
+  | User_email <json name="user:email">
+  | User_follow <json name="user:follow">
+  | Public_repo <json name="public_repo">
+  | Repo <json name="repo">
+  | Repo_deployment <json name="repo_deployment">
+  | Repo_status <json name="repo:status">
+  | Delete_repo <json name="delete_repo">
+  | Notifications <json name="notifications">
+  | Gist <json name="gist">
+  | Read_repo_hook <json name="read:repo_hook">
+  | Write_repo_hook <json name="write:repo_hook">
+  | Admin_repo_hook <json name="admin:repo_hook">
+  | Admin_org_hook <json name="admin:org_hook">
+  | Read_org <json name="read:org">
+  | Write_org <json name="write:org">
+  | Admin_org <json name="admin:org">
+  | Read_public_key <json name="read:public_key">
+  | Write_public_key <json name="write:public_key">
+  | Admin_public_key <json name="admin:public_key">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type app = {
+  name: string;
+  url: string;
+}  <ocaml field_prefix="app_">
+
+type auth_req = {
+  ~scopes: scope list;
+   note: string;
+  ?note_url: string option;
+  ?client_id: string option;
+  ?client_secret: string option;
+  ?fingerprint: string option;
+} <ocaml field_prefix="auth_req_">
+
+type auth = {
+  scopes: scope list;
+  token: string;
+  app: app;
+  url: string;
+  id: int <ocaml repr="int64">;
+  ?note: string option;
+  ?note_url: string option;
+} <ocaml field_prefix="auth_">
+
+type auths = auth list
+
+type state = [
+  | Open <json name="open">
+  | Closed <json name="closed">
+]
+
+type new_issue = {
+  title: string;
+  ?body: string option;
+  ?assignee: string option;
+  ?milestone: int option;
+  ~labels: string list;
+} <ocaml field_prefix="new_issue_">
+
+type update_issue = {
+  ?title: string option;
+  ?body: string option;
+  ?state: state option;
+  ?assignee: string option;
+  ?milestone: int option;
+  ?labels: string list option;
+} <ocaml field_prefix="update_issue_">
+
+type issue_sort = [
+  | Created <json name="created">
+  | Updated <json name="updated">
+  | Comments <json name="comments">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type direction = [
+  | Asc <json name="asc">
+  | Desc <json name="desc">
+]
+
+type org = {
+  login: string;
+  id: int <ocaml repr="int64">;
+  url: string;
+  ?avatar_url: string option;
+} <ocaml field_prefix="org_">
+
+type orgs = org list
+
+type user = {
+  inherit org
+} <ocaml field_prefix="user_">
+
+type linked_user = {
+  html_url: string;
+  inherit user
+} <ocaml field_prefix="linked_user_">
+
+type linked_users = linked_user list
+
+type contributor = {
+  contributions: int;
+  inherit linked_user
+} <ocaml field_prefix="contributor_">
+
+type contributors = contributor list
+
+type user_info = {
+  ?name: string option;
+  ?company: string option;
+  ?blog: string option;
+  ?location: string option;
+  ?email: string option;
+  ~hireable: bool;
+  ~bio: string;
+  ~public_repos: int;
+  ~public_gists: int;
+  ~followers: int;
+  ~following: int;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  (*ty <json name="type">: user_type;*)
+  inherit linked_user
+} <ocaml field_prefix="user_info_">
+
+type organization = {
+  name: string; (* opt? *)
+  company: string; (* opt? *)
+  blog: string; (* opt? *)
+  location: string; (* opt? *)
+  email: string; (* opt? *)
+  public_repos: int;
+  public_gists: int;
+  followers: int;
+  following: int;
+  html_url: string;
+  created_at: string;
+  (*ty <json name="type">: org_type;*)
+  inherit org
+} <ocaml field_prefix="organization_">
+
+type team = {
+  url: string;
+  name: string;
+  id: int <ocaml repr="int64">;
+} <ocaml field_prefix="team_">
+
+type teams = team list
+
+type team_permission = [
+  | Pull <json name="pull">
+  | Push <json name="push">
+  | Admin <json name="admin">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type team_info = {
+  permission: team_permission;
+  members_count: int;
+  repos_count: int;
+  organization: org;
+  inherit team
+} <ocaml field_prefix="team_info_">
+
+type team_infos = team_info list
+
+type base_label = {
+  name: string;
+  color: string;
+} <ocaml field_prefix="base_label_">
+
+type label = {
+  url: string;
+  inherit base_label
+} <ocaml field_prefix="label_">
+
+type labels = label list
+
+type new_label = {
+  name: string;
+  color: string;
+} <ocaml field_prefix="new_label_">
+
+type label_names = string list
+
+type milestone_sort = [
+  | Due_date <json name="due_date">
+  | Completeness <json name="completeness">
+]
+
+type new_milestone = {
+  title: string;
+  ~state <ocaml default="`Open">: state;
+  ?description: string option;
+  ?due_on: string option;
+} <ocaml field_prefix="new_milestone_">
+
+type update_milestone = {
+  ?title: string option;
+  ?state: state option;
+  ?description: string option;
+  ?due_on: string option;
+} <ocaml field_prefix="update_milestone_">
+
+type milestone = {
+  url: string;
+  number: int;
+  ~state <ocaml default="`Open">: state;
+  ~title: string;
+  ~description: string;
+  ?creator: user option;
+  open_issues: int;
+  closed_issues: int;
+  created_at: string;
+  ?due_on: string option;
+} <ocaml field_prefix="milestone_">
+
+type milestones = milestone list
+
+type issue = {
+  url: string;
+  html_url: string;
+  number: int;
+  ~state <ocaml default="`Open">: state;
+  title: string;
+  ~body: string;
+  user: user;
+  labels: label list;
+  ~comments: int;
+  ~created_at: string;
+  ~updated_at: string;
+  ?closed_at: string option;
+  ?milestone: milestone option;
+  ~sort <ocaml default="`Created">: issue_sort;
+  ~direction <ocaml default="`Desc">: direction;
+  ?mentioned: string list option;
+  ?pull_request: pull_ref option;
+} <ocaml field_prefix="issue_">
+
+type issues = issue list
+
+type comment = {
+  id: int <ocaml repr="int64">;
+  url: string;
+  html_url: string;
+  body: string;
+  user: user;
+  created_at: string;
+  updated_at: string;
+} <ocaml field_prefix="comment_">
+
+type issue_comment = {
+  inherit comment
+} <ocaml field_prefix="issue_comment_">
+
+type issue_comments = issue_comment list
+
+type new_issue_comment = {
+  body: string;
+} <ocaml field_prefix="new_issue_comment_">
+
+type repo_commit = {
+  sha: string;
+  url: string;
+} <ocaml field_prefix="repo_commit_">
+
+type repo_tag = {
+  name: string;
+  commit: repo_commit;
+  zipball_url: string;
+  tarball_url: string;
+} <ocaml field_prefix="repo_tag_">
+
+type repo_tags = repo_tag list
+
+type repo_branch = {
+  name: string;
+  commit: repo_commit;
+} <ocaml field_prefix="repo_branch_">
+
+type repo_branches = repo_branch list
+
+type obj_type = [
+  | Blob <json name="blob">
+  | Tree <json name="tree">
+  | Commit <json name="commit">
+  | Tag <json name="tag">
+]
+
+type obj = {
+  ty <json name="type">: obj_type;
+  sha: string;
+  url: string;
+} <ocaml field_prefix="obj_">
+
+type git_ref = {
+  name <json name="ref">: string;
+  url: string;
+  obj <json name="object">: obj;
+} <ocaml field_prefix="git_ref_">
+
+type git_refs = git_ref list
+
+type info = {
+  date: string;
+  email: string;
+  name: string;
+} <ocaml field_prefix="info_">
+
+type tag = {
+  obj <json name="object">: obj;
+  url: string;
+  sha: string;
+  tag: string;
+  message: string;
+  tagger: info;
+} <ocaml field_prefix="tag_">
+
+type git_commit = {
+  url: string;
+  author: info;
+  message: string;
+} <ocaml field_prefix="git_commit_">
+
+type commit = {
+  url: string;
+  sha: string;
+  git <json name="commit">: git_commit;
+  ?author: user option; (* why? *)
+  ?committer: user option; (* why? *)
+} <ocaml field_prefix="commit_">
+
+type commits = commit list
+
+type repo = {
+  id: int <ocaml repr="int64">;
+  name: string;
+  url: string;
+} <ocaml field_prefix="repo_">
+
+type new_repo = {
+  name : string;
+  description : string;
+  homepage : string;
+  private : bool;
+  has_issues : bool;
+  has_wiki : bool;
+  has_downloads : bool;
+  team_id : int;
+  auto_init : bool;
+  ?gitignore_template : string option;
+  ?license_template : string option;
+} <ocaml field_prefix="new_repo_">
+
+type repository = {
+  owner: user;
+  full_name: string;
+  ?description: string option;
+  ~private: bool;
+  fork: bool;
+  html_url: string;
+  clone_url: string;
+  git_url: string;
+  ssh_url: string;
+  svn_url: string;
+  ?mirror_url: string option;
+  ~homepage: string;
+  ?language: string option;
+  forks_count: int;
+  ?subscribers_count: int option;
+  stargazers_count: int;
+  size: int;
+  ?default_branch: string option;
+  open_issues_count: int;
+  ?pushed_at: string option;
+  created_at: string;
+  updated_at: string;
+  ?organization: user option;
+  has_issues: bool;
+  has_wiki: bool;
+  has_downloads: bool;
+  has_pages: bool;
+  inherit repo
+} <ocaml field_prefix="repository_">
+
+type repositories = repository list
+
+type repository_search = {
+  total_count: int;
+  incomplete_results: bool;
+  items: repositories;
+} <ocaml field_prefix="repository_search_">
+
+type branch = {
+  label: string;
+  ref: string;
+  sha: string;
+  ?user: user option;
+  ?repo: repository option;
+} <ocaml field_prefix="branch_">
+
+type link = {
+  href: string;
+}
+
+type contribution_week = {
+  w: int;
+  a: int;
+  d: int;
+  c: int;
+} <ocaml field_prefix="repo_contribution_week_">
+
+type contributor_stats = {
+  author: user;
+  total: int;
+  weeks: contribution_week list;
+} <ocaml field_prefix="repo_contributor_stats_">
+
+type contributors_stats = contributor_stats list
+
+type pull_links = {
+  self: link;
+  html: link;
+  comments: link;
+  review_comments: link;
+} <ocaml field_prefix="pull_">
+
+type pull_ref = {
+  url: string;
+  html_url: string;
+  diff_url: string;
+  patch_url: string;
+} <ocaml field_prefix="pull_ref_">
+
+type pull = {
+  issue_url: string;
+  number: int;
+  ~state <ocaml default="`Open">: state;
+  title: string;
+  ~body: string;
+  created_at: string;
+  updated_at: string;
+  ?closed_at: string option;
+  ?merged_at: string option;
+  head: branch;
+  base: branch;
+  links <json name="_links">: pull_links;
+  user: user;
+  inherit pull_ref
+} <ocaml field_prefix="pull_">
+
+type pulls = pull list
+
+type new_pull = {
+  title: string;
+  ?body: string option;
+  base: string;
+  head: string;
+} <ocaml field_prefix="new_pull_">
+
+type new_pull_issue = {
+  issue: int;
+  base: string;
+  head: string;
+} <ocaml field_prefix="new_pull_issue_">
+
+type update_pull = {
+  ?title: string option;
+  ?body: string option;
+  ?state: state option;
+  ?base: string option;
+} <ocaml field_prefix="update_pull_">
+
+type commit_comment = {
+  ?position: int option;
+  ?line: int option;
+  ?path: string option;
+  commit_id: string;
+  inherit comment
+} <ocaml field_prefix="commit_comment_">
+
+type commit_comment_event = {
+  comment: commit_comment;
+} <ocaml field_prefix="commit_comment_event_">
+
+type ref = [
+  | Repository <json name="repository">
+  | Branch <json name="branch"> of string
+  | Tag <json name="tag"> of string
+]
+
+type create_event = {
+  ref <json tag_field="ref_type">: ref;
+  master_branch: string;
+  ?description: string option;
+  (* pusher_type *)
+} <ocaml field_prefix="create_event_">
+
+type delete_event = {
+  ref <json tag_field="ref_type">: ref;
+  (* pusher_type *)
+} <ocaml field_prefix="delete_event_">
+
+type fork_event = {
+  forkee: repository;
+} <ocaml field_prefix="fork_event_">
+
+type wiki_page_action = [
+  | Created <json name="created">
+  | Edited <json name="edited">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type wiki_page = {
+  name <json name="page_name">: string;
+  title: string;
+  action: wiki_page_action;
+  sha: string;
+  html_url: string;
+} <ocaml field_prefix="wiki_page_">
+
+type gollum_event = {
+  pages: wiki_page list;
+} <ocaml field_prefix="gollum_event_">
+
+type repo_issues_action = [
+  | Closed <json name="closed">
+  | Reopened <json name="reopened">
+  | Subscribed <json name="subscribed">
+  | Merged <json name="merged">
+  | Referenced <json name="referenced">
+  | Mentioned <json name="mentioned">
+  | Assigned <json name="assigned">
+  | Unassigned <json name="unassigned">
+  | Labeled <json name="labeled">
+  | Unlabeled <json name="unlabeled">
+  | Milestoned <json name="milestoned">
+  | Demilestoned <json name="demilestoned">
+  | Renamed <json name="renamed">
+  | Locked <json name="locked">
+  | Unlocked <json name="unlocked">
+  | Head_ref_deleted <json name="head_ref_deleted">
+  | Head_ref_restored <json name="head_ref_restored">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type issue_rename = {
+  from: string;
+  to: string;
+} <ocaml field_prefix="issue_rename_">
+
+type repo_issue_event = {
+  id: int;
+  url: string;
+  ?actor: linked_user option;
+  event: repo_issues_action;
+  created_at: string;
+  ?label: base_label option;
+  ?assignee: linked_user option;
+  ?assigner: linked_user option;
+  ?milestone: milestone option;
+  ?rename: issue_rename option;
+} <ocaml field_prefix="repo_issue_event_">
+
+type repo_issues_event = {
+  issue: issue;
+  inherit repo_issue_event
+} <ocaml field_prefix="repo_issues_event_">
+
+type repo_issues_events = repo_issues_event list
+type repo_issue_events = repo_issue_event list
+
+type change = {
+  from: string;
+} <ocaml field_prefix="change_">
+
+type body_changes = {
+  ?body: change option;
+} <ocaml field_prefix="body_changes_">
+
+type ticket_changes = {
+  ?title: change option;
+  inherit body_changes
+} <ocaml field_prefix="ticket_changes_">
+
+type issue_comment_action = [
+  | Created <json name="created">
+  | Edited <json name="edited"> of body_changes
+  | Deleted <json name="deleted">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type issue_comment_event = {
+  action <json name="changes" tag_field="action">: issue_comment_action;
+  issue: issue;
+  comment: issue_comment;
+} <ocaml field_prefix="issue_comment_event_">
+
+type issues_action = [
+  | Assigned <json name="assigned">
+  | Unassigned <json name="unassigned">
+  | Labeled <json name="labeled">
+  | Unlabeled <json name="unlabeled">
+  | Opened <json name="opened">
+  | Edited <json name="edited"> of ticket_changes
+  | Closed <json name="closed">
+  | Reopened <json name="reopened">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type issues_event = {
+  action <json name="changes" tag_field="action">: issues_action;
+  issue: issue;
+  ?assignee: user_info option;
+  ?label: label option;
+} <ocaml field_prefix="issues_event_">
+
+type member_action = [
+  | Added <json name="added">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type member_event = {
+  action: member_action;
+  member: linked_user;
+} <ocaml field_prefix="member_event_">
+
+(* TODO: this could use constr + optional support *)
+type page_build_error = {
+  ?message: string option;
+} <ocaml field_prefix="page_build_error_">
+
+type page_build_status = [
+  | Building <json name="building">
+  | Built <json name="built">
+  | Errored <json name="errored">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type page_build = {
+  url: string;
+  ?status: page_build_status option;
+  error: page_build_error;
+} <ocaml field_prefix="page_build_">
+
+type page_build_event = {
+  build: page_build;
+} <ocaml field_prefix="page_build_event_">
+
+type pull_request_action = [
+  | Assigned <json name="assigned">
+  | Unassigned <json name="unassigned">
+  | Labeled <json name="labeled">
+  | Unlabeled <json name="unlabeled">
+  | Opened <json name="opened">
+  | Edited <json name="edited"> of ticket_changes
+  | Closed <json name="closed">
+  | Reopened <json name="reopened">
+  | Synchronize <json name="synchronize">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type pull_request_event = {
+  action <json name="changes" tag_field="action">: pull_request_action;
+  number: int;
+  pull_request: pull;
+} <ocaml field_prefix="pull_request_event_">
+
+type pull_request_review_comment_action = [
+  | Created <json name="created">
+  | Edited <json name="edited"> of body_changes
+  | Deleted <json name="deleted">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type pull_request_review_comment = {
+  diff_hunk: string;
+  original_position: int;
+  original_commit_id: string;
+  pull_request_url: string;
+  inherit commit_comment
+} <ocaml field_prefix="pull_request_review_comment_">
+
+type pull_request_review_comment_event = {
+  action <json name="changes" tag_field="action">: pull_request_review_comment_action;
+  pull_request: pull;
+  comment: pull_request_review_comment;
+} <ocaml field_prefix="pull_request_review_comment_event_">
+
+type push_event_author = {
+  name: string;
+  email: string;
+} <ocaml field_prefix="push_event_author_">
+
+type push_event_commit_base = {
+  url: string;
+  message: string;
+  author: push_event_author;
+  distinct: bool;
+} <ocaml field_prefix="push_event_commit_base_">
+
+type push_event_hook_commit = {
+  id: string;
+  tree_id: string;
+  inherit push_event_commit_base
+} <ocaml field_prefix="push_event_hook_commit_">
+
+type push_event_commit = {
+  sha: string;
+  inherit push_event_commit_base
+} <ocaml field_prefix="push_event_commit_">
+
+type push_event_base = {
+  ref: string;
+  before: string;
+} <ocaml field_prefix="push_event_base_">
+
+type push_event = {
+  head: string;
+  size: int;
+  commits: push_event_commit list;
+  inherit push_event_base
+} <ocaml field_prefix="push_event_">
+
+type push_event_hook = {
+  after: string;
+  created: bool;
+  deleted: bool;
+  forced: bool;
+  commits: push_event_hook_commit list;
+  head_commit: push_event_hook_commit nullable;
+  inherit push_event_base
+} <ocaml field_prefix="push_event_hook_">
+
+type release_action = [
+  | Published <json name="published">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type release_event = {
+  action: release_action;
+  release: release;
+} <ocaml field_prefix="release_event_">
+
+type repository_action = [
+  | Created <json name="created">
+  | Deleted <json name="deleted">
+  | Publicized <json name="publicized">
+  | Privatized <json name="privatized">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type repository_event = {
+  action: repository_action;
+  repository: repository;
+} <ocaml field_prefix="repository_event_">
+
+type status_branch_commit = {
+  sha: string;
+  url: string;
+} <ocaml field_prefix="status_branch_commit_">
+
+type status_branch = {
+  name: string;
+  commit: status_branch_commit;
+} <ocaml field_prefix="status_branch_">
+
+type status_event = {
+  sha: string;
+  (* name *)
+  ?target_url: string option;
+  ?context : string option;
+  ?description: string option;
+  state: status_state;
+  commit: commit;
+  branches: status_branch list;
+  (* created_at *)
+  (* updated_at *)
+} <ocaml field_prefix="status_event_">
+
+type team_add_info = {
+  slug: string;
+  permission: team_permission;
+  members_url: string;
+  repositories_url: string;
+  inherit team
+} <ocaml field_prefix="team_add_info_">
+
+type team_add_event = {
+  ?team: team_add_info option;
+  ?user: user option;
+  ?repository: repository option;
+  organization: org;
+} <ocaml field_prefix="team_add_event_">
+
+type watch_action = [
+  | Started <json name="started">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type watch_event = {
+  action: watch_action;
+} <ocaml field_prefix="watch_event_">
+
+type file = {
+  ?sha: string option; (* e.g. if status is 'renamed', this is None *)
+  filename: string;
+  status: string; (* TODO: variant? at least "added" *)
+  additions: int;
+  deletions: int;
+  changes: int;
+  blob_url: string;
+  raw_url: string;
+  ?patch: string option;
+} <ocaml field_prefix="file_">
+
+type files = file list
+
+type merge_request = {
+  ?commit_message: string option;
+} <ocaml field_prefix="merge_">
+
+type merge = {
+  ?sha: string option;
+  merged: bool;
+  message: string;
+} <ocaml field_prefix="merge_">
+
+type event_type = [
+  | CommitComment <json name="commit_comment">
+  | Create <json name="create">
+  | Delete <json name="delete">
+  | Deployment <json name="deployment">
+  | DeploymentStatus <json name="deployment_status">
+  | Download <json name="download">
+  | Follow <json name="follow">
+  | Fork <json name="fork">
+  | ForkApply <json name="fork_apply">
+  | Gist <json name="gist">
+  | Gollum <json name="gollum">
+  | IssueComment <json name="issue_comment">
+  | Issues <json name="issues">
+  | Member <json name="member">
+  | PageBuild <json name="page_build">
+  | Public <json name="public">
+  | PullRequest <json name="pull_request">
+  | PullRequestReviewComment <json name="pull_request_review_comment">
+  | Push <json name="push">
+  | Release <json name="release">
+  | Repository <json name="repository">
+  | Status <json name="status">
+  | TeamAdd <json name="team_add">
+  | Watch <json name="watch">
+  | All <json name="*">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type event_constr = [
+  | CommitComment <json name="CommitCommentEvent"> of commit_comment_event
+  | Create <json name="CreateEvent"> of create_event
+  | Delete <json name="DeleteEvent"> of delete_event
+  (*| Deployment <json name="deployment"> of *)
+  (*| DeploymentStatus <json name="deployment_status"> of *)
+  | Download <json name="DownloadEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Follow <json name="FollowEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Fork <json name="ForkEvent"> of fork_event
+  | ForkApply <json name="ForkApplyEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gist <json name="GistEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gollum <json name="GollumEvent"> of gollum_event
+  | IssueComment <json name="IssueCommentEvent"> of issue_comment_event
+  | Issues <json name="IssuesEvent"> of issues_event
+  | Member <json name="MemberEvent"> of member_event
+  (*| PageBuild <json name="page_build"> of page_build_event*)
+  | Public <json name="PublicEvent">
+  | PullRequest <json name="PullRequestEvent"> of pull_request_event
+  | PullRequestReviewComment <json name="PullRequestReviewCommentEvent">
+    of pull_request_review_comment_event
+  | Push <json name="PushEvent"> of push_event
+  | Release <json name="ReleaseEvent"> of release_event
+  | Repository <json name="RepositoryEvent"> of repository_event
+  | Status <json name="StatusEvent"> of status_event
+  (*| TeamAdd <json name="team_add"> of team_add_event*)
+  | Watch <json name="WatchEvent"> of watch_event
+  | Unknown <json untyped> of (string * json option)
+]
+
+type event = {
+  public: bool;
+  payload <json tag_field="type">: event_constr;
+  actor: user;
+  ?org: org option;
+  created_at: string;
+  repo: repo;
+  id: int <ocaml repr="int64">;
+} <ocaml field_prefix="event_">
+
+type events = event list
+
+type event_hook_constr = [
+  | CommitComment <json name="CommitCommentEvent"> of commit_comment_event
+  | Create <json name="CreateEvent"> of create_event
+  | Delete <json name="DeleteEvent"> of delete_event
+  (*| Deployment <json name="deployment"> of *)
+  (*| DeploymentStatus <json name="deployment_status"> of *)
+  | Download <json name="DownloadEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Follow <json name="FollowEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Fork <json name="ForkEvent"> of fork_event
+  | ForkApply <json name="ForkApplyEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gist <json name="GistEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gollum <json name="GollumEvent"> of gollum_event
+  | IssueComment <json name="IssueCommentEvent"> of issue_comment_event
+  | Issues <json name="IssuesEvent"> of issues_event
+  | Member <json name="MemberEvent"> of member_event
+  (*| PageBuild <json name="page_build"> of page_build_event*)
+  | Public <json name="PublicEvent">
+  | PullRequest <json name="PullRequestEvent"> of pull_request_event
+  | PullRequestReviewComment <json name="PullRequestReviewCommentEvent">
+    of pull_request_review_comment_event
+  | Push <json name="PushEvent"> of push_event_hook
+  | Release <json name="ReleaseEvent"> of release_event
+  | Repository <json name="RepositoryEvent"> of repository_event
+  | Status <json name="StatusEvent"> of status_event
+  (*| TeamAdd <json name="team_add"> of team_add_event*)
+  | Watch <json name="WatchEvent"> of watch_event
+  | Unknown <json untyped> of (string * json option)
+]
+
+type event_hook_metadata = {
+  sender: user;
+  ?organisation: org option;
+  created_at: string;
+  repository: repository;
+  id: int <ocaml repr="int64">;
+} <ocaml field_prefix="event_hook_metadata_">
+
+type bool_as_string = string wrap <ocaml
+  t="bool"
+  wrap="fun x -> x <> \"0\""
+  unwrap="function true -> \"1\" | false -> \"0\""
+>
+
+type web_hook_config = {
+  url: string;
+  ?content_type: string option;
+  ~insecure_ssl <ocaml default="false">: bool_as_string;
+  ?secret: string option;
+} <ocaml field_prefix="web_hook_config_">
+
+type json <ocaml module="Yojson.Safe"> = abstract
+
+type hook_config = [
+  | Web <json name="web"> of web_hook_config
+  | Unknown <json untyped> of (string * json option)
+]
+
+type hook = {
+  url: string;
+  updated_at: string;
+  created_at: string;
+  events: event_type list;
+  active: bool;
+  config <json tag_field="name">: hook_config;
+  id: int <ocaml repr="int64">;
+} <ocaml field_prefix="hook_">
+
+type hooks = hook list
+
+type new_hook = {
+  config <json tag_field="name">: hook_config;
+  events: event_type list;
+  active: bool;
+} <ocaml field_prefix="new_hook_">
+
+type update_hook = {
+  config <json tag_field="name">: hook_config;
+  ?events: event_type list option;
+  active: bool;
+} <ocaml field_prefix="update_hook_">
+
+type status_state = [
+  | Pending <json name="pending">
+  | Success <json name="success">
+  | Failure <json name="failure">
+  | Error <json name="error">
+  | Unknown <json untyped> of (string * json option)
+]
+
+type base_status = {
+  url: string;
+  updated_at: string;
+  created_at: string;
+  id: int <ocaml repr="int64">;
+  state: status_state;
+  ?target_url: string option;
+  ?description: string option;
+  ?context: string option;
+} <ocaml field_prefix="base_status_">
+
+type base_statuses = base_status list
+
+type status = {
+  creator: user;
+  inherit base_status
+} <ocaml field_prefix="status_">
+
+type statuses = status list
+
+type combined_status = {
+  state: status_state;
+  sha: string;
+  total_count: int;
+  statuses: base_statuses;
+  repository: repo;
+  url: string;
+  commit_url: string;
+} <ocaml field_prefix="combined_status_">
+
+type new_status = {
+  state: status_state;
+  ?target_url: string option;
+  ?description: string option;
+  ?context: string option;
+} <ocaml field_prefix="new_status_">
+
+type release = {
+  id: int <ocaml repr="int64">;
+  tag_name: string;
+  ?target_commitish: string option;
+  ?name: string option;
+  ?body: string option;
+  draft: bool;
+  prerelease: bool;
+  ~created_at: string;
+  ~published_at: string;
+  url: string;
+  html_url: string;
+  assets_url: string;
+  upload_url: string;
+} <ocaml field_prefix="release_">
+
+type releases = release list
+
+type release_repo = {
+  user: string;
+  repo: string;
+  release: release;
+} <ocaml field_prefix="release_repo_">
+type release_repos = release_repo list
+
+type new_release = {
+  tag_name: string;
+  target_commitish: string;
+  ?name: string option;
+  ?body: string option;
+  draft: bool;
+  prerelease: bool;
+} <ocaml field_prefix="new_release_">
+
+type update_release = {
+  ?tag_name: string option;
+  ?target_commitish: string option;
+  ?name: string option;
+  ?body: string option;
+  ?draft: bool option;
+  ?prerelease: bool option;
+} <ocaml field_prefix="update_release_">
+
+type deploy_key = {
+  id: int <ocaml repr="int64">;
+  key: string;
+  url: string;
+  title: string;
+} <ocaml field_prefix="deploy_key_">
+
+type deploy_keys = deploy_key list
+
+type new_deploy_key = {
+  title: string;
+  key: string;
+} <ocaml field_prefix="new_deploy_key_">
+
+type gist_file = {
+  size: int;
+  raw_url: string;
+  ty <json name="type">: string;
+  ?truncated: bool option;
+  ?language: string option;
+  ?content: string option;
+} <ocaml field_prefix="gist_file_">
+
+type gist_files = (string * gist_file) list <json repr="object">
+
+type gist_fork = {
+  user: user;
+  url: string;
+  id: int <ocaml repr="int64">;
+  created_at: string;
+  updated_at: string;
+} <ocaml field_prefix="gist_fork_">
+
+type gist_forks = gist_fork list
+
+type change_status = {
+  deletions: int;
+  additions: int;
+  total: int;
+} <ocaml field_prefix="change_status_">
+
+type gist_commit = {
+  url: string;
+  version: string;
+  user: user;
+  change_status: change_status;
+  committed_at: string;
+} <ocaml field_prefix="gist_commit_">
+
+type gist_commits = gist_commit list
+
+type gist = {
+  url: string;
+  forks_url: string;
+  commits_url: string;
+  id: string;
+  ?description: string option;
+  public: bool;
+  owner: user;
+  ?user: string option;
+  files: gist_files;
+  comments: int;
+  comments_url: string;
+  html_url: string;
+  git_pull_url: string;
+  git_push_url: string;
+  created_at: string;
+  updated_at: string;
+  ?forks: gist_fork list option;
+  ?history: gist_commits option;
+} <ocaml field_prefix="gist_">
+
+type gists = gist list
+
+type new_gist_content = {
+  content: string;
+} <ocaml field_prefix="new_gist_">
+
+type new_gist_contents = (string * new_gist_content) list <json repr="object">
+
+type new_gist = {
+  files: new_gist_contents;
+  description: string;
+  public: bool;
+} <ocaml field_prefix="new_gist_">
+
+type update_gist_file = {
+  ?content: string option;
+  ?name <json name="filename">: string option;
+} <ocaml field_prefix="update_gist_file_">
+
+type update_gist = {
+  description: string;
+  files: (string * update_gist) list <json repr="object">
+} <ocaml field_prefix="update_gist_">
+
+type emojis = (string * string) list <json repr="object">
+
+type timeline_action = [
+  | Assigned <json name="assigned">
+  | Closed <json name="closed">
+  | Commented <json name="commented">
+  | Committed <json name="committed">
+  | Cross_referenced <json name="cross-referenced">
+  | Demilestoned <json name="demilestoned">
+  | Head_ref_deleted <json name="head_ref_deleted">
+  | Head_ref_restored <json name="head_ref_restored">
+  | Labeled <json name="labeled">
+  | Locked <json name="locked">
+  | Mentioned <json name="mentioned">
+  | Merged <json name="merged">
+  | Milestoned <json name="milestoned">
+  | Referenced <json name="referenced">
+  | Renamed <json name="renamed">
+  | Reopened <json name="reopened">
+  | Review_dismissed <json name="review_dismissed">
+  | Review_requested <json name="review_requested">
+  | Review_request_removed <json name="review_request_removed">
+  | Subscribed <json name="subscribed">
+  | Unassigned <json name="unassigned">
+  | Unlabeled <json name="unlabeled">
+  | Unlocked <json name="unlocked">
+  | Unsubscribed <json name="unsubscribed">
+]
+
+type timeline_source = {
+  ?id: int option <ocaml repr="int64 option">;
+  ?url: string option;
+  ?actor: user option;
+  ?issue: issue option;
+} <ocaml field_prefix="timeline_source_">
+
+type timeline_event = {
+  ?id: int option <ocaml repr="int64 option">;
+  ?url: string option;
+  ?actor: user option;
+  ?commit_id: string option;
+  event: timeline_action;
+  created_at: string;
+  ?label: base_label option;
+  ?assignee: user option;
+  ?milestone: milestone option;
+  ?source: timeline_source option;
+  ?rename: issue_rename option;
+} <ocaml field_prefix="timeline_event_">
+
+type timeline_events = timeline_event list

--- a/atdgen/test/jbuild
+++ b/atdgen/test/jbuild
@@ -1,6 +1,16 @@
 (jbuild_version 1)
 
 (rule
+ ((targets (github_t.ml github_t.mli))
+  (deps    (github.atd))
+  (action  (run atdgen -t ${<}))))
+
+(rule
+ ((targets (github_j.ml github_j.mli))
+  (deps    (github.atd))
+  (action  (run atdgen -j -j-std ${<}))))
+
+(rule
  ((targets (test.ml test.mli))
   (deps    (test.atd))
   (action  (run ${bin:atdgen} ${<}))))
@@ -59,6 +69,17 @@
     test_atdgen_main
     test_atdgen_type_conv
     test_lib))))
+
+(executables
+ ((libraries (atd atdgen))
+  (names (github_j))
+  (modules (github_t github_j))))
+
+(alias
+ ((name runtest)
+  (package atdgen)
+  (deps (github_j.exe))
+  (action (run ${<}))))
 
 (alias
  ((name   runtest)


### PR DESCRIPTION
The goal of this PR is to build atdgen with:

```
$ jbuilder build --dev
```

I succeeded doing so with the following caveats:

* The commit history looks atrocious. Sorry about that, I'll need to squash
before the merge.

* There are some suspicious looking unused arguments that might be uncovering
potential bugs. Check out the commits with "suspicious" somewhere in the title.
Those are really the only ones that need review.

Important note:

This PR actaully revealed to me some regressions i've introduced in my mli PR.
My mli for the various runtimes was vary conservative and hence doesn't include
many of the functions that are used by generated code. The tests didn't fail at
ony of this, so we really need to improve that. I will fix this regression in an
upcoming PR.

Some other general notes recommedations:

* Polymorphic variants make type errors really really ugly. Is there a reason
why there's so prevalent in this codebase? I'd love to be able to just change
them into normal variants

* The loc arguments to constructors are ignored so much I wonder if it makes
sense to just have 2 ast's with/without locs.

* There are some pretty big tuple arguments to some constructors. We should
really clean those up.