### PR TITLE
Cleanup output

### DIFF
--- a/atdgen/test/jbuild
+++ b/atdgen/test/jbuild
@@ -58,7 +58,7 @@
   (action
    (run
     ${bin:atdgen} -json -extend Test -j-custom-fields
-    "fun loc s -> Printf.printf \"Warning: skipping field %s (def: %s)\" s loc"
+    "fun loc s -> Printf.eprintf \"Warning: skipping field %s (def: %s)\n\" s loc"
     ${<}
     -o testj))))
 

--- a/atdgen/test/test.atd
+++ b/atdgen/test/test.atd
@@ -23,7 +23,7 @@ j  *  j
       ">
 
 type r = {
-  a : int <ocaml validator="fun _ _ -> print_endline \"field a\"; None">;
+  a : int <ocaml validator="fun _ _ -> None">;
   b <ocaml mutable> : bool;
   c : p;
 }
@@ -112,7 +112,6 @@ type extended = {
   ~b5 <ocaml name="b5x" default="0.5"> : float;
 } <ocaml validator="\
     fun path x ->
-      print_endline \"Validating record of type 'extended'\";
       if x.b0x >= 0 then None
       else Some (Atdgen_runtime.Util.Validation.error path)">
 

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -555,11 +555,13 @@ and read_r = (
                   2
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -611,11 +613,13 @@ and read_r = (
                     2
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -842,7 +846,8 @@ and read_poly read__x read__y = (
                     0
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
                 )
               | 's' -> (
@@ -850,15 +855,18 @@ and read_poly read__x read__y = (
                     1
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -898,7 +906,8 @@ and read_poly read__x read__y = (
                       0
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                     )
                   )
                 | 's' -> (
@@ -906,15 +915,18 @@ and read_poly read__x read__y = (
                       1
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                     )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -1409,7 +1421,8 @@ let read_val1 = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 119, characters 12-161" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 118, characters 12-161" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -1439,7 +1452,8 @@ let read_val1 = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 119, characters 12-161" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 118, characters 12-161" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -1654,11 +1668,13 @@ let read_val2 = (
                   1
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -1703,11 +1719,13 @@ let read_val2 = (
                     1
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -2718,11 +2736,13 @@ let read_mixed_record = (
                         9
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                       )
                 )
                 else (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
               )
             | 7 -> (
@@ -2744,15 +2764,18 @@ let read_mixed_record = (
                         14
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                       )
                 )
                 else (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
               )
             | _ -> (
-                (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
               )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3009,11 +3032,13 @@ let read_mixed_record = (
                           9
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                         )
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                   )
                 )
               | 7 -> (
@@ -3035,15 +3060,18 @@ let read_mixed_record = (
                           14
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                         )
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3509,11 +3537,13 @@ let read_test = (
                   4
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3591,11 +3621,13 @@ let read_test = (
                     4
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3779,7 +3811,8 @@ let read__30 = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 205, characters 18-33" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 204, characters 18-33" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3809,7 +3842,8 @@ let read__30 = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 205, characters 18-33" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 204, characters 18-33" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3889,7 +3923,8 @@ let read_some_record = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 191, characters 19-95" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 190, characters 19-95" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3919,7 +3954,8 @@ let read_some_record = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 191, characters 19-95" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 190, characters 19-95" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4010,7 +4046,8 @@ let read_precision = (
                     2
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                   )
                 )
               | 's' -> (
@@ -4020,7 +4057,8 @@ let read_precision = (
                           1
                         )
                         else (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                       )
                     | 'q' -> (
@@ -4028,19 +4066,23 @@ let read_precision = (
                           0
                         )
                         else (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                       )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4087,7 +4129,8 @@ let read_precision = (
                       2
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                     )
                   )
                 | 's' -> (
@@ -4097,7 +4140,8 @@ let read_precision = (
                             1
                           )
                           else (
-                            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                           )
                         )
                       | 'q' -> (
@@ -4105,19 +4149,23 @@ let read_precision = (
                             0
                           )
                           else (
-                            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                           )
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4721,7 +4769,8 @@ let read_generic read__a = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 204, characters 18-35" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 203, characters 18-35" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4751,7 +4800,8 @@ let read_generic read__a = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 204, characters 18-35" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 203, characters 18-35" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4832,7 +4882,8 @@ let read_floats = (
                     0
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
                 )
               | '6' -> (
@@ -4840,15 +4891,18 @@ let read_floats = (
                     1
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4888,7 +4942,8 @@ let read_floats = (
                       0
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                     )
                   )
                 | '6' -> (
@@ -4896,15 +4951,18 @@ let read_floats = (
                       1
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                     )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -5207,11 +5265,13 @@ let read_extended = (
                   5
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -5297,11 +5357,13 @@ let read_extended = (
                     5
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -5549,11 +5611,13 @@ let read_base = (
                   1
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -5595,11 +5659,13 @@ let read_base = (
                     1
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -188,7 +188,7 @@ and validate_r : _ -> r -> _ = (
   fun path x ->
     match
       (
-        fun _ _ -> print_endline "field a"; None
+        fun _ _ -> None
       ) (`Field "a" :: path) x.a
     with
       | Some _ as err -> err
@@ -428,7 +428,6 @@ let validate_extended_tuple = (
 let validate_extended : _ -> extended -> _ = (
   fun path x ->
     match ( fun path x ->
-      print_endline "Validating record of type 'extended'";
       if x.b0x >= 0 then None
       else Some (Atdgen_runtime.Util.Validation.error path) ) path x with
       | Some _ as err -> err

--- a/atdj/test/jbuild
+++ b/atdj/test/jbuild
@@ -49,5 +49,5 @@
    (AtdjTest.java
     json.jar
     junit-4.8.2.jar
-    (files_recursively_in com)))
+    (glob_files com/mylife/test/*.java)))
   (action (run ./run_test.sh))))

--- a/atdj/test/run_test.sh
+++ b/atdj/test/run_test.sh
@@ -4,5 +4,7 @@ CLASSPATH='.:json.jar:junit-4.8.2.jar'
 
 javac -classpath $CLASSPATH com/mylife/test/*.java
 javac -classpath $CLASSPATH AtdjTest.java
-javadoc -classpath $CLASSPATH -d doc/test -public com.mylife.test
-java  -classpath $CLASSPATH AtdjTest
+javadoc -quiet -Xdoclint:none -classpath $CLASSPATH -d doc/test \
+        -public com.mylife.test -quiet \
+    | grep -v "Creating destination directory"
+java  -classpath $CLASSPATH AtdjTest | grep -v -E '^(Time:|JUnit version)' > java.trace


### PR DESCRIPTION
There's quite a lot of noise in the output that makes debugging tougher than it should be. This cleans it up. Some last bits of output (concerning the missing fields for example) are kind of part of the test, so they have to be kept for now until we fix the tests.