### PR TITLE
Remove a massive amount of polymorphic variants

### DIFF
--- a/atd/src/ast.ml
+++ b/atd/src/ast.ml
@@ -27,20 +27,19 @@ and module_item =
 and type_param = string list
 
 and type_expr =
-    [ `Sum of loc * variant list * annot
-    | `Record of loc * field list * annot
-    | `Tuple of loc * cell list * annot
-    | `List of loc * type_expr * annot
-    | `Option of loc * type_expr * annot
-    | `Nullable of loc * type_expr * annot
-    | `Shared of loc * type_expr * annot
-    | `Wrap of loc * type_expr * annot
-    | `Name of loc * type_inst * annot
-    | `Tvar of loc * string
-    ]
-      (* `List, `Option, `Nullable, `Shared and `Wrap are
-         the only predefined types with a type
-         parameter (and no special syntax). *)
+  | Sum of loc * variant list * annot
+  | Record of loc * field list * annot
+  | Tuple of loc * cell list * annot
+  | List of loc * type_expr * annot
+  | Option of loc * type_expr * annot
+  | Nullable of loc * type_expr * annot
+  | Shared of loc * type_expr * annot
+  | Wrap of loc * type_expr * annot
+  | Name of loc * type_inst * annot
+  | Tvar of loc * string
+  (* List, Option, Nullable, Shared and Wrap are
+     the only predefined types with a type
+     parameter (and no special syntax). *)
 
 and type_inst = loc * string * type_expr list
 
@@ -56,33 +55,33 @@ and field_kind =
   | With_default
 
 and field =
-    [ `Field of (loc * (string * field_kind * annot) * type_expr)
-    | `Inherit of (loc * type_expr) ]
+  [ `Field of (loc * (string * field_kind * annot) * type_expr)
+  | `Inherit of (loc * type_expr) ]
 
 
 let loc_of_type_expr = function
-    `Sum (loc, _, _)
-  | `Record (loc, _, _)
-  | `Tuple (loc, _, _)
-  | `List (loc, _, _)
-  | `Option (loc, _, _)
-  | `Nullable (loc, _, _)
-  | `Shared (loc, _, _)
-  | `Wrap (loc, _, _)
-  | `Name (loc, _, _)
-  | `Tvar (loc, _) -> loc
+  | Sum (loc, _, _)
+  | Record (loc, _, _)
+  | Tuple (loc, _, _)
+  | List (loc, _, _)
+  | Option (loc, _, _)
+  | Nullable (loc, _, _)
+  | Shared (loc, _, _)
+  | Wrap (loc, _, _)
+  | Name (loc, _, _)
+  | Tvar (loc, _) -> loc
 
 let set_type_expr_loc loc = function
-    `Sum (_, a, b) -> `Sum (loc, a, b)
-  | `Record (_, a, b) -> `Record (loc, a, b)
-  | `Tuple (_, a, b) -> `Tuple (loc, a, b)
-  | `List (_, a, b) -> `List (loc, a, b)
-  | `Option (_, a, b) -> `Option (loc, a, b)
-  | `Nullable (_, a, b) -> `Nullable (loc, a, b)
-  | `Shared (_, a, b) -> `Shared (loc, a, b)
-  | `Wrap (_, a, b) -> `Wrap (loc, a, b)
-  | `Name (_, a, b) -> `Name (loc, a, b)
-  | `Tvar (_, a) -> `Tvar (loc, a)
+  | Sum (_, a, b) -> Sum (loc, a, b)
+  | Record (_, a, b) -> Record (loc, a, b)
+  | Tuple (_, a, b) -> Tuple (loc, a, b)
+  | List (_, a, b) -> List (loc, a, b)
+  | Option (_, a, b) -> Option (loc, a, b)
+  | Nullable (_, a, b) -> Nullable (loc, a, b)
+  | Shared (_, a, b) -> Shared (loc, a, b)
+  | Wrap (_, a, b) -> Wrap (loc, a, b)
+  | Name (_, a, b) -> Name (loc, a, b)
+  | Tvar (_, a) -> Tvar (loc, a)
 
 let string_of_loc (pos1, pos2) =
   let line1 = pos1.pos_lnum
@@ -97,45 +96,42 @@ let error s = raise (Atd_error s)
 let error_at loc s = error (string_of_loc loc ^ "\n" ^ s)
 
 let annot_of_type_expr = function
-    `Sum (_, _, an)
-  | `Record (_, _, an)
-  | `Tuple (_, _, an)
-  | `List (_, _, an)
-  | `Option (_, _, an)
-  | `Nullable (_, _, an)
-  | `Shared (_, _, an)
-  | `Wrap (_, _, an)
-  | `Name (_, _, an) -> an
-  | `Tvar (_, _) -> []
-
-
+  | Sum (_, _, an)
+  | Record (_, _, an)
+  | Tuple (_, _, an)
+  | List (_, _, an)
+  | Option (_, _, an)
+  | Nullable (_, _, an)
+  | Shared (_, _, an)
+  | Wrap (_, _, an)
+  | Name (_, _, an) -> an
+  | Tvar (_, _) -> []
 
 let map_annot f = function
-    `Sum (loc, vl, a) ->  `Sum (loc, vl, f a)
-  | `Record (loc, fl, a) -> `Record (loc, fl, f a)
-  | `Tuple (loc, tl, a) -> `Tuple (loc, tl, f a)
-  | `List (loc, t, a) -> `List (loc, t, f a)
-  | `Option (loc, t, a) -> `Option (loc, t, f a)
-  | `Nullable (loc, t, a) -> `Nullable (loc, t, f a)
-  | `Shared (loc, t, a) -> `Shared (loc, t, f a)
-  | `Wrap (loc, t, a) -> `Wrap (loc, t, f a)
-  | `Tvar _ as x -> x
-  | `Name (loc, (loc2, name, args), a) ->
-      `Name (loc, (loc2, name, args), f a)
+  | Sum (loc, vl, a) ->  Sum (loc, vl, f a)
+  | Record (loc, fl, a) -> Record (loc, fl, f a)
+  | Tuple (loc, tl, a) -> Tuple (loc, tl, f a)
+  | List (loc, t, a) -> List (loc, t, f a)
+  | Option (loc, t, a) -> Option (loc, t, f a)
+  | Nullable (loc, t, a) -> Nullable (loc, t, f a)
+  | Shared (loc, t, a) -> Shared (loc, t, f a)
+  | Wrap (loc, t, a) -> Wrap (loc, t, f a)
+  | Tvar _ as x -> x
+  | Name (loc, (loc2, name, args), a) ->
+      Name (loc, (loc2, name, args), f a)
 
-let rec amap_type_expr f (x : type_expr) =
-  match x with
-      `Sum (loc, vl, a) ->  `Sum (loc, List.map (amap_variant f) vl, f a)
-    | `Record (loc, fl, a) -> `Record (loc, List.map (amap_field f) fl, f a)
-    | `Tuple (loc, tl, a) -> `Tuple (loc, List.map (amap_cell f) tl, f a)
-    | `List (loc, t, a) -> `List (loc, amap_type_expr f t, f a)
-    | `Option (loc, t, a) -> `Option (loc, amap_type_expr f t, f a)
-    | `Nullable (loc, t, a) -> `Nullable (loc, amap_type_expr f t, f a)
-    | `Shared (loc, t, a) -> `Shared (loc, amap_type_expr f t, f a)
-    | `Wrap (loc, t, a) -> `Wrap (loc, amap_type_expr f t, f a)
-    | `Tvar _ as x -> x
-    | `Name (loc, (loc2, name, args), a) ->
-        `Name (loc, (loc2, name, List.map (amap_type_expr f) args), f a)
+let rec amap_type_expr f = function
+  | Sum (loc, vl, a) ->  Sum (loc, List.map (amap_variant f) vl, f a)
+  | Record (loc, fl, a) -> Record (loc, List.map (amap_field f) fl, f a)
+  | Tuple (loc, tl, a) -> Tuple (loc, List.map (amap_cell f) tl, f a)
+  | List (loc, t, a) -> List (loc, amap_type_expr f t, f a)
+  | Option (loc, t, a) -> Option (loc, amap_type_expr f t, f a)
+  | Nullable (loc, t, a) -> Nullable (loc, amap_type_expr f t, f a)
+  | Shared (loc, t, a) -> Shared (loc, amap_type_expr f t, f a)
+  | Wrap (loc, t, a) -> Wrap (loc, amap_type_expr f t, f a)
+  | Tvar _ as x -> x
+  | Name (loc, (loc2, name, args), a) ->
+      Name (loc, (loc2, name, List.map (amap_type_expr f) args), f a)
 
 and amap_variant f = function
     Variant (loc, (name, a), o) ->
@@ -172,46 +168,46 @@ let map_all_annot f ((head, body) : full_module) =
 let rec fold (f : type_expr -> 'a -> 'a) (x : type_expr) acc =
   let acc = f x acc in
   match x with
-      `Sum (_, variant_list, _annot) ->
-        List.fold_right (fold_variant f) variant_list acc
+    Sum (_, variant_list, _annot) ->
+      List.fold_right (fold_variant f) variant_list acc
 
-    | `Record (_, field_list, _annot) ->
-        List.fold_right (fold_field f) field_list acc
+  | Record (_, field_list, _annot) ->
+      List.fold_right (fold_field f) field_list acc
 
-    | `Tuple (_, l, _annot) ->
-        List.fold_right (fun (_, x, _) acc -> fold f x acc) l acc
+  | Tuple (_, l, _annot) ->
+      List.fold_right (fun (_, x, _) acc -> fold f x acc) l acc
 
-    | `List (_, type_expr, _annot) ->
-        fold f type_expr acc
+  | List (_, type_expr, _annot) ->
+      fold f type_expr acc
 
-    | `Option (_, type_expr, _annot) ->
-        fold f type_expr acc
+  | Option (_, type_expr, _annot) ->
+      fold f type_expr acc
 
-    | `Nullable (_, type_expr, _annot) ->
-        fold f type_expr acc
+  | Nullable (_, type_expr, _annot) ->
+      fold f type_expr acc
 
-    | `Shared (_, type_expr, _annot) ->
-        fold f type_expr acc
+  | Shared (_, type_expr, _annot) ->
+      fold f type_expr acc
 
-    | `Wrap (_, type_expr, _annot) ->
-        fold f type_expr acc
+  | Wrap (_, type_expr, _annot) ->
+      fold f type_expr acc
 
-    | `Name (_, (_2, _name, type_expr_list), _annot) ->
-        List.fold_right (fold f) type_expr_list acc
+  | Name (_, (_2, _name, type_expr_list), _annot) ->
+      List.fold_right (fold f) type_expr_list acc
 
-    | `Tvar (_, _string) ->
-        acc
+  | Tvar (_, _string) ->
+      acc
 
 and fold_variant f x acc =
   match x with
-      Variant (_, _, Some type_expr) -> fold f type_expr acc
-    | Variant _ -> acc
-    | Inherit (_, type_expr) -> fold f type_expr acc
+    Variant (_, _, Some type_expr) -> fold f type_expr acc
+  | Variant _ -> acc
+  | Inherit (_, type_expr) -> fold f type_expr acc
 
 and fold_field f x acc =
   match x with
-      `Field (_, _, type_expr) -> fold f type_expr acc
-    | `Inherit (_, type_expr) -> fold f type_expr acc
+    `Field (_, _, type_expr) -> fold f type_expr acc
+  | `Inherit (_, type_expr) -> fold f type_expr acc
 
 
 module Type_names = Set.Make (String)
@@ -228,12 +224,12 @@ let extract_type_names ?(ignorable = []) x =
     fold (
       fun x acc ->
         match x with
-            `Name (_, (_, name, _), _) -> add name acc
-          | _ -> acc
+          Name (_, (_, name, _), _) -> add name acc
+        | _ -> acc
     )
       x Type_names.empty
   in
   Type_names.elements acc
 
 let is_parametrized x =
-  fold (fun x b -> b || match x with `Tvar _ -> true | _ -> false) x false
+  fold (fun x b -> b || match x with Tvar _ -> true | _ -> false) x false

--- a/atd/src/ast.ml
+++ b/atd/src/ast.ml
@@ -27,16 +27,16 @@ and module_item =
 and type_param = string list
 
 and type_expr =
-    [ `Sum of (loc * variant list * annot)
-    | `Record of (loc * field list * annot)
-    | `Tuple of (loc * cell list * annot)
-    | `List of (loc * type_expr * annot)
-    | `Option of (loc * type_expr * annot)
-    | `Nullable of (loc * type_expr * annot)
-    | `Shared of (loc * type_expr * annot)
-    | `Wrap of (loc * type_expr * annot)
-    | `Name of (loc * type_inst * annot)
-    | `Tvar of (loc * string)
+    [ `Sum of loc * variant list * annot
+    | `Record of loc * field list * annot
+    | `Tuple of loc * cell list * annot
+    | `List of loc * type_expr * annot
+    | `Option of loc * type_expr * annot
+    | `Nullable of loc * type_expr * annot
+    | `Shared of loc * type_expr * annot
+    | `Wrap of loc * type_expr * annot
+    | `Name of loc * type_inst * annot
+    | `Tvar of loc * string
     ]
       (* `List, `Option, `Nullable, `Shared and `Wrap are
          the only predefined types with a type
@@ -51,10 +51,9 @@ and variant =
 and cell = loc * type_expr * annot
 
 and field_kind =
-    [ `Required
-    | `Optional
-    | `With_default
-    ]
+  | Required
+  | Optional
+  | With_default
 
 and field =
     [ `Field of (loc * (string * field_kind * annot) * type_expr)

--- a/atd/src/ast.ml
+++ b/atd/src/ast.ml
@@ -22,7 +22,7 @@ and annot_field = string * (loc * string option)
 and type_def = loc * (string * type_param * annot) * type_expr
 
 and module_item =
-    [ `Type of type_def ]
+  | Type of type_def
 
 and type_param = string list
 
@@ -158,8 +158,8 @@ and amap_field f = function
 and amap_cell f (loc, x, a) =
   (loc, amap_type_expr f x, f a)
 
-let amap_module_item f (`Type (loc, (name, param, a), x)) =
-  `Type (loc, (name, param, f a), amap_type_expr f x)
+let amap_module_item f (Type (loc, (name, param, a), x)) =
+  Type (loc, (name, param, f a), amap_type_expr f x)
 
 let amap_head f (loc, a) = (loc, f a)
 

--- a/atd/src/ast.ml
+++ b/atd/src/ast.ml
@@ -45,8 +45,8 @@ and type_expr =
 and type_inst = loc * string * type_expr list
 
 and variant =
-    [ `Variant of (loc * (string * annot) * type_expr option)
-    | `Inherit of (loc * type_expr) ]
+  | Variant of loc * (string * annot) * type_expr option
+  | Inherit of loc * type_expr
 
 and cell = loc * type_expr * annot
 
@@ -138,15 +138,15 @@ let rec amap_type_expr f (x : type_expr) =
         `Name (loc, (loc2, name, List.map (amap_type_expr f) args), f a)
 
 and amap_variant f = function
-    `Variant (loc, (name, a), o) ->
+    Variant (loc, (name, a), o) ->
       let o =
         match o with
-            None -> None
-          | Some x -> Some (amap_type_expr f x)
+          None -> None
+        | Some x -> Some (amap_type_expr f x)
       in
-      `Variant (loc, (name, f a), o)
-  | `Inherit (loc, x) ->
-      `Inherit (loc, amap_type_expr f x)
+      Variant (loc, (name, f a), o)
+  | Inherit (loc, x) ->
+      Inherit (loc, amap_type_expr f x)
 
 and amap_field f = function
     `Field (loc, (name, kind, a), x) ->
@@ -204,9 +204,9 @@ let rec fold (f : type_expr -> 'a -> 'a) (x : type_expr) acc =
 
 and fold_variant f x acc =
   match x with
-      `Variant (_, _, Some type_expr) -> fold f type_expr acc
-    | `Variant _ -> acc
-    | `Inherit (_, type_expr) -> fold f type_expr acc
+      Variant (_, _, Some type_expr) -> fold f type_expr acc
+    | Variant _ -> acc
+    | Inherit (_, type_expr) -> fold f type_expr acc
 
 and fold_field f x acc =
   match x with

--- a/atd/src/ast.mli
+++ b/atd/src/ast.mli
@@ -50,41 +50,40 @@ and type_param = string list
     (** List of type variables without the tick. *)
 
 and type_expr =
-    [ `Sum of (loc * variant list * annot)
-    | `Record of (loc * field list * annot)
-    | `Tuple of (loc * cell list * annot)
-    | `List of (loc * type_expr * annot)
-    | `Option of (loc * type_expr * annot)
-    | `Nullable of (loc * type_expr * annot)
-    | `Shared of (loc * type_expr * annot)
-    | `Wrap of (loc * type_expr * annot)
-    | `Name of (loc * type_inst * annot)
-    | `Tvar of (loc * string)
-    ]
+    | Sum of loc * variant list * annot
+    | Record of loc * field list * annot
+    | Tuple of loc * cell list * annot
+    | List of loc * type_expr * annot
+    | Option of loc * type_expr * annot
+    | Nullable of loc * type_expr * annot
+    | Shared of loc * type_expr * annot
+    | Wrap of loc * type_expr * annot
+    | Name of loc * type_inst * annot
+    | Tvar of loc * string
       (**
          A type expression is one of the following:
-         - [`Sum]: a sum type (within square brackets)
-         - [`Record]: a record type (within curly braces)
-         - [`Tuple]: a tuple (within parentheses)
-         - [`List]: a list type written [list] with its parameter
+         - [Sum]: a sum type (within square brackets)
+         - [Record]: a record type (within curly braces)
+         - [Tuple]: a tuple (within parentheses)
+         - [List]: a list type written [list] with its parameter
          e.g. [int list]
-         - [`Option]: an option type written [option] with its parameter
+         - [Option]: an option type written [option] with its parameter
          e.g. [string option]
-         - [`Nullable]: adds a null value to a type.
-         [`Option] should be preferred over [`Nullable] since
+         - [Nullable]: adds a null value to a type.
+         [Option] should be preferred over [Nullable] since
          it makes it possible to distinguish [Some None] from [None].
-         - [`Shared]: values for which sharing must be preserved. Such
+         - [Shared]: values for which sharing must be preserved. Such
          type expressions may not be parametrized. Values may only
          be shared if the source location of the type expression is the same.
-         - [`Wrap]: optional wrapping of a type. For example, a timestamp
+         - [Wrap]: optional wrapping of a type. For example, a timestamp
          represented as a string can be wrapped within a proper time type.
          In that case, the wrapper would parse the timestamp and convert
          it into the internal representation of its choice. Unwrapping
          would consist in converting it back to a string.
-         - [`Name]: a type name other than [list] or [option], including
+         - [Name]: a type name other than [list] or [option], including
          the predefined types [unit], [bool], [int], [float], [string]
          and [abstract].
-         - [`Tvar]: a type variable identifier without the tick
+         - [Tvar]: a type variable identifier without the tick
       *)
 
 and type_inst = loc * string * type_expr list

--- a/atd/src/ast.mli
+++ b/atd/src/ast.mli
@@ -39,7 +39,7 @@ and module_body = module_item list
     *)
 
 and module_item =
-    [ `Type of type_def ]
+  | Type of type_def
       (** There is currently only one kind of module items,
           that is single type definitions. *)
 

--- a/atd/src/ast.mli
+++ b/atd/src/ast.mli
@@ -91,15 +91,15 @@ and type_inst = loc * string * type_expr list
     (** A type name and its arguments *)
 
 and variant =
-    [ `Variant of (loc * (string * annot) * type_expr option)
-    | `Inherit of (loc * type_expr) ]
-      (**
-         A single variant or an [inherit] statement.
-         [`Inherit] statements can be expanded into variants
-         using {!Atd_inherit}
-         or at loading time using the [inherit_variant] option
-         offered by the {!Atd.Util} functions.
-      *)
+  | Variant of loc * (string * annot) * type_expr option
+  | Inherit of loc * type_expr
+  (**
+     A single variant or an [inherit] statement.
+     [Inherit] statements can be expanded into variants
+     using {!Atd_inherit}
+     or at loading time using the [inherit_variant] option
+     offered by the {!Atd.Util} functions.
+  *)
 
 and cell = loc * type_expr * annot
     (** Tuple cell. Note that annotations placed before the type

--- a/atd/src/ast.mli
+++ b/atd/src/ast.mli
@@ -108,23 +108,22 @@ and cell = loc * type_expr * annot
         [(float * float * <ocaml default="0.0"> float)]. *)
 
 and field_kind =
-    [ `Required
-    | `Optional
-    | `With_default
-    ]
-      (**
-         Different kinds of record fields based on the
-         - [`Required]: required field, e.g. [id : string]
-         - [`Optional]: optional field without a default value, e.g.
-         [?name : string option].  The ATD type of the field
-         value must be an option type.
-         - [`With_default]: optional field with a default value, e.g.
-         [~websites : string list]. The default value may be implicit
-         or specified explicitely using annotations.
-         Each target language that cannot omit fields
-         may have to specify the default in its own syntax.
+  | Required
+  | Optional
+  | With_default
+  (**
+     Different kinds of record fields based on the
+     - [Required]: required field, e.g. [id : string]
+     - [Optional]: optional field without a default value, e.g.
+     [?name : string option].  The ATD type of the field
+     value must be an option type.
+     - [With_default]: optional field with a default value, e.g.
+     [~websites : string list]. The default value may be implicit
+     or specified explicitely using annotations.
+     Each target language that cannot omit fields
+     may have to specify the default in its own syntax.
 
-         Sample ATD file:
+     Sample ATD file:
 {v
 type level = [ Beginner | Advanced | Expert ]
 

--- a/atd/src/check.ml
+++ b/atd/src/check.ml
@@ -150,7 +150,7 @@ let check (l : Ast.module_body) =
 
   (* first pass: put all definitions in the table *)
   List.iter (
-    function `Type ((loc, (k, pl, _), _) as x) ->
+    function Type ((loc, (k, pl, _), _) as x) ->
       if Hashtbl.mem tbl k then
         if Hashtbl.mem predef k then
           error_at loc
@@ -165,6 +165,6 @@ let check (l : Ast.module_body) =
   (* second pass: check existence and arity of types in type expressions,
      check that inheritance is not cyclic *)
   List.iter (
-    function `Type (_, (_, tvars, _), t) ->
+    function (Ast.Type (_, (_, tvars, _), t)) ->
       check_type_expr tbl tvars t
   ) l;

--- a/atd/src/check.ml
+++ b/atd/src/check.ml
@@ -5,12 +5,12 @@ open Printf
 open Ast
 
 let add_name accu = function
-    `Name (_, (_, k, _), _) -> k :: accu
+    Name (_, (_, k, _), _) -> k :: accu
   | _ -> accu
 
 let get_kind = function
-    `Sum _ -> `Sum
-  | `Record _ -> `Record
+    Sum _ -> `Sum
+  | Record _ -> `Record
   | _ -> `Other
 
 let check_inheritance tbl (t0 : type_expr) =
@@ -27,30 +27,30 @@ let check_inheritance tbl (t0 : type_expr) =
 
   let rec check kind inherited (t : type_expr) =
     match t with
-      `Sum (_, vl, _) when kind = `Sum ->
+      Sum (_, vl, _) when kind = `Sum ->
         List.iter (
           function
             Inherit (_, t) -> check kind inherited t
           | Variant _ -> ()
         ) vl
 
-    | `Record (_, fl, _) when kind = `Record ->
+    | Record (_, fl, _) when kind = `Record ->
         List.iter (
           function
             `Inherit (_, t) -> check kind inherited t
           | `Field _ -> ()
         ) fl
 
-    | `Sum _
-    | `Record _
-    | `Tuple _
-    | `List _
-    | `Option _
-    | `Nullable _
-    | `Shared _
-    | `Wrap _ as x -> not_a kind x
+    | Sum _
+    | Record _
+    | Tuple _
+    | List _
+    | Option _
+    | Nullable _
+    | Shared _
+    | Wrap _ as x -> not_a kind x
 
-    | `Name (_, (loc, k, _), _) ->
+    | Name (_, (loc, k, _), _) ->
         if List.mem k inherited then
           error_at (loc_of_type_expr t0) "Cyclic inheritance"
         else
@@ -63,7 +63,7 @@ let check_inheritance tbl (t0 : type_expr) =
            | Some (_, _, t) -> check kind (k :: inherited) t
           )
 
-    | `Tvar _ ->
+    | Tvar _ ->
         error_at (loc_of_type_expr t0) "Cannot inherit from a type variable"
 
   in
@@ -73,25 +73,25 @@ let check_inheritance tbl (t0 : type_expr) =
 
 let check_type_expr tbl tvars (t : type_expr) =
   let rec check : type_expr -> unit = function
-      `Sum (_, vl, _) as x ->
+      Sum (_, vl, _) as x ->
         List.iter (check_variant (Hashtbl.create 10)) vl;
         check_inheritance tbl x
 
-    | `Record (_, fl, _) as x ->
+    | Record (_, fl, _) as x ->
         List.iter (check_field (Hashtbl.create 10)) fl;
         check_inheritance tbl x
 
-    | `Tuple (_, tl, _) -> List.iter (fun (_, x, _) -> check x) tl
-    | `List (_, t, _) -> check t
-    | `Option (_, t, _) -> check t
-    | `Nullable (_, t, _) -> check t
-    | `Shared (loc, t, _) ->
+    | Tuple (_, tl, _) -> List.iter (fun (_, x, _) -> check x) tl
+    | List (_, t, _) -> check t
+    | Option (_, t, _) -> check t
+    | Nullable (_, t, _) -> check t
+    | Shared (loc, t, _) ->
         if Ast.is_parametrized t then
           error_at loc "Shared type cannot be polymorphic";
         check t
-    | `Wrap (_, t, _) -> check t
+    | Wrap (_, t, _) -> check t
 
-    | `Name (_, (loc, k, tal), _) ->
+    | Name (_, (loc, k, tal), _) ->
         assert (k <> "list" && k <> "option"
                 && k <> "nullable" && k <> "shared" && k <> "wrap");
         let (arity, _opt_def) =
@@ -108,7 +108,7 @@ let check_type_expr tbl tvars (t : type_expr) =
 
         List.iter check tal
 
-    | `Tvar (loc, s) ->
+    | Tvar (loc, s) ->
         if not (List.mem s tvars) then
           error_at loc (sprintf "Unbound type variable '%s" s)
 

--- a/atd/src/check.mli
+++ b/atd/src/check.mli
@@ -1,1 +1,1 @@
-val check : [ `Type of Ast.type_def ] list -> unit
+val check : Ast.module_body -> unit

--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -156,15 +156,15 @@ and mapvar_field f = function
   | `Inherit (loc, t) -> `Inherit (loc, mapvar_expr f t)
 
 and mapvar_variant f = function
-    `Variant (loc, k, opt_t) ->
-      `Variant (
+    Variant (loc, k, opt_t) ->
+      Variant (
         loc, k,
         (match opt_t with
-             None -> None
-           | Some t -> Some (mapvar_expr f t)
+           None -> None
+         | Some t -> Some (mapvar_expr f t)
         )
       )
-  | `Inherit (loc, t) -> `Inherit (loc, mapvar_expr f t)
+  | Inherit (loc, t) -> Inherit (loc, mapvar_expr f t)
 
 
 let var_of_int i =
@@ -439,12 +439,12 @@ let expand ?(keep_poly = false) (l : type_def list)
     | `Inherit (loc, t) -> `Inherit (loc, subst env t)
 
   and subst_variant env = function
-      `Variant (loc, k, opt_t) as x ->
+      Variant (loc, k, opt_t) as x ->
         (match opt_t with
-             None -> x
-           | Some t -> `Variant (loc, k, Some (subst env t))
+           None -> x
+         | Some t -> Variant (loc, k, Some (subst env t))
         )
-    | `Inherit (loc, t) -> `Inherit (loc, subst env t)
+    | Inherit (loc, t) -> Inherit (loc, subst env t)
 
   and subst_only_args env = function
       `List (loc, t, a)
@@ -533,12 +533,12 @@ let replace_type_names (subst : string -> string) (t : type_expr) : type_expr =
     | `Inherit (loc, t) -> `Inherit (loc, replace t)
 
   and replace_variant = function
-      `Variant (loc, k, opt_t) as x ->
+      Variant (loc, k, opt_t) as x ->
         (match opt_t with
-             None -> x
-           | Some t -> `Variant (loc, k, Some (replace t))
+           None -> x
+         | Some t -> Variant (loc, k, Some (replace t))
         )
-    | `Inherit (loc, t) -> `Inherit (loc, replace t)
+    | Inherit (loc, t) -> Inherit (loc, replace t)
   in
   replace t
 

--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -113,43 +113,43 @@ let init_table () =
 let rec mapvar_expr
     (f : string -> string) (x : Ast.type_expr) : Ast.type_expr =
   match x with
-      `Sum (loc, vl, a) ->
-        `Sum (loc, List.map (mapvar_variant f) vl, a)
-    | `Record (loc, fl, a) ->
-        `Record (loc, List.map (mapvar_field f) fl, a)
-    | `Tuple (loc, tl, a) ->
-        `Tuple (loc,
-                List.map (fun (loc, x, a) -> (loc, mapvar_expr f x, a)) tl,
-                a)
-    | `List (loc, t, a) ->
-        `List (loc, mapvar_expr f t, a)
-    | `Name (loc, (loc2, "list", [t]), a) ->
-        `Name (loc, (loc2, "list", [mapvar_expr f t]), a)
+    Sum (loc, vl, a) ->
+      Sum (loc, List.map (mapvar_variant f) vl, a)
+  | Record (loc, fl, a) ->
+      Record (loc, List.map (mapvar_field f) fl, a)
+  | Tuple (loc, tl, a) ->
+      Tuple (loc,
+             List.map (fun (loc, x, a) -> (loc, mapvar_expr f x, a)) tl,
+             a)
+  | List (loc, t, a) ->
+      List (loc, mapvar_expr f t, a)
+  | Name (loc, (loc2, "list", [t]), a) ->
+      Name (loc, (loc2, "list", [mapvar_expr f t]), a)
 
-    | `Option (loc, t, a) ->
-        `Option (loc, mapvar_expr f t, a)
-    | `Name (loc, (loc2, "option", [t]), a) ->
-        `Name (loc, (loc2, "option", [mapvar_expr f t]), a)
+  | Option (loc, t, a) ->
+      Option (loc, mapvar_expr f t, a)
+  | Name (loc, (loc2, "option", [t]), a) ->
+      Name (loc, (loc2, "option", [mapvar_expr f t]), a)
 
-    | `Nullable (loc, t, a) ->
-        `Nullable (loc, mapvar_expr f t, a)
-    | `Name (loc, (loc2, "nullable", [t]), a) ->
-        `Name (loc, (loc2, "nullable", [mapvar_expr f t]), a)
+  | Nullable (loc, t, a) ->
+      Nullable (loc, mapvar_expr f t, a)
+  | Name (loc, (loc2, "nullable", [t]), a) ->
+      Name (loc, (loc2, "nullable", [mapvar_expr f t]), a)
 
-    | `Shared (loc, t, a) ->
-        `Shared (loc, mapvar_expr f t, a)
-    | `Name (loc, (loc2, "shared", [t]), a) ->
-        `Name (loc, (loc2, "shared", [mapvar_expr f t]), a)
+  | Shared (loc, t, a) ->
+      Shared (loc, mapvar_expr f t, a)
+  | Name (loc, (loc2, "shared", [t]), a) ->
+      Name (loc, (loc2, "shared", [mapvar_expr f t]), a)
 
-    | `Wrap (loc, t, a) ->
-        `Wrap (loc, mapvar_expr f t, a)
-    | `Name (loc, (loc2, "wrap", [t]), a) ->
-        `Name (loc, (loc2, "wrap", [mapvar_expr f t]), a)
+  | Wrap (loc, t, a) ->
+      Wrap (loc, mapvar_expr f t, a)
+  | Name (loc, (loc2, "wrap", [t]), a) ->
+      Name (loc, (loc2, "wrap", [mapvar_expr f t]), a)
 
-    | `Tvar (loc, s) -> `Tvar (loc, f s)
+  | Tvar (loc, s) -> Tvar (loc, f s)
 
-    | `Name (loc, (loc2, k, args), a) ->
-        `Name (loc, (loc2, k, List.map (mapvar_expr f) args), a)
+  | Name (loc, (loc2, k, args), a) ->
+      Name (loc, (loc2, k, List.map (mapvar_expr f) args), a)
 
 and mapvar_field f = function
     `Field (loc, k, t) -> `Field (loc, k, mapvar_expr f t)
@@ -220,28 +220,28 @@ let make_type_name loc orig_name args an =
     "@(" ^ Print.string_of_type_name orig_name normalized_args an ^ ")" in
   let mapping = List.rev !mapping in
   let new_args =
-    List.map (fun (old_s, _) -> `Tvar (loc, old_s)) mapping in
+    List.map (fun (old_s, _) -> Tvar (loc, old_s)) mapping in
   let new_env =
-    List.map (fun (old_s, new_s) -> old_s, `Tvar (loc, new_s)) mapping
+    List.map (fun (old_s, new_s) -> old_s, Tvar (loc, new_s)) mapping
   in
   new_name, new_args, new_env
 
 let is_abstract (x : type_expr) =
   match x with
-      `Name (_, (_, "abstract", _), _) -> true
-    | _ -> false
+    Name (_, (_, "abstract", _), _) -> true
+  | _ -> false
 
 let expr_of_lvalue loc name param annot =
-  `Name (loc, (loc, name, List.map (fun s -> `Tvar (loc, s)) param), annot)
+  Name (loc, (loc, name, List.map (fun s -> Tvar (loc, s)) param), annot)
 
 
 let is_cyclic lname t =
   match t with
-      `Name (_, (_, rname, _), _) -> lname = rname
-    | _ -> false
+    Name (_, (_, rname, _), _) -> lname = rname
+  | _ -> false
 
 let is_tvar = function
-    `Tvar _ -> true
+    Tvar _ -> true
   | _ -> false
 
 
@@ -251,7 +251,7 @@ let add_annot (x : type_expr) a : type_expr =
 
 
 let expand ?(keep_poly = false) (l : type_def list)
-    : type_def list * original_types =
+  : type_def list * original_types =
 
   let seqnum, tbl = init_table () in
 
@@ -259,49 +259,49 @@ let expand ?(keep_poly = false) (l : type_def list)
 
   let rec subst env (t : type_expr) : type_expr =
     match t with
-        `Sum (loc, vl, a) ->
-          `Sum (loc, List.map (subst_variant env) vl, a)
-      | `Record (loc, fl, a) ->
-          `Record (loc, List.map (subst_field env) fl, a)
-      | `Tuple (loc, tl, a) ->
-          `Tuple (loc,
-                  List.map (fun (loc, x, a) -> (loc, subst env x, a)) tl, a)
+      Sum (loc, vl, a) ->
+        Sum (loc, List.map (subst_variant env) vl, a)
+    | Record (loc, fl, a) ->
+        Record (loc, List.map (subst_field env) fl, a)
+    | Tuple (loc, tl, a) ->
+        Tuple (loc,
+               List.map (fun (loc, x, a) -> (loc, subst env x, a)) tl, a)
 
-      | `List (loc as loc2, t, a)
-      | `Name (loc, (loc2, "list", [t]), a) ->
-          let t' = subst env t in
-          subst_type_name loc loc2 "list" [t'] a
+    | List (loc as loc2, t, a)
+    | Name (loc, (loc2, "list", [t]), a) ->
+        let t' = subst env t in
+        subst_type_name loc loc2 "list" [t'] a
 
-      | `Option (loc as loc2, t, a)
-      | `Name (loc, (loc2, "option", [t]), a) ->
-          let t' = subst env t in
-          subst_type_name loc loc2 "option" [t'] a
+    | Option (loc as loc2, t, a)
+    | Name (loc, (loc2, "option", [t]), a) ->
+        let t' = subst env t in
+        subst_type_name loc loc2 "option" [t'] a
 
-      | `Nullable (loc as loc2, t, a)
-      | `Name (loc, (loc2, "nullable", [t]), a) ->
-          let t' = subst env t in
-          subst_type_name loc loc2 "nullable" [t'] a
+    | Nullable (loc as loc2, t, a)
+    | Name (loc, (loc2, "nullable", [t]), a) ->
+        let t' = subst env t in
+        subst_type_name loc loc2 "nullable" [t'] a
 
-      | `Shared (loc as loc2, t, a)
-      | `Name (loc, (loc2, "shared", [t]), a) ->
-          let t' = subst env t in
-          subst_type_name loc loc2 "shared" [t'] a
+    | Shared (loc as loc2, t, a)
+    | Name (loc, (loc2, "shared", [t]), a) ->
+        let t' = subst env t in
+        subst_type_name loc loc2 "shared" [t'] a
 
-      | `Wrap (loc as loc2, t, a)
-      | `Name (loc, (loc2, "wrap", [t]), a) ->
-          let t' = subst env t in
-          subst_type_name loc loc2 "wrap" [t'] a
+    | Wrap (loc as loc2, t, a)
+    | Name (loc, (loc2, "wrap", [t]), a) ->
+        let t' = subst env t in
+        subst_type_name loc loc2 "wrap" [t'] a
 
-      | `Tvar (_, s) as x ->
-          (try List.assoc s env
-           with Not_found -> x)
+    | Tvar (_, s) as x ->
+        (try List.assoc s env
+         with Not_found -> x)
 
-      | `Name (loc, (loc2, name, args), a) ->
-          let args' = List.map (subst env) args in
-          if List.for_all is_tvar args' then
-            `Name (loc, (loc2, name, args'), a)
-          else
-            subst_type_name loc loc2 name args' a
+    | Name (loc, (loc2, name, args), a) ->
+        let args' = List.map (subst env) args in
+        if List.for_all is_tvar args' then
+          Name (loc, (loc2, name, args'), a)
+        else
+          subst_type_name loc loc2 name args' a
 
   and subst_type_name loc loc2 name args an =
     (*
@@ -332,7 +332,7 @@ let expand ?(keep_poly = false) (l : type_def list)
       The annotation has been transferred to the right-hand
       expression of the new type definition.
     *)
-    `Name (loc, (loc2, new_name, new_args), [])
+    Name (loc, (loc2, new_name, new_args), [])
 
 
   and create_type_def loc orig_name orig_args env name n_param an0 =
@@ -369,14 +369,14 @@ let expand ?(keep_poly = false) (l : type_def list)
     in
     let ((_, _, _) as td') =
       match orig_opt_td with
-          None ->
-            assert false (* Original type definitions must all exist,
-                            even for predefined types and abstract types. *)
-        | Some (_, (k, pl, def_an), t) ->
-            assert (k = orig_name);
-            let new_params = vars_of_int n_param in
-            let t = add_annot t an0 in
-            let t = set_type_expr_loc loc t in
+        None ->
+          assert false (* Original type definitions must all exist,
+                          even for predefined types and abstract types. *)
+      | Some (_, (k, pl, def_an), t) ->
+          assert (k = orig_name);
+          let new_params = vars_of_int n_param in
+          let t = add_annot t an0 in
+          let t = set_type_expr_loc loc t in
 
             (*
                First replace the type expression being specialized
@@ -385,7 +385,7 @@ let expand ?(keep_poly = false) (l : type_def list)
 
                (int, 'b) foo  -->  (int, 'a) foo
             *)
-            let args = List.map (subst env) orig_args in
+          let args = List.map (subst env) orig_args in
 
             (*
               Then expand the expression into its definition,
@@ -410,27 +410,27 @@ let expand ?(keep_poly = false) (l : type_def list)
               'y -> 'a
 
             *)
-            let env = List.map2 (fun var value -> (var, value)) pl args in
+          let env = List.map2 (fun var value -> (var, value)) pl args in
 
-            let t' =
-              if is_abstract t then
+          let t' =
+            if is_abstract t then
                 (*
                   e.g.: type 'a t = abstract
                   use 'a t and preserve "t"
                 *)
-                let t =
-                  expr_of_lvalue loc orig_name pl
-                    (Ast.annot_of_type_expr t)
-                in
+              let t =
+                expr_of_lvalue loc orig_name pl
+                  (Ast.annot_of_type_expr t)
+              in
+              subst_only_args env t
+            else
+              let t' = subst env t in
+              if is_cyclic name t' then
                 subst_only_args env t
               else
-                let t' = subst env t in
-                if is_cyclic name t' then
-                  subst_only_args env t
-                else
-                  t'
-            in
-            (loc, (name, new_params, def_an), t')
+                t'
+          in
+          (loc, (name, new_params, def_an), t')
     in
     Hashtbl.replace tbl name (i, n_param, None, Some td')
 
@@ -447,28 +447,28 @@ let expand ?(keep_poly = false) (l : type_def list)
     | Inherit (loc, t) -> Inherit (loc, subst env t)
 
   and subst_only_args env = function
-      `List (loc, t, a)
-    | `Name (loc, (_, "list", [t]), a) ->
-        `List (loc, subst env t, a)
+      List (loc, t, a)
+    | Name (loc, (_, "list", [t]), a) ->
+        List (loc, subst env t, a)
 
-    | `Option (loc, t, a)
-    | `Name (loc, (_, "option", [t]), a) ->
-        `Option (loc, subst env t, a)
+    | Option (loc, t, a)
+    | Name (loc, (_, "option", [t]), a) ->
+        Option (loc, subst env t, a)
 
-    | `Nullable (loc, t, a)
-    | `Name (loc, (_, "nullable", [t]), a) ->
-        `Nullable (loc, subst env t, a)
+    | Nullable (loc, t, a)
+    | Name (loc, (_, "nullable", [t]), a) ->
+        Nullable (loc, subst env t, a)
 
-    | `Shared (loc, t, a)
-    | `Name (loc, (_, "shared", [t]), a) ->
-        `Shared (loc, subst env t, a)
+    | Shared (loc, t, a)
+    | Name (loc, (_, "shared", [t]), a) ->
+        Shared (loc, subst env t, a)
 
-    | `Wrap (loc, t, a)
-    | `Name (loc, (_, "wrap", [t]), a) ->
-        `Wrap (loc, subst env t, a)
+    | Wrap (loc, t, a)
+    | Name (loc, (_, "wrap", [t]), a) ->
+        Wrap (loc, subst env t, a)
 
-    | `Name (loc, (loc2, name, args), an) ->
-        `Name (loc, (loc2, name, List.map (subst env) args), an)
+    | Name (loc, (loc2, name, args), an) ->
+        Name (loc, (loc2, name, List.map (subst env) args), an)
 
     | _ -> assert false
   in
@@ -501,10 +501,10 @@ let expand ?(keep_poly = false) (l : type_def list)
     Hashtbl.fold (
       fun _ (i, n, _, opt_td') l ->
         match opt_td' with
-            None -> l
-          | Some td' ->
-              if n = 0 || keep_poly then (i, td') :: l
-              else l
+          None -> l
+        | Some td' ->
+            if n = 0 || keep_poly then (i, td') :: l
+            else l
     ) tbl []
   in
   let l = List.sort (fun (i, _) (j, _) -> compare i j) l in
@@ -515,18 +515,18 @@ let expand ?(keep_poly = false) (l : type_def list)
 let replace_type_names (subst : string -> string) (t : type_expr) : type_expr =
   let rec replace (t : type_expr) : type_expr =
     match t with
-        `Sum (loc, vl, a) -> `Sum (loc, List.map replace_variant vl, a)
-      | `Record (loc, fl, a) -> `Record (loc, List.map replace_field fl, a)
-      | `Tuple (loc, tl, a) ->
-          `Tuple (loc, List.map (fun (loc, x, a) -> loc, replace x, a) tl, a)
-      | `List (loc, t, a) -> `List (loc, replace t, a)
-      | `Option (loc, t, a) -> `Option (loc, replace t, a)
-      | `Nullable (loc, t, a) -> `Nullable (loc, replace t, a)
-      | `Shared (loc, t, a) -> `Shared (loc, replace t, a)
-      | `Wrap (loc, t, a) -> `Wrap (loc, replace t, a)
-      | `Tvar (_, _) as t -> t
-      | `Name (loc, (loc2, k, l), a) ->
-          `Name (loc, (loc2, subst k, List.map replace l), a)
+      Sum (loc, vl, a) -> Sum (loc, List.map replace_variant vl, a)
+    | Record (loc, fl, a) -> Record (loc, List.map replace_field fl, a)
+    | Tuple (loc, tl, a) ->
+        Tuple (loc, List.map (fun (loc, x, a) -> loc, replace x, a) tl, a)
+    | List (loc, t, a) -> List (loc, replace t, a)
+    | Option (loc, t, a) -> Option (loc, replace t, a)
+    | Nullable (loc, t, a) -> Nullable (loc, replace t, a)
+    | Shared (loc, t, a) -> Shared (loc, replace t, a)
+    | Wrap (loc, t, a) -> Wrap (loc, replace t, a)
+    | Tvar (_, _) as t -> t
+    | Name (loc, (loc2, k, l), a) ->
+        Name (loc, (loc2, subst k, List.map replace l), a)
 
   and replace_field = function
       `Field (loc, k, t) -> `Field (loc, k, replace t)
@@ -572,11 +572,11 @@ let standardize_type_names
       let k' = new_id tbl in
       Hashtbl.add tbl k k';
       begin try
-        let orig_info = Hashtbl.find original_types k in
-        Hashtbl.remove original_types k;
-        Hashtbl.add original_types k' orig_info
-      with Not_found ->
-        assert false (* Must have been added during expand *)
+          let orig_info = Hashtbl.find original_types k in
+          Hashtbl.remove original_types k;
+          Hashtbl.add original_types k' orig_info
+        with Not_found ->
+          assert false (* Must have been added during expand *)
       end;
       k'
   in

--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -597,10 +597,10 @@ let standardize_type_names
 
 
 let expand_module_body ?(prefix = "_") ?keep_poly ?(debug = false) l =
-  let td_list = List.map (function `Type td -> td) l in
+  let td_list = List.map (function (Type td) -> td) l in
   let (td_list, original_types) = expand ?keep_poly td_list in
   let td_list =
     if debug then td_list
     else standardize_type_names ~prefix ~original_types td_list
   in
-  (List.map (fun td -> `Type td) td_list, original_types)
+  (List.map (fun td -> (Type td)) td_list, original_types)

--- a/atd/src/inherit.ml
+++ b/atd/src/inherit.ml
@@ -137,11 +137,11 @@ let expand_module_body
     ?inherit_fields
     ?inherit_variants
     (l : Ast.module_body) =
-  let td_list = List.map (function `Type td -> td) l in
+  let td_list = List.map (function (Ast.Type td) -> td) l in
   let tbl = load_defs td_list in
   let td_list =
     List.map (
       fun (loc, name, t) ->
         (loc, name, expand ?inherit_fields ?inherit_variants tbl t)
     ) td_list in
-  List.map (fun td -> `Type td) td_list
+  List.map (fun td -> Ast.Type td) td_list

--- a/atd/src/inherit.ml
+++ b/atd/src/inherit.ml
@@ -40,80 +40,80 @@ let expand ?(inherit_fields = true) ?(inherit_variants = true) tbl t0 =
 
   let rec subst deref param (t : type_expr) : type_expr =
     match t with
-        `Sum (loc, vl, a) ->
-          let vl = List.flatten (List.map (subst_variant param) vl) in
-          let vl =
-            if inherit_variants then
-              keep_last_defined get_variant_name vl
-            else
-              vl
-          in
-          `Sum (loc, vl, a)
-
-      | `Record (loc, fl, a) ->
-          let fl = List.flatten (List.map (subst_field param) fl) in
-          let fl =
-            if inherit_fields then
-              keep_last_defined get_field_name fl
-            else
-              fl
-          in
-          `Record (loc, fl, a)
-
-      | `Tuple (loc, tl, a) ->
-          `Tuple (
-            loc,
-            List.map (fun (loc, x, a) -> (loc, subst false param x, a)) tl, a
-          )
-
-      | `List (loc, t, a)
-      | `Name (loc, (_, "list", [t]), a) ->
-          `List (loc, subst false param t, a)
-
-      | `Option (loc, t, a)
-      | `Name (loc, (_, "option", [t]), a) ->
-          `Option (loc, subst false param t, a)
-
-      | `Nullable (loc, t, a)
-      | `Name (loc, (_, "nullable", [t]), a) ->
-          `Nullable (loc, subst false param t, a)
-
-      | `Shared (loc, t, a)
-      | `Name (loc, (_, "shared", [t]), a) ->
-          `Shared (loc, subst false param t, a)
-
-      | `Wrap (loc, t, a)
-      | `Name (loc, (_, "wrap", [t]), a) ->
-          `Wrap (loc, subst false param t, a)
-
-      | `Tvar (_, s) ->
-          (try List.assoc s param
-           with Not_found -> t)
-
-      | `Name (loc, (loc2, k, args), a) ->
-          let expanded_args = List.map (subst false param) args in
-          if deref then
-            let _, vars, _, t =
-              try
-                match Hashtbl.find tbl k with
-                    _, Some (_, (k, vars, a), t) -> k, vars, a, t
-                  | _, None -> failwith ("Cannot inherit from type " ^ k)
-              with Not_found ->
-                failwith ("Missing type definition for " ^ k)
-            in
-            let param = List.combine vars expanded_args in
-            subst true param t
+      Sum (loc, vl, a) ->
+        let vl = List.flatten (List.map (subst_variant param) vl) in
+        let vl =
+          if inherit_variants then
+            keep_last_defined get_variant_name vl
           else
-            `Name (loc, (loc2, k, expanded_args), a)
+            vl
+        in
+        Sum (loc, vl, a)
+
+    | Record (loc, fl, a) ->
+        let fl = List.flatten (List.map (subst_field param) fl) in
+        let fl =
+          if inherit_fields then
+            keep_last_defined get_field_name fl
+          else
+            fl
+        in
+        Record (loc, fl, a)
+
+    | Tuple (loc, tl, a) ->
+        Tuple (
+          loc,
+          List.map (fun (loc, x, a) -> (loc, subst false param x, a)) tl, a
+        )
+
+    | List (loc, t, a)
+    | Name (loc, (_, "list", [t]), a) ->
+        List (loc, subst false param t, a)
+
+    | Option (loc, t, a)
+    | Name (loc, (_, "option", [t]), a) ->
+        Option (loc, subst false param t, a)
+
+    | Nullable (loc, t, a)
+    | Name (loc, (_, "nullable", [t]), a) ->
+        Nullable (loc, subst false param t, a)
+
+    | Shared (loc, t, a)
+    | Name (loc, (_, "shared", [t]), a) ->
+        Shared (loc, subst false param t, a)
+
+    | Wrap (loc, t, a)
+    | Name (loc, (_, "wrap", [t]), a) ->
+        Wrap (loc, subst false param t, a)
+
+    | Tvar (_, s) ->
+        (try List.assoc s param
+         with Not_found -> t)
+
+    | Name (loc, (loc2, k, args), a) ->
+        let expanded_args = List.map (subst false param) args in
+        if deref then
+          let _, vars, _, t =
+            try
+              match Hashtbl.find tbl k with
+                _, Some (_, (k, vars, a), t) -> k, vars, a, t
+              | _, None -> failwith ("Cannot inherit from type " ^ k)
+            with Not_found ->
+              failwith ("Missing type definition for " ^ k)
+          in
+          let param = List.combine vars expanded_args in
+          subst true param t
+        else
+          Name (loc, (loc2, k, expanded_args), a)
 
   and subst_field param = function
       `Field (loc, k, t) -> [ `Field (loc, k, subst false param t) ]
     | `Inherit (_, t) as x ->
         (match subst true param t with
-             `Record (_, vl, _) ->
-               if inherit_fields then vl
-               else [ x ]
-           | _ -> failwith "Not a record type"
+           Record (_, vl, _) ->
+             if inherit_fields then vl
+             else [ x ]
+         | _ -> failwith "Not a record type"
         )
 
   and subst_variant param = function
@@ -124,7 +124,7 @@ let expand ?(inherit_fields = true) ?(inherit_variants = true) tbl t0 =
         )
     | Inherit (_, t) as x ->
         (match subst true param t with
-           `Sum (_, vl, _) ->
+           Sum (_, vl, _) ->
              if inherit_variants then vl
              else [ x ]
          | _ -> failwith "Not a sum type"

--- a/atd/src/inherit.ml
+++ b/atd/src/inherit.ml
@@ -32,8 +32,8 @@ let get_field_name : field -> string = function
   | `Inherit _ -> assert false
 
 let get_variant_name : variant -> string = function
-    `Variant (_, (k, _), _) -> k
-  | `Inherit _ -> assert false
+    Variant (_, (k, _), _) -> k
+  | Inherit _ -> assert false
 
 
 let expand ?(inherit_fields = true) ?(inherit_variants = true) tbl t0 =
@@ -117,17 +117,17 @@ let expand ?(inherit_fields = true) ?(inherit_variants = true) tbl t0 =
         )
 
   and subst_variant param = function
-      `Variant (loc, k, opt_t) as x ->
+      Variant (loc, k, opt_t) as x ->
         (match opt_t with
-             None -> [ x ]
-           | Some t -> [ `Variant (loc, k, Some (subst false param t)) ]
+           None -> [ x ]
+         | Some t -> [ Variant (loc, k, Some (subst false param t)) ]
         )
-    | `Inherit (_, t) as x ->
+    | Inherit (_, t) as x ->
         (match subst true param t with
-             `Sum (_, vl, _) ->
-               if inherit_variants then vl
-               else [ x ]
-           | _ -> failwith "Not a sum type"
+           `Sum (_, vl, _) ->
+             if inherit_variants then vl
+             else [ x ]
+         | _ -> failwith "Not a sum type"
         )
   in
   subst false [] t0

--- a/atd/src/parser.mly
+++ b/atd/src/parser.mly
@@ -59,7 +59,7 @@ afield:
 module_item:
 
 | TYPE p = type_param s = LIDENT a = annot EQ t = type_expr
-                               { `Type (($startpos, $endpos), (s, p, a), t) }
+                               { Type (($startpos, $endpos), (s, p, a), t) }
 
 | TYPE type_param LIDENT annot EQ _e=error
     { syntax_error "Expecting type expression" $startpos(_e) $endpos(_e) }

--- a/atd/src/parser.mly
+++ b/atd/src/parser.mly
@@ -205,7 +205,7 @@ field:
 ;
 
 field_name:
-| k = LIDENT             { (k, `Required) }
-| QUESTION k = LIDENT    { (k, `Optional) }
-| TILDE k = LIDENT       { (k, `With_default) }
+| k = LIDENT             { (k, Required) }
+| QUESTION k = LIDENT    { (k, Optional) }
+| TILDE k = LIDENT       { (k, With_default) }
 ;

--- a/atd/src/parser.mly
+++ b/atd/src/parser.mly
@@ -175,11 +175,11 @@ variant_list0:
 
 variant:
 | x = UIDENT a = annot OF t = type_expr
-     { `Variant (($startpos, $endpos), (x, a), Some t) }
+     { Variant (($startpos, $endpos), (x, a), Some t) }
 | x = UIDENT a = annot
-     { `Variant (($startpos, $endpos), (x, a), None) }
+     { Variant (($startpos, $endpos), (x, a), None) }
 | INHERIT t = type_expr
-     { `Inherit (($startpos, $endpos), t) }
+     { Inherit (($startpos, $endpos), t) }
 | UIDENT annot OF _e=error
      { syntax_error "Expecting type expression after 'of'"
          $startpos(_e) $endpos(_e) }

--- a/atd/src/parser.mly
+++ b/atd/src/parser.mly
@@ -84,20 +84,20 @@ type_var_list:
 
 type_expr:
 | OP_BRACK l = variant_list CL_BRACK a = annot
-     { `Sum (($startpos, $endpos), l, a) }
+     { Sum (($startpos, $endpos), l, a) }
 | OP_BRACK CL_BRACK a = annot
-     { `Sum (($startpos, $endpos), [], a) }
+     { Sum (($startpos, $endpos), [], a) }
 
 | OP_CURL l = field_list CL_CURL a = annot
-     { `Record (($startpos, $endpos), l, a) }
+     { Record (($startpos, $endpos), l, a) }
 | OP_CURL CL_CURL a = annot
-     { `Record (($startpos, $endpos), [], a) }
+     { Record (($startpos, $endpos), [], a) }
 
 | OP_PAREN x = annot_expr CL_PAREN a = annot
-     { `Tuple (($startpos, $endpos), [x], a) }
+     { Tuple (($startpos, $endpos), [x], a) }
 
 | OP_PAREN l = cartesian_product CL_PAREN a = annot
-     { `Tuple (($startpos, $endpos), l, a) }
+     { Tuple (($startpos, $endpos), l, a) }
 
 | x = type_inst a = annot
      { let pos1 = $startpos in
@@ -105,9 +105,9 @@ type_expr:
        let loc = (pos1, pos2) in
        let _, name, args = x in
        match name, args with
-           "list", [x] -> `List (loc, x, a)
-         | "option", [x] -> `Option (loc, x, a)
-         | "nullable", [x] -> `Nullable (loc, x, a)
+           "list", [x] -> List (loc, x, a)
+         | "option", [x] -> Option (loc, x, a)
+         | "nullable", [x] -> Nullable (loc, x, a)
          | "shared", [x] ->
              let a =
                if Annot.has_field ["share"] "id" a then
@@ -117,16 +117,16 @@ type_expr:
                  Annot.set_field loc
                    "share" "id" (Some (Annot.create_id ())) a
              in
-             `Shared (loc, x, a)
-         | "wrap", [x] -> `Wrap (loc, x, a)
+             Shared (loc, x, a)
+         | "wrap", [x] -> Wrap (loc, x, a)
 
          | ("list"|"option"|"nullable"|"shared"|"wrap"), _ ->
              syntax_error (sprintf "%s expects one argument" name) pos1 pos2
 
-         | _ -> (`Name (loc, x, a) : type_expr) }
+         | _ -> (Name (loc, x, a) : type_expr) }
 
 | x = TIDENT
-     { `Tvar (($startpos, $endpos), x) }
+     { Tvar (($startpos, $endpos), x) }
 | OP_BRACK variant_list _e=error
      { syntax_error "Expecting ']'" $startpos(_e) $endpos(_e) }
 | OP_CURL field_list _e=error

--- a/atd/src/predef.ml
+++ b/atd/src/predef.ml
@@ -9,7 +9,7 @@ let list_def : type_def =
   (
     loc,
     ("list", ["a"], []),
-    `List (loc, `Tvar (loc, "a"), [])
+    List (loc, Tvar (loc, "a"), [])
   )
 
 let option_def : type_def =
@@ -17,7 +17,7 @@ let option_def : type_def =
   (
     loc,
     ("option", ["a"], []),
-    `Option (loc, `Tvar (loc, "a"), [])
+    Option (loc, Tvar (loc, "a"), [])
   )
 
 let nullable_def : type_def =
@@ -25,7 +25,7 @@ let nullable_def : type_def =
   (
     loc,
     ("nullable", ["a"], []),
-    `Nullable (loc, `Tvar (loc, "a"), [])
+    Nullable (loc, Tvar (loc, "a"), [])
   )
 
 let shared_def : type_def =
@@ -33,7 +33,7 @@ let shared_def : type_def =
   (
     loc,
     ("shared", ["a"], []),
-    `Shared (loc, `Tvar (loc, "a"), [])
+    Shared (loc, Tvar (loc, "a"), [])
   )
 
 let wrap_def : type_def =
@@ -41,7 +41,7 @@ let wrap_def : type_def =
   (
     loc,
     ("wrap", ["a"], []),
-    `Wrap (loc, `Tvar (loc, "a"), [])
+    Wrap (loc, Tvar (loc, "a"), [])
   )
 
 

--- a/atd/src/print.ml
+++ b/atd/src/print.ml
@@ -105,27 +105,27 @@ let make_closures format_annot =
 
   let rec format_module_item (x : module_item) =
     match x with
-        `Type (_, (s, param, a), t) ->
-          let left =
-            if a = [] then
-              let l =
-                make_atom "type" ::
-                  prepend_type_param param
-                  [ make_atom (s ^ " =") ]
-              in
-              horizontal_sequence l
-            else
-              let l =
-                make_atom "type"
-                :: prepend_type_param param [ make_atom s ]
-              in
-              let x = append_annots a (horizontal_sequence l) in
-              horizontal_sequence [ x; make_atom "=" ]
-          in
-          Label (
-            (left, label),
-            format_type_expr t
-          )
+      Type (_, (s, param, a), t) ->
+        let left =
+          if a = [] then
+            let l =
+              make_atom "type" ::
+              prepend_type_param param
+                [ make_atom (s ^ " =") ]
+            in
+            horizontal_sequence l
+          else
+            let l =
+              make_atom "type"
+              :: prepend_type_param param [ make_atom s ]
+            in
+            let x = append_annots a (horizontal_sequence l) in
+            horizontal_sequence [ x; make_atom "=" ]
+        in
+        Label (
+          (left, label),
+          format_type_expr t
+        )
 
 
 

--- a/atd/src/print.ml
+++ b/atd/src/print.ml
@@ -2,36 +2,36 @@ open Easy_format
 open Ast
 
 let rlist = { list with
-                wrap_body = `Force_breaks;
-                indent_body = 0;
-                align_closing = false;
-                space_after_opening = false;
-                space_before_closing = false
+              wrap_body = `Force_breaks;
+              indent_body = 0;
+              align_closing = false;
+              space_after_opening = false;
+              space_before_closing = false
             }
 
 let plist = { list with
-                align_closing = false;
-                space_after_opening = false;
-                space_before_closing = false }
+              align_closing = false;
+              space_after_opening = false;
+              space_before_closing = false }
 
 let hlist = { list with wrap_body = `No_breaks }
 let shlist = { hlist with
-                 stick_to_label = false;
-                 space_after_opening = false;
-                 space_before_closing = false }
+               stick_to_label = false;
+               space_after_opening = false;
+               space_before_closing = false }
 let shlist0 = { shlist with space_after_separator = false }
 
 let llist = {
   list with
-    separators_stick_left = false;
-    space_before_separator = true;
-    space_after_separator = true
+  separators_stick_left = false;
+  space_before_separator = true;
+  space_after_separator = true
 }
 
 let lplist = {
   llist with
-    space_after_opening = false;
-    space_before_closing = false
+  space_after_opening = false;
+  space_before_closing = false
 }
 
 let label0 = { label with space_after_label = false }
@@ -45,29 +45,29 @@ let quote_string s = Printf.sprintf "%S" s
 
 let format_prop (k, (_, opt)) =
   match opt with
-      None -> make_atom k
-    | Some s ->
-        Label (
-          (make_atom (k ^ "="), label0),
-          (make_atom (quote_string s))
-        )
+    None -> make_atom k
+  | Some s ->
+      Label (
+        (make_atom (k ^ "="), label0),
+        (make_atom (quote_string s))
+      )
 
 let default_annot (s, (_, l)) =
   match l with
-      [] -> make_atom ("<" ^ s ^ ">")
-    | l ->
-        List (
-          ("<", "", ">", plist),
-          [
-            Label (
-              (make_atom s, label),
-              List (
-                ("", "", "", plist),
-                List.map format_prop l
-              )
+    [] -> make_atom ("<" ^ s ^ ">")
+  | l ->
+      List (
+        ("<", "", ">", plist),
+        [
+          Label (
+            (make_atom s, label),
+            List (
+              ("", "", "", plist),
+              List.map format_prop l
             )
-          ]
-        )
+          )
+        ]
+      )
 
 
 let string_of_field k = function
@@ -80,26 +80,26 @@ let make_closures format_annot =
 
   let append_annots (l : annot) x =
     match l with
-        [] -> x
-      | _ ->
-          Label (
-            (x, label),
-            List (("", "", "", plist), List.map format_annot l)
-          )
+      [] -> x
+    | _ ->
+        Label (
+          (x, label),
+          List (("", "", "", plist), List.map format_annot l)
+        )
   in
 
   let prepend_colon_annots l x =
     match l with
-        [] -> x
-      | _ ->
-          Label (
-            (Label (
-               (List (("", "", "", plist), List.map format_annot l), label0),
-               make_atom ":"
-             ),
-             label),
-            x
-          )
+      [] -> x
+    | _ ->
+        Label (
+          (Label (
+             (List (("", "", "", plist), List.map format_annot l), label0),
+             make_atom ":"
+           ),
+           label),
+          x
+        )
   in
 
   let rec format_module_item (x : module_item) =
@@ -130,71 +130,71 @@ let make_closures format_annot =
 
   and prepend_type_param l tl =
     match l with
-        [] -> tl
-      | _ ->
-          let make_var s = make_atom ("'" ^ s) in
-          let x =
-            match l with
-                [s] -> make_var s
-              | l -> List (("(", ",", ")", plist), List.map make_var l)
-          in
-          x :: tl
+      [] -> tl
+    | _ ->
+        let make_var s = make_atom ("'" ^ s) in
+        let x =
+          match l with
+            [s] -> make_var s
+          | l -> List (("(", ",", ")", plist), List.map make_var l)
+        in
+        x :: tl
 
   and prepend_type_args l tl =
     match l with
-        [] -> tl
-      | _ ->
-          let x =
-            match l with
-                [t] -> format_type_expr t
-              | l -> List (("(", ",", ")", plist), List.map format_type_expr l)
-          in
-          x :: tl
+      [] -> tl
+    | _ ->
+        let x =
+          match l with
+            [t] -> format_type_expr t
+          | l -> List (("(", ",", ")", plist), List.map format_type_expr l)
+        in
+        x :: tl
 
   and format_type_expr x =
     match x with
-        `Sum (_, l, a) ->
-          append_annots a (
-            List (
-              ("[", "|", "]", llist),
-              List.map format_variant l
-            )
+      `Sum (_, l, a) ->
+        append_annots a (
+          List (
+            ("[", "|", "]", llist),
+            List.map format_variant l
           )
-      | `Record (_, l, a) ->
-          append_annots a (
-            List (
-              ("{", ";", "}", list),
-              List.map format_field l
-            )
+        )
+    | `Record (_, l, a) ->
+        append_annots a (
+          List (
+            ("{", ";", "}", list),
+            List.map format_field l
           )
-      | `Tuple (_, l, a) ->
-          append_annots a (
-            List (
-              ("(", "*", ")", lplist),
-              List.map format_tuple_field l
-            )
+        )
+    | `Tuple (_, l, a) ->
+        append_annots a (
+          List (
+            ("(", "*", ")", lplist),
+            List.map format_tuple_field l
           )
+        )
 
-      | `List (_, t, a) ->
-          format_type_name "list" [t] a
+    | `List (_, t, a) ->
+        format_type_name "list" [t] a
 
-      | `Option (_, t, a) ->
-          format_type_name "option" [t] a
+    | `Option (_, t, a) ->
+        format_type_name "option" [t] a
 
-      | `Nullable (_, t, a) ->
-          format_type_name "nullable" [t] a
+    | `Nullable (_, t, a) ->
+        format_type_name "nullable" [t] a
 
-      | `Shared (_, t, a) ->
-          format_type_name "shared" [t] a
+    | `Shared (_, t, a) ->
+        format_type_name "shared" [t] a
 
-      | `Wrap (_, t, a) ->
-          format_type_name "wrap" [t] a
+    | `Wrap (_, t, a) ->
+        format_type_name "wrap" [t] a
 
-      | `Name (_, (_, name, args), a) ->
-          format_type_name name args a
+    | `Name (_, (_, name, args), a) ->
+        format_type_name name args a
 
-      | `Tvar (_, name) ->
-          make_atom ("'" ^ name)
+    | `Tvar (_, name) ->
+        make_atom ("'" ^ name)
 
   and format_type_name name args a =
     append_annots a (
@@ -209,32 +209,32 @@ let make_closures format_annot =
 
   and format_field x =
     match x with
-        `Field (_, (k, fk, a), t) ->
-          Label (
-            (horizontal_sequence0 [
-               append_annots a (make_atom (string_of_field k fk));
-               make_atom ":"
-             ], label),
-            format_type_expr t
-          )
-      | `Inherit (_, t) -> format_inherit t
+      `Field (_, (k, fk, a), t) ->
+        Label (
+          (horizontal_sequence0 [
+             append_annots a (make_atom (string_of_field k fk));
+             make_atom ":"
+           ], label),
+          format_type_expr t
+        )
+    | `Inherit (_, t) -> format_inherit t
 
   and format_variant x =
     match x with
-        `Variant (_, (k, a), opt) ->
-          let cons = append_annots a (make_atom k) in
-          (match opt with
-               None -> cons
-             | Some t ->
-                 Label (
-                   (cons, label),
-                   Label (
-                     (make_atom "of", label),
-                     format_type_expr t
-                   )
-                 )
-          )
-      | `Inherit (_, t) -> format_inherit t
+      Variant (_, (k, a), opt) ->
+        let cons = append_annots a (make_atom k) in
+        (match opt with
+           None -> cons
+         | Some t ->
+             Label (
+               (cons, label),
+               Label (
+                 (make_atom "of", label),
+                 format_type_expr t
+               )
+             )
+        )
+    | Inherit (_, t) -> format_inherit t
   in
 
   let format_full_module ((_, an), l) =

--- a/atd/src/print.ml
+++ b/atd/src/print.ml
@@ -70,11 +70,10 @@ let default_annot (s, (_, l)) =
         )
 
 
-let string_of_field k fk =
-  match fk with
-      `Required -> k
-    | `Optional -> "?" ^ k
-    | `With_default -> "~" ^ k
+let string_of_field k = function
+    Required -> k
+  | Optional -> "?" ^ k
+  | With_default -> "~" ^ k
 
 
 let make_closures format_annot =

--- a/atd/src/print.ml
+++ b/atd/src/print.ml
@@ -38,8 +38,8 @@ let label0 = { label with space_after_label = false }
 
 let make_atom s = Atom (s, atom)
 
-let horizontal_sequence l = List (("", "", "", shlist), l)
-let horizontal_sequence0 l = List (("", "", "", shlist0), l)
+let horizontal_sequence l = Easy_format.List (("", "", "", shlist), l)
+let horizontal_sequence0 l = Easy_format.List (("", "", "", shlist0), l)
 
 let quote_string s = Printf.sprintf "%S" s
 
@@ -153,21 +153,21 @@ let make_closures format_annot =
 
   and format_type_expr x =
     match x with
-      `Sum (_, l, a) ->
+      Sum (_, l, a) ->
         append_annots a (
           List (
             ("[", "|", "]", llist),
             List.map format_variant l
           )
         )
-    | `Record (_, l, a) ->
+    | Record (_, l, a) ->
         append_annots a (
           List (
             ("{", ";", "}", list),
             List.map format_field l
           )
         )
-    | `Tuple (_, l, a) ->
+    | Tuple (_, l, a) ->
         append_annots a (
           List (
             ("(", "*", ")", lplist),
@@ -175,25 +175,25 @@ let make_closures format_annot =
           )
         )
 
-    | `List (_, t, a) ->
+    | List (_, t, a) ->
         format_type_name "list" [t] a
 
-    | `Option (_, t, a) ->
+    | Option (_, t, a) ->
         format_type_name "option" [t] a
 
-    | `Nullable (_, t, a) ->
+    | Nullable (_, t, a) ->
         format_type_name "nullable" [t] a
 
-    | `Shared (_, t, a) ->
+    | Shared (_, t, a) ->
         format_type_name "shared" [t] a
 
-    | `Wrap (_, t, a) ->
+    | Wrap (_, t, a) ->
         format_type_name "wrap" [t] a
 
-    | `Name (_, (_, name, args), a) ->
+    | Name (_, (_, name, args), a) ->
         format_type_name name args a
 
-    | `Tvar (_, name) ->
+    | Tvar (_, name) ->
         make_atom ("'" ^ name)
 
   and format_type_name name args a =
@@ -238,7 +238,7 @@ let make_closures format_annot =
   in
 
   let format_full_module ((_, an), l) =
-    List (
+    Easy_format.List (
       ("", "", "", rlist),
       List.map format_annot an @ List.map format_module_item l
     )

--- a/atd/src/reflect.ml
+++ b/atd/src/reflect.ml
@@ -36,55 +36,55 @@ let print_annot_list buf l =
 
 let rec print_type_expr buf (x : Ast.type_expr) =
   match x with
-      `Sum (loc, variant_list, annot_list) ->
-        bprintf buf "`Sum (%a, %a, %a)"
-          print_loc loc
-          (print_list print_variant) variant_list
-          print_annot_list annot_list
-    | `Record (loc, field_list, annot_list) ->
-        bprintf buf "`Record (%a, %a, %a)"
-          print_loc loc
-          (print_list print_field) field_list
-          print_annot_list annot_list
-    | `Tuple (loc, cell_list, annot_list) ->
-        bprintf buf "`Tuple (%a, %a, %a)"
-          print_loc loc
-          (print_list print_cell) cell_list
-          print_annot_list annot_list
-    | `List (loc, type_expr, annot_list) ->
-        bprintf buf "`List (%a, %a, %a)"
-          print_loc loc
-          print_type_expr type_expr
-          print_annot_list annot_list
-    | `Option (loc, type_expr, annot_list) ->
-        bprintf buf "`Option (%a, %a, %a)"
-          print_loc loc
-          print_type_expr type_expr
-          print_annot_list annot_list
-    | `Nullable (loc, type_expr, annot_list) ->
-        bprintf buf "`Nullable (%a, %a, %a)"
-          print_loc loc
-          print_type_expr type_expr
-          print_annot_list annot_list
-    | `Shared (loc, type_expr, annot_list) ->
-        bprintf buf "`Shared (%a, %a, %a)"
-          print_loc loc
-          print_type_expr type_expr
-          print_annot_list annot_list
-    | `Wrap (loc, type_expr, annot_list) ->
-        bprintf buf "`Wrap (%a, %a, %a)"
-          print_loc loc
-          print_type_expr type_expr
-          print_annot_list annot_list
-    | `Name (loc, type_inst, annot_list) ->
-        bprintf buf "`Name (%a, %a, %a)"
-          print_loc loc
-          print_type_inst type_inst
-          print_annot_list annot_list
-    | `Tvar (loc, string) ->
-        bprintf buf "`Tvar (%a, %S)"
-          print_loc loc
-          string
+  | Sum (loc, variant_list, annot_list) ->
+      bprintf buf "`Sum (%a, %a, %a)"
+        print_loc loc
+        (print_list print_variant) variant_list
+        print_annot_list annot_list
+  | Record (loc, field_list, annot_list) ->
+      bprintf buf "`Record (%a, %a, %a)"
+        print_loc loc
+        (print_list print_field) field_list
+        print_annot_list annot_list
+  | Tuple (loc, cell_list, annot_list) ->
+      bprintf buf "`Tuple (%a, %a, %a)"
+        print_loc loc
+        (print_list print_cell) cell_list
+        print_annot_list annot_list
+  | List (loc, type_expr, annot_list) ->
+      bprintf buf "`List (%a, %a, %a)"
+        print_loc loc
+        print_type_expr type_expr
+        print_annot_list annot_list
+  | Option (loc, type_expr, annot_list) ->
+      bprintf buf "`Option (%a, %a, %a)"
+        print_loc loc
+        print_type_expr type_expr
+        print_annot_list annot_list
+  | Nullable (loc, type_expr, annot_list) ->
+      bprintf buf "`Nullable (%a, %a, %a)"
+        print_loc loc
+        print_type_expr type_expr
+        print_annot_list annot_list
+  | Shared (loc, type_expr, annot_list) ->
+      bprintf buf "`Shared (%a, %a, %a)"
+        print_loc loc
+        print_type_expr type_expr
+        print_annot_list annot_list
+  | Wrap (loc, type_expr, annot_list) ->
+      bprintf buf "`Wrap (%a, %a, %a)"
+        print_loc loc
+        print_type_expr type_expr
+        print_annot_list annot_list
+  | Name (loc, type_inst, annot_list) ->
+      bprintf buf "`Name (%a, %a, %a)"
+        print_loc loc
+        print_type_inst type_inst
+        print_annot_list annot_list
+  | Tvar (loc, string) ->
+      bprintf buf "`Tvar (%a, %S)"
+        print_loc loc
+        string
 
 and print_cell buf (loc, x, a) =
   bprintf buf "(%a, %a, %a)"

--- a/atd/src/reflect.ml
+++ b/atd/src/reflect.ml
@@ -119,9 +119,9 @@ and print_field buf x =
 and print_field_kind buf fk =
   Buffer.add_string buf
     (match fk with
-         `Required -> "`Required"
-       | `Optional -> "`Optional"
-       | `With_default -> "`With_default")
+       Required -> "`Required"
+     | Optional -> "`Optional"
+     | With_default -> "`With_default")
 
 and print_type_inst buf (loc, s, l) =
   bprintf buf "(%a, %S, %a)"

--- a/atd/src/reflect.ml
+++ b/atd/src/reflect.ml
@@ -130,7 +130,7 @@ and print_type_inst buf (loc, s, l) =
     (print_list print_type_expr) l
 
 
-let print_module_item buf (`Type (loc, (name, param, a), x)) =
+let print_module_item buf (Ast.Type (loc, (name, param, a), x)) =
   bprintf buf "`Type (%a, (%S, %a, %a), %a)"
     print_loc loc
     name (print_list print_qstring) param print_annot_list a

--- a/atd/src/reflect.ml
+++ b/atd/src/reflect.ml
@@ -94,15 +94,15 @@ and print_cell buf (loc, x, a) =
 
 and print_variant buf x =
   match x with
-      `Variant (loc, (s, a), o) ->
-        bprintf buf "`Variant (%a, (%S, %a), %a)"
-          print_loc loc
-          s print_annot_list a
-          (print_opt print_type_expr) o
-    | `Inherit (loc, x) ->
-        bprintf buf "`Inherit (%a, %a)"
-          print_loc loc
-          print_type_expr x
+    Variant (loc, (s, a), o) ->
+      bprintf buf "`Variant (%a, (%S, %a), %a)"
+        print_loc loc
+        s print_annot_list a
+        (print_opt print_type_expr) o
+  | Inherit (loc, x) ->
+      bprintf buf "`Inherit (%a, %a)"
+        print_loc loc
+        print_type_expr x
 
 and print_field buf x =
   match x with

--- a/atd/src/util.ml
+++ b/atd/src/util.ml
@@ -71,7 +71,7 @@ module Tsort = Sort.Make (
     type id = string (* type name *)
 
     let id def =
-      let `Type (_, (name, _, _), _) = def in
+      let Ast.Type (_, (name, _, _), _) = def in
       name
 
     let to_string name = name
@@ -83,7 +83,7 @@ let tsort l0 =
   let l =
     List.map (
       fun def ->
-        let `Type (_, (_, _, _), x) = def in
+        let Ast.Type (_, (_, _, _), x) = def in
         let deps = Ast.extract_type_names ~ignorable x in
         (def, deps)
     ) l0

--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -30,17 +30,16 @@ to incompatible values."
         var := Some x
 
 type mode =
-    [ `T (* -t (type defs and create_* functions) *)
-    | `B (* -b (biniou serialization) *)
-    | `J (* -j (json serialization) *)
-    | `V (* -v (validators) *)
-    | `Dep (* -dep (print all file dependencies produced by -t -b -j -v) *)
-    | `List (* -list (list all files produced by -t -b -j -v) *)
+  | T (* -t (type defs and create_* functions) *)
+  | B (* -b (biniou serialization) *)
+  | J (* -j (json serialization) *)
+  | V (* -v (validators) *)
+  | Dep (* -dep (print all file dependencies produced by -t -b -j -v) *)
+  | List (* -list (list all files produced by -t -b -j -v) *)
 
-    | `Biniou (* -biniou (deprecated) *)
-    | `Json (* -json (deprecated) *)
-    | `Validate (* -validate (deprecated) *)
-    ]
+  | Biniou (* -biniou (deprecated) *)
+  | Json (* -json (deprecated) *)
+  | Validate (* -validate (deprecated) *)
 
 let parse_ocaml_version () =
   let re = Str.regexp "^\\([0-9]+\\)\\.\\([0-9]+\\)" in
@@ -97,36 +96,36 @@ let main () =
          ppx_deriving preprocessor
     ";
     "-t", Arg.Unit (fun () ->
-                      set_once "output type" mode `T;
+                      set_once "output type" mode T;
                       set_once "no function definitions" with_fundefs false),
     "
           Produce files example_t.mli and example_t.ml
           containing OCaml type definitions derived from example.atd.";
 
-    "-b", Arg.Unit (fun () -> set_once "output type" mode `B),
+    "-b", Arg.Unit (fun () -> set_once "output type" mode B),
     "
           Produce files example_b.mli and example_b.ml
           containing OCaml serializers and deserializers for the Biniou
           data format from the specifications in example.atd.";
 
-    "-j", Arg.Unit (fun () -> set_once "output type" mode `J),
+    "-j", Arg.Unit (fun () -> set_once "output type" mode J),
     "
           Produce files example_j.mli and example_j.ml
           containing OCaml serializers and deserializers for the JSON
           data format from the specifications in example.atd.";
 
-    "-v", Arg.Unit (fun () -> set_once "output type" mode `V),
+    "-v", Arg.Unit (fun () -> set_once "output type" mode V),
     "
           Produce files example_v.mli and example_v.ml
           containing OCaml functions for creating records and
           validators from the specifications in example.atd.";
 
-    "-dep", Arg.Unit (fun () -> set_once "output type" mode `Dep),
+    "-dep", Arg.Unit (fun () -> set_once "output type" mode Dep),
     "
           Output Make-compatible dependencies for all possible
           products of atdgen -t, -b, -j and -v, and exit.";
 
-    "-list", Arg.Unit (fun () -> set_once "output type" mode `List),
+    "-list", Arg.Unit (fun () -> set_once "output type" mode List),
     "
           Output a space-separated list of all possible products of
           atdgen -t, -b, -j and -v, and exit.";
@@ -146,7 +145,7 @@ let main () =
 
     "-biniou",
     Arg.Unit (fun () ->
-                set_once "output type" mode `Biniou),
+                set_once "output type" mode Biniou),
     "
           [deprecated in favor of -t and -b]
           Produce serializers and deserializers for Biniou
@@ -154,7 +153,7 @@ let main () =
 
     "-json",
     Arg.Unit (fun () ->
-                set_once "output type" mode `Json),
+                set_once "output type" mode Json),
     "
           [deprecated in favor of -t and -j]
           Produce serializers and deserializers for JSON
@@ -234,7 +233,7 @@ let main () =
 
     "-validate",
     Arg.Unit (fun () ->
-                set_once "output type" mode `Validate),
+                set_once "output type" mode Validate),
     "
           [deprecated in favor of -t and -v]
           Produce data validators from <ocaml validator=\"x\"> annotations
@@ -309,17 +308,17 @@ Generate OCaml code offering:
   * record-creating functions supporting default fields (-v)
   * user-specified data validators (-v)
 
-Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
+Recommended usage: %s (-t|-b|-j|-v|-dep|-list|-bs) example.atd" Sys.argv.(0) in
   Arg.parse options (fun file -> files := file :: !files) msg;
 
   if (!std_json
       || !unknown_field_handler <> None
       || !constr_mismatch_handler <> None) && !mode = None then
-    set_once "output mode" mode `Json;
+    set_once "output mode" mode Json;
 
   let mode =
     match !mode with
-        None -> `Biniou
+        None -> Biniou
       | Some x -> x
   in
 
@@ -328,19 +327,19 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
         Some x -> x
       | None ->
           match mode with
-              `T | `B | `J -> false
-            | `V -> true
-            | `Biniou | `Json | `Validate -> true
-            | `Dep | `List -> true (* don't care *)
+              T | B | J -> false
+            | V -> true
+            | Biniou | Json | Validate -> true
+            | Dep | List -> true (* don't care *)
   in
 
   let force_defaults =
     match mode with
-        `J | `Json -> !j_defaults
-      | `T
-      | `B | `Biniou
-      | `V | `Validate
-      | `Dep | `List -> false (* don't care *)
+        J | Json -> !j_defaults
+      | T
+      | B | Biniou
+      | V | Validate
+      | Dep | List -> false (* don't care *)
   in
 
   let atd_file =
@@ -369,10 +368,10 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
       | Files base ->
           Some base, Ox_emit.Files
             (match mode with
-                 `T -> base ^ "_t"
-               | `B -> base ^ "_b"
-               | `J -> base ^ "_j"
-               | `V -> base ^ "_v"
+                 T -> base ^ "_t"
+               | B -> base ^ "_b"
+               | J -> base ^ "_j"
+               | V -> base ^ "_v"
                | _ -> base
             )
   in
@@ -380,7 +379,7 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
     match base_prefix with
         None ->
           (match mode with
-               `B | `J | `V -> Some "T"
+               B | J |  V -> Some "T"
              | _ -> None
           )
       | Some base ->
@@ -388,7 +387,7 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
               Some _ as x -> x
             | None ->
                 (match mode with
-                     `B | `J | `V ->
+                     B | J | V ->
                        Some (String.capitalize_ascii (Filename.basename base) ^ "_t")
                    | _ -> None
           )
@@ -399,26 +398,26 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
       | Some s -> s
   in
   match mode with
-      `Dep -> print_deps (get_base_prefix ())
-    | `List -> print_file_list (get_base_prefix ())
-    | `T | `B | `J | `V | `Biniou | `Json | `Validate ->
+      Dep -> print_deps (get_base_prefix ())
+    | List -> print_file_list (get_base_prefix ())
+    | T | B | J | V | Biniou | Json | Validate ->
 
         let opens = List.rev !opens in
         let make_ocaml_files =
           match mode with
-              `T ->
+              T ->
                 Ob_emit.make_ocaml_files
-            | `B | `Biniou ->
+            | B | Biniou ->
                 Ob_emit.make_ocaml_files
-            | `J | `Json ->
+            | J | Json ->
                 Oj_emit.make_ocaml_files
                   ~std: !std_json
                   ~unknown_field_handler: !unknown_field_handler
                   ~constr_mismatch_handler: !constr_mismatch_handler
                   ~preprocess_input: !j_preprocess_input
-            | `V | `Validate ->
+            | V | Validate ->
                 Ov_emit.make_ocaml_files
-            | _ -> assert false
+            | Dep | List -> assert false
         in
         let with_default default = function None -> default | Some x -> x in
 

--- a/atdgen/bin/jbuild
+++ b/atdgen/bin/jbuild
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (executables
- ((libraries (str atdgen_emit))
+ ((libraries (str atd atdgen_emit))
   (names (ag_main))
   (flags (:include ${ROOT}/ocamlflags.sexp))
   (public_names (atdgen))

--- a/atdgen/src/biniou.ml
+++ b/atdgen/src/biniou.ml
@@ -12,27 +12,25 @@ type biniou_list = [ `Array | `Table ]
 type biniou_field = { biniou_unwrapped : bool }
 
 type biniou_repr =
-    [
-    | `Unit
-    | `Bool
-    | `Int of biniou_int
-    | `Float of biniou_float
+  | Unit
+  | Bool
+  | Int of biniou_int
+  | Float of biniou_float
 
-    | `String
-    | `Sum
-    | `Record
-    | `Tuple
-    | `List of biniou_list
-    | `Option
-    | `Nullable
-    | `Wrap
-    | `External
+  | String
+  | Sum
+  | Record
+  | Tuple
+  | List of biniou_list
+  | Option
+  | Nullable
+  | Wrap
+  | External
 
-    | `Cell
-    | `Field of biniou_field
-    | `Variant
-    | `Def
-    ]
+  | Cell
+  | Field of biniou_field
+  | Variant
+  | Def
 
 let biniou_int_of_string s : biniou_int option =
   match s with

--- a/atdgen/src/biniou.mli
+++ b/atdgen/src/biniou.mli
@@ -8,27 +8,25 @@ type biniou_list = [ `Array | `Table ]
 type biniou_field = { biniou_unwrapped : bool }
 
 type biniou_repr =
-    [
-    | `Unit
-    | `Bool
-    | `Int of biniou_int
-    | `Float of biniou_float
+  | Unit
+  | Bool
+  | Int of biniou_int
+  | Float of biniou_float
 
-    | `String
-    | `Sum
-    | `Record
-    | `Tuple
-    | `List of biniou_list
-    | `Option
-    | `Nullable
-    | `Wrap
-    | `External
+  | String
+  | Sum
+  | Record
+  | Tuple
+  | List of biniou_list
+  | Option
+  | Nullable
+  | Wrap
+  | External
 
-    | `Cell
-    | `Field of biniou_field
-    | `Variant
-    | `Def
-    ]
+  | Cell
+  | Field of biniou_field
+  | Variant
+  | Def
 
 val get_biniou_float : Atd.Annot.t -> biniou_float
 val get_biniou_int : Atd.Annot.t -> biniou_int

--- a/atdgen/src/json.ml
+++ b/atdgen/src/json.ml
@@ -5,7 +5,7 @@
 type json_float = [ `Float of int option (* max decimal places *)
                   | `Int ]
 
-type json_list = [ `Array | `Object ]
+type json_list = Array | Object
 
 type json_variant = { json_cons : string option }
 
@@ -65,12 +65,12 @@ let get_json_float an : json_float =
 
 let json_list_of_string s : json_list option =
   match s with
-      "array" -> Some `Array
-    | "object" -> Some `Object
+      "array" -> Some Array
+    | "object" -> Some Object
     | _ -> None
 
 let get_json_list an =
-  Atd.Annot.get_field json_list_of_string `Array ["json"] "repr" an
+  Atd.Annot.get_field json_list_of_string Array ["json"] "repr" an
 
 let get_json_cons default an =
   Atd.Annot.get_field (fun s -> Some s) default ["json"] "name" an

--- a/atdgen/src/json.ml
+++ b/atdgen/src/json.ml
@@ -2,8 +2,9 @@
   Mapping from ATD to JSON
 *)
 
-type json_float = [ `Float of int option (* max decimal places *)
-                  | `Int ]
+type json_float =
+  | Float of int option (* max decimal places *)
+  | Int
 
 type json_list = Array | Object
 
@@ -60,8 +61,8 @@ let get_json_float an : json_float =
   match
     Atd.Annot.get_field json_float_of_string `Float ["json"] "repr" an
   with
-      `Float -> `Float (get_json_precision an)
-    | `Int -> `Int
+      `Float -> Float (get_json_precision an)
+    | `Int -> Int
 
 let json_list_of_string s : json_list option =
   match s with

--- a/atdgen/src/json.ml
+++ b/atdgen/src/json.ml
@@ -21,27 +21,23 @@ type json_record = {
 }
 
 type json_repr =
-    [
-    | `Unit
-    | `Bool
-    | `Int
-    | `Float of json_float
-
-    | `String
-    | `Sum
-    | `Record of json_record
-    | `Tuple
-    | `List of json_list
-    | `Option
-    | `Nullable
-    | `Wrap (* should we add support for Base64 encoding of binary data? *)
-    | `External
-
-    | `Cell
-    | `Field of json_field
-    | `Variant of json_variant
-    | `Def
-    ]
+  | Bool
+  | Cell
+  | Def
+  | External
+  | Field of json_field
+  | Float of json_float
+  | Int
+  | List of json_list
+  | Nullable
+  | Option
+  | Record of json_record
+  | String
+  | Sum
+  | Tuple
+  | Unit
+  | Variant of json_variant
+  | Wrap (* should we add support for Base64 encoding of binary data? *)
 
 let json_float_of_string s : [ `Float | `Int ] option =
   match s with

--- a/atdgen/src/json.mli
+++ b/atdgen/src/json.mli
@@ -2,7 +2,7 @@
 type json_float = [ `Float of int option (* max decimal places *)
                   | `Int ]
 
-type json_list = [ `Array | `Object ]
+type json_list = Array | Object
 
 type json_variant = { json_cons : string option }
 

--- a/atdgen/src/json.mli
+++ b/atdgen/src/json.mli
@@ -18,23 +18,23 @@ type json_record = {
 }
 
 type json_repr =
-  [ `Bool
-  | `Cell
-  | `Def
-  | `External
-  | `Field of json_field
-  | `Float of json_float
-  | `Int
-  | `List of json_list
-  | `Nullable
-  | `Option
-  | `Record of json_record
-  | `String
-  | `Sum
-  | `Tuple
-  | `Unit
-  | `Variant of json_variant
-  | `Wrap ]
+  | Bool
+  | Cell
+  | Def
+  | External
+  | Field of json_field
+  | Float of json_float
+  | Int
+  | List of json_list
+  | Nullable
+  | Option
+  | Record of json_record
+  | String
+  | Sum
+  | Tuple
+  | Unit
+  | Variant of json_variant
+  | Wrap
 
 
 val get_json_list : Atd.Annot.t -> json_list

--- a/atdgen/src/json.mli
+++ b/atdgen/src/json.mli
@@ -1,6 +1,7 @@
 
-type json_float = [ `Float of int option (* max decimal places *)
-                  | `Int ]
+type json_float =
+  | Float of int option (* max decimal places *)
+  | Int
 
 type json_list = Array | Object
 

--- a/atdgen/src/mapping.ml
+++ b/atdgen/src/mapping.ml
@@ -10,21 +10,21 @@ type loc_id = string
   Generic mapping, based on the core ATD types
 *)
 type ('a, 'b) mapping =
-    [ `Unit of (loc * 'a * 'b)
-    | `Bool of (loc * 'a * 'b)
-    | `Int of (loc * 'a * 'b)
-    | `Float of (loc * 'a * 'b)
-    | `String of (loc * 'a * 'b)
-    | `Sum of (loc * ('a, 'b) variant_mapping array * 'a * 'b)
-    | `Record of (loc * ('a, 'b) field_mapping array * 'a * 'b)
-    | `Tuple of (loc * ('a, 'b) cell_mapping array * 'a * 'b)
-    | `List of (loc * ('a, 'b) mapping * 'a * 'b)
-    | `Option of (loc * ('a, 'b) mapping * 'a * 'b)
-    | `Nullable of (loc * ('a, 'b) mapping * 'a * 'b)
-    | `Wrap of (loc * ('a, 'b) mapping * 'a * 'b)
-    | `Name of (loc * string * ('a, 'b) mapping list * 'a option * 'b option)
-    | `External of (loc * string * ('a, 'b) mapping list * 'a * 'b)
-    | `Tvar of (loc * string) ]
+  | Unit of loc * 'a * 'b
+  | Bool of loc * 'a * 'b
+  | Int of loc * 'a * 'b
+  | Float of loc * 'a * 'b
+  | String of loc * 'a * 'b
+  | Sum of loc * ('a, 'b) variant_mapping array * 'a * 'b
+  | Record of loc * ('a, 'b) field_mapping array * 'a * 'b
+  | Tuple of loc * ('a, 'b) cell_mapping array * 'a * 'b
+  | List of loc * ('a, 'b) mapping * 'a * 'b
+  | Option of loc * ('a, 'b) mapping * 'a * 'b
+  | Nullable of loc * ('a, 'b) mapping * 'a * 'b
+  | Wrap of loc * ('a, 'b) mapping * 'a * 'b
+  | Name of loc * string * ('a, 'b) mapping list * 'a option * 'b option
+  | External of loc * string * ('a, 'b) mapping list * 'a * 'b
+  | Tvar of loc * string
 
 and ('a, 'b) cell_mapping = {
   cel_loc : loc;
@@ -73,54 +73,54 @@ let is_abstract x = as_abstract x <> None
 
 let loc_of_mapping x =
   match (x : (_, _) mapping) with
-      `Unit (loc, _, _)
-    | `Bool (loc, _, _)
-    | `Int (loc, _, _)
-    | `Float (loc, _, _)
-    | `String (loc, _, _)
-    | `Sum (loc, _, _, _)
-    | `Record (loc, _, _, _)
-    | `Tuple (loc, _, _, _)
-    | `List (loc, _, _, _)
-    | `Option (loc, _, _, _)
-    | `Nullable (loc, _, _, _)
-    | `Wrap (loc, _, _, _)
-    | `Name (loc, _, _, _, _)
-    | `External (loc, _, _, _, _)
-    | `Tvar (loc, _) -> loc
+    | Unit (loc, _, _)
+    | Bool (loc, _, _)
+    | Int (loc, _, _)
+    | Float (loc, _, _)
+    | String (loc, _, _)
+    | Sum (loc, _, _, _)
+    | Record (loc, _, _, _)
+    | Tuple (loc, _, _, _)
+    | List (loc, _, _, _)
+    | Option (loc, _, _, _)
+    | Nullable (loc, _, _, _)
+    | Wrap (loc, _, _, _)
+    | Name (loc, _, _, _, _)
+    | External (loc, _, _, _, _)
+    | Tvar (loc, _) -> loc
 
 
 module Env = Map.Make (String)
 
 let rec subst env (x : (_, _) mapping) =
   match x with
-      `Unit (_, _, _)
-    | `Bool (_, _, _)
-    | `Int (_, _, _)
-    | `Float (_, _, _)
-    | `String (_, _, _) -> x
-    | `Sum (loc, ar, a, b) ->
-        `Sum (loc, Array.map (subst_variant env) ar, a, b)
-    | `Record (loc, ar, a, b) ->
-        `Record (loc, Array.map (subst_field env) ar, a, b)
-    | `Tuple (loc, ar, a, b) ->
-        `Tuple (loc, Array.map (subst_cell env) ar, a, b)
-    | `List (loc, x, a, b) ->
-        `List (loc, subst env x, a, b)
-    | `Option (loc, x, a, b) ->
-        `Option (loc, subst env x, a, b)
-    | `Nullable (loc, x, a, b) ->
-        `Nullable (loc, subst env x, a, b)
-    | `Wrap (loc, x, a, b) ->
-        `Wrap (loc, subst env x, a, b)
-    | `Name (loc, name, args, a, b) ->
-        `Name (loc, name, List.map (subst env) args, a, b)
-    | `External (loc, name, args, a, b) ->
-        `External (loc, name, List.map (subst env) args, a, b)
-    | `Tvar (_, s) ->
-        try Env.find s env
-        with Not_found ->
-          invalid_arg (sprintf "Mapping.subst_var: '%s" s)
+    Unit (_, _, _)
+  | Bool (_, _, _)
+  | Int (_, _, _)
+  | Float (_, _, _)
+  | String (_, _, _) -> x
+  | Sum (loc, ar, a, b) ->
+      Sum (loc, Array.map (subst_variant env) ar, a, b)
+  | Record (loc, ar, a, b) ->
+      Record (loc, Array.map (subst_field env) ar, a, b)
+  | Tuple (loc, ar, a, b) ->
+      Tuple (loc, Array.map (subst_cell env) ar, a, b)
+  | List (loc, x, a, b) ->
+      List (loc, subst env x, a, b)
+  | Option (loc, x, a, b) ->
+      Option (loc, subst env x, a, b)
+  | Nullable (loc, x, a, b) ->
+      Nullable (loc, subst env x, a, b)
+  | Wrap (loc, x, a, b) ->
+      Wrap (loc, subst env x, a, b)
+  | Name (loc, name, args, a, b) ->
+      Name (loc, name, List.map (subst env) args, a, b)
+  | External (loc, name, args, a, b) ->
+      External (loc, name, List.map (subst env) args, a, b)
+  | Tvar (_, s) ->
+      try Env.find s env
+      with Not_found ->
+        invalid_arg (sprintf "Mapping.subst_var: '%s" s)
 
 and subst_variant env x =
   match x.var_arg with
@@ -156,12 +156,12 @@ let rec find_name loc env visited name =
 
 and deref_expr env visited x =
   match x with
-      `Name (loc, name, args, _, _) ->
-        (try
-           let param, x = find_name loc env visited name in
-           apply param x args
-         with Not_found -> x)
-    | _ -> x
+    Name (loc, name, args, _, _) ->
+      (try
+         let param, x = find_name loc env visited name in
+         apply param x args
+       with Not_found -> x)
+  | _ -> x
 
 let flatten l = List.flatten (List.map snd l)
 
@@ -185,5 +185,5 @@ let make_deref
 *)
 let rec unwrap (deref: ('a, 'b) mapping -> ('a, 'b) mapping) x =
   match deref x with
-  | `Wrap (_, x, _, _) -> unwrap deref x
+  | Wrap (_, x, _, _) -> unwrap deref x
   | x -> x

--- a/atdgen/src/mapping.ml
+++ b/atdgen/src/mapping.ml
@@ -61,7 +61,7 @@ type ('a, 'b) def = {
 
 
 let as_abstract = function
-    `Name (_, (loc, "abstract", l), a) ->
+    Atd.Ast.Name (_, (loc, "abstract", l), a) ->
       if l <> [] then
         error loc "\"abstract\" takes no type parameters";
       Some (loc, a)

--- a/atdgen/src/mapping.mli
+++ b/atdgen/src/mapping.mli
@@ -52,12 +52,9 @@ type ('a, 'b) def = {
   def_brepr : 'b;
 }
 
-val as_abstract
-  : [> `Name of 'a * (Atd.Ast.loc * string * 'b list) * 'c ]
-  -> (loc * 'c) option
+val as_abstract : Atd.Ast.type_expr -> (loc * Atd.Ast.annot) option
 
-val is_abstract :
-  [> `Name of 'a * (Atd.Ast.loc * string * 'b list) * 'c ] -> bool
+val is_abstract : Atd.Ast.type_expr -> bool
 
 val loc_of_mapping : ('a, 'b) mapping -> loc
 

--- a/atdgen/src/mapping.mli
+++ b/atdgen/src/mapping.mli
@@ -3,21 +3,21 @@ type loc = Atd.Ast.loc
 type loc_id = string
 
 type ('a, 'b) mapping =
-    [ `Unit of loc * 'a * 'b
-    | `Bool of loc * 'a * 'b
-    | `Int of loc * 'a * 'b
-    | `Float of loc * 'a * 'b
-    | `String of loc * 'a * 'b
-    | `Sum of loc * ('a, 'b) variant_mapping array * 'a * 'b
-    | `Record of loc * ('a, 'b) field_mapping array * 'a * 'b
-    | `Tuple of loc * ('a, 'b) cell_mapping array * 'a * 'b
-    | `List of loc * ('a, 'b) mapping * 'a * 'b
-    | `Option of loc * ('a, 'b) mapping * 'a * 'b
-    | `Nullable of loc * ('a, 'b) mapping * 'a * 'b
-    | `Wrap of loc * ('a, 'b) mapping * 'a * 'b
-    | `Name of loc * string * ('a, 'b) mapping list * 'a option * 'b option
-    | `External of loc * string * ('a, 'b) mapping list * 'a * 'b
-    | `Tvar of loc * string ]
+  | Unit of loc * 'a * 'b
+  | Bool of loc * 'a * 'b
+  | Int of loc * 'a * 'b
+  | Float of loc * 'a * 'b
+  | String of loc * 'a * 'b
+  | Sum of loc * ('a, 'b) variant_mapping array * 'a * 'b
+  | Record of loc * ('a, 'b) field_mapping array * 'a * 'b
+  | Tuple of loc * ('a, 'b) cell_mapping array * 'a * 'b
+  | List of loc * ('a, 'b) mapping * 'a * 'b
+  | Option of loc * ('a, 'b) mapping * 'a * 'b
+  | Nullable of loc * ('a, 'b) mapping * 'a * 'b
+  | Wrap of loc * ('a, 'b) mapping * 'a * 'b
+  | Name of loc * string * ('a, 'b) mapping list * 'a option * 'b option
+  | External of loc * string * ('a, 'b) mapping list * 'a * 'b
+  | Tvar of loc * string
 
 and ('a, 'b) cell_mapping = {
   cel_loc : loc;

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -566,8 +566,8 @@ and make_variant_writer deref tick x : Indent.t list =
 and make_record_writer deref tagged a record_kind =
   let dot =
     match record_kind with
-        `Record -> "."
-      | `Object -> "#"
+        Record -> "."
+      | Object -> "#"
   in
   let fields = get_fields deref a in
   let write_length =
@@ -664,8 +664,8 @@ and make_table_writer deref tagged list_kind x =
   in
   let dot =
     match record_kind with
-        `Record -> "."
-      | `Object -> "#"
+        Record -> "."
+      | Object -> "#"
   in
   let let_len =
     match list_kind with
@@ -929,8 +929,8 @@ let rec make_reader
 
     | Record (loc, a, `Record o, `Record) ->
         (match o with
-             `Record -> ()
-           | `Object ->
+             Record -> ()
+           | Object ->
                error loc "Sorry, OCaml objects are not supported"
         );
         let body = make_record_reader deref ~ocaml_version type_annot a in
@@ -1221,8 +1221,8 @@ and make_table_reader deref ~ocaml_version loc list_kind x =
     match deref x with
         Record (loc, a, `Record o, `Record) ->
           (match o with
-               `Record -> ()
-             | `Object ->
+               Record -> ()
+             | Object ->
                  error loc "Sorry, OCaml objects are not supported"
           );
           get_fields deref a

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -173,34 +173,34 @@ let get_fields deref a =
     fun x ->
       let ocaml_fname, ocaml_default, optional, unwrapped =
         match x.f_arepr, x.f_brepr with
-            Ocaml.Repr.Field o, `Field b ->
-              let ocaml_default =
-                match x.f_kind with
-                    `With_default ->
-                      (match o.Ocaml.ocaml_default with
-                           None ->
-                             let d =
-                               Ocaml.get_implicit_ocaml_default
-                                 deref x.f_value in
-                             if d = None then
-                               error x.f_loc "Missing default field value"
-                             else
-                               d
-                         | Some _ as default -> default
-                      )
-                  | `Optional -> Some "None"
-                  | `Required -> None
-              in
-              let optional =
-                match x.f_kind with
-                    `Optional | `With_default -> true
-                  | `Required -> false
-              in
-              o.Ocaml.ocaml_fname,
-              ocaml_default,
-              optional,
-              b.Biniou.biniou_unwrapped
-          | _ -> assert false
+          Ocaml.Repr.Field o, `Field b ->
+            let ocaml_default =
+              match x.f_kind with
+                With_default ->
+                  (match o.Ocaml.ocaml_default with
+                     None ->
+                       let d =
+                         Ocaml.get_implicit_ocaml_default
+                           deref x.f_value in
+                       if d = None then
+                         error x.f_loc "Missing default field value"
+                       else
+                         d
+                   | Some _ as default -> default
+                  )
+              | Optional -> Some "None"
+              | Required -> None
+            in
+            let optional =
+              match x.f_kind with
+                Optional | With_default -> true
+              | Required -> false
+            in
+            o.Ocaml.ocaml_fname,
+            ocaml_default,
+            optional,
+            b.Biniou.biniou_unwrapped
+        | _ -> assert false
       in
       (x, ocaml_fname, ocaml_default, optional, unwrapped)
   )

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -1502,7 +1502,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ocaml.ocaml_of_atd ~pp_convs ~target:`Biniou ~type_aliases (head, m1) in
+    Ocaml.ocaml_of_atd ~pp_convs ~target:Biniou ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -131,9 +131,9 @@ val %s_of_string :%s
 
 let rec get_biniou_tag (x : ob_mapping) =
   match x with
-    Unit (_, `Unit, `Unit) -> "Bi_io.unit_tag"
-  | Bool (_, `Bool, `Bool) -> "Bi_io.bool_tag"
-  | Int (_, `Int _, `Int b) ->
+    Unit (_, Unit, `Unit) -> "Bi_io.unit_tag"
+  | Bool (_, Bool, `Bool) -> "Bi_io.bool_tag"
+  | Int (_, Int _, `Int b) ->
       (match b with
          `Uvint -> "Bi_io.uvint_tag"
        | `Svint -> "Bi_io.svint_tag"
@@ -142,27 +142,27 @@ let rec get_biniou_tag (x : ob_mapping) =
        | `Int32 -> "Bi_io.int32_tag"
        | `Int64 -> "Bi_io.int64_tag"
       )
-  | Float (_, `Float, `Float b) ->
+  | Float (_, Float, `Float b) ->
       (match b with
          `Float32 -> "Bi_io.float32_tag"
        | `Float64 -> "Bi_io.float64_tag"
       )
-  | String (_, `String, `String) -> "Bi_io.string_tag"
-  | Sum (_, _, `Sum _, `Sum) -> "Bi_io.variant_tag"
-  | Record (_, _, `Record _, `Record) -> "Bi_io.record_tag"
-  | Tuple (_, _, `Tuple, `Tuple) -> "Bi_io.tuple_tag"
-  | List (_, _, `List _, `List b) ->
+  | String (_, String, `String) -> "Bi_io.string_tag"
+  | Sum (_, _, Sum _, `Sum) -> "Bi_io.variant_tag"
+  | Record (_, _, Record _, `Record) -> "Bi_io.record_tag"
+  | Tuple (_, _, Tuple, `Tuple) -> "Bi_io.tuple_tag"
+  | List (_, _, List _, `List b) ->
       (match b with
          `Array -> "Bi_io.array_tag"
        | `Table -> "Bi_io.table_tag"
       )
-  | Option (_, _, `Option, `Option)
-  | Nullable (_, _, `Nullable, `Nullable) -> "Bi_io.num_variant_tag"
-  | Wrap (_, x, `Wrap _, `Wrap) -> get_biniou_tag x
+  | Option (_, _, Option, `Option)
+  | Nullable (_, _, Nullable, `Nullable) -> "Bi_io.num_variant_tag"
+  | Wrap (_, x, Wrap _, `Wrap) -> get_biniou_tag x
 
   | Name (_, s, _, None, None) -> sprintf "%s_tag" s
   | External (_, _, _,
-              `External (_, main_module, ext_name),
+              External (_, main_module, ext_name),
               `External) ->
       sprintf "%s.%s_tag" main_module ext_name
   | Tvar (_, s) -> sprintf "%s_tag" (Ox_emit.name_of_var s)
@@ -173,7 +173,7 @@ let get_fields deref a =
     fun x ->
       let ocaml_fname, ocaml_default, optional, unwrapped =
         match x.f_arepr, x.f_brepr with
-            `Field o, `Field b ->
+            Ocaml.Repr.Field o, `Field b ->
               let ocaml_default =
                 match x.f_kind with
                     `With_default ->
@@ -227,11 +227,11 @@ let rec get_writer_name
 
   let un = if tagged then "" else "untagged_" in
   match x with
-    Unit (_, `Unit, `Unit) ->
+    Unit (_, Unit, `Unit) ->
       sprintf "Bi_io.write_%sunit" un
-  | Bool (_, `Bool, `Bool) ->
+  | Bool (_, Bool, `Bool) ->
       sprintf "Bi_io.write_%sbool" un
-  | Int (loc, `Int o, `Int b) ->
+  | Int (loc, Int o, `Int b) ->
       (match o, b with
          Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
        | Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
@@ -244,12 +244,12 @@ let rec get_writer_name
            error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
-  | Float (_, `Float, `Float b) ->
+  | Float (_, Float, `Float b) ->
       (match b with
          `Float32 -> sprintf "Bi_io.write_%sfloat32" un
        | `Float64 -> sprintf "Bi_io.write_%sfloat64" un
       )
-  | String (_, `String, `String) ->
+  | String (_, String, `String) ->
       sprintf "Bi_io.write_%sstring" un
 
   | Tvar (_, s) ->
@@ -262,7 +262,7 @@ let rec get_writer_name
       else s
 
   | External (_, _, args,
-              `External (_, main_module, ext_name),
+              External (_, main_module, ext_name),
               `External) ->
       let f = main_module ^ "." ^ name_f ext_name in
       let l = List.map get_writer_names args in
@@ -331,11 +331,11 @@ let rec get_reader_name
       sprintf "Atdgen_runtime.Ob_run.get_%s_reader" s
   in
   match x with
-    Unit (_, `Unit, `Unit) -> xreader "unit"
+    Unit (_, Unit, `Unit) -> xreader "unit"
 
-  | Bool (_, `Bool, `Bool) -> xreader "bool"
+  | Bool (_, Bool, `Bool) -> xreader "bool"
 
-  | Int (loc, `Int o, `Int b) ->
+  | Int (loc, Int o, `Int b) ->
       (match o, b with
          Int, `Uvint
        | Int, `Svint
@@ -348,13 +348,13 @@ let rec get_reader_name
            error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
-  | Float (_, `Float, `Float b) ->
+  | Float (_, Float, `Float b) ->
       (match b with
          `Float32 -> xreader "float32"
        | `Float64 -> xreader "float64"
       )
 
-  | String (_, `String, `String) -> xreader "string"
+  | String (_, String, `String) -> xreader "string"
 
   | Tvar (_, s) ->
       let name = Ox_emit.name_of_var s in
@@ -370,7 +370,7 @@ let rec get_reader_name
       else s
 
   | External (_, _, args,
-              `External (_, main_module, ext_name),
+              External (_, main_module, ext_name),
               `External) ->
       let f = main_module ^ "." ^ name_f ext_name in
       let l = List.map get_reader_names args in
@@ -409,7 +409,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
   | External _
   | Tvar _ -> [ `Line (get_writer_name ~tagged x) ]
 
-  | Sum (_, a, `Sum x, `Sum) ->
+  | Sum (_, a, Sum x, `Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -438,14 +438,14 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | Record (_, a, `Record o, `Record) ->
+    | Record (_, a, Record o, `Record) ->
         let body = make_record_writer deref tagged a o in
         [
           `Annot ("fun", `Line "fun ob x ->");
           `Block body;
         ]
 
-    | Tuple (_, a, `Tuple, `Tuple) ->
+    | Tuple (_, a, Tuple, `Tuple) ->
         let main =
           let len = Array.length a in
           let a =
@@ -478,7 +478,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | List (_, x, `List o, `List b) ->
+    | List (_, x, List o, `List b) ->
         (match o, b with
              List, `Array ->
                let tag = get_biniou_tag x in
@@ -510,15 +510,15 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
                ]
         )
 
-    | Option (_, x, `Option, `Option)
-    | Nullable (_, x, `Nullable, `Nullable) ->
+    | Option (_, x, Option, `Option)
+    | Nullable (_, x, Nullable, `Nullable) ->
         [
           `Line (sprintf "Atdgen_runtime.Ob_run.write_%soption (" un);
           `Block (make_writer ~tagged:true deref x);
           `Line ")";
         ]
 
-    | Wrap (_, x, `Wrap o, `Wrap) ->
+    | Wrap (_, x, Wrap o, `Wrap) ->
         let simple_writer = make_writer ~tagged deref x in
         (match o with
             None -> simple_writer
@@ -540,7 +540,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
 and make_variant_writer deref tick x : Indent.t list =
   let o =
     match x.var_arepr, x.var_brepr with
-        `Variant o, `Variant -> o
+        Variant o, `Variant -> o
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -658,7 +658,7 @@ and make_record_writer deref tagged a record_kind =
 and make_table_writer deref tagged list_kind x =
   let a, record_kind =
     match deref x with
-        Record (_, a, `Record record_kind, `Record) -> a, record_kind
+        Record (_, a, Record record_kind, `Record) -> a, record_kind
       | _ ->
           error (loc_of_mapping x) "Not a record type"
   in
@@ -897,7 +897,7 @@ let rec make_reader
     | External _
     | Tvar _ -> [ `Line (get_reader_name ~tagged x) ]
 
-    | Sum (_, a, `Sum x, `Sum) ->
+    | Sum (_, a, Sum x, `Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -927,7 +927,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.variant_tag body
 
-    | Record (loc, a, `Record o, `Record) ->
+    | Record (loc, a, Record o, `Record) ->
         (match o with
              Record -> ()
            | Object ->
@@ -936,11 +936,11 @@ let rec make_reader
         let body = make_record_reader deref ~ocaml_version type_annot a in
         wrap_body ~tagged Bi_io.record_tag body
 
-    | Tuple (_, a, `Tuple, `Tuple) ->
+    | Tuple (_, a, Tuple, `Tuple) ->
         let body = make_tuple_reader deref ~ocaml_version a in
         wrap_body ~tagged Bi_io.tuple_tag body
 
-    | List (loc, x, `List o, `List b) ->
+    | List (loc, x, List o, `List b) ->
         (match o, b with
              List, `Array ->
                let f =
@@ -982,8 +982,8 @@ let rec make_reader
                                      Bi_io.array_tag, body2 ]
         )
 
-    | Option (_, x, `Option, `Option)
-    | Nullable (_, x, `Nullable, `Nullable) ->
+    | Option (_, x, Option, `Option)
+    | Nullable (_, x, Nullable, `Nullable) ->
         let body = [
           `Line "match Char.code (Bi_inbuf.read_char ib) with";
           `Block [
@@ -1005,7 +1005,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.num_variant_tag body
 
-    | Wrap (_, x, `Wrap o, `Wrap) ->
+    | Wrap (_, x, Wrap o, `Wrap) ->
         let simple_reader = make_reader deref ~tagged ~ocaml_version x in
         (match o with
             None -> simple_reader
@@ -1035,7 +1035,7 @@ let rec make_reader
 and make_variant_reader ~ocaml_version deref type_annot tick x : Indent.t list =
   let o =
     match x.var_arepr, x.var_brepr with
-        `Variant o, `Variant -> o
+        Variant o, `Variant -> o
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -1130,7 +1130,7 @@ and make_tuple_reader deref ~ocaml_version a =
     Array.map (
       fun x ->
         match x.cel_arepr with
-            `Cell f -> x, f.Ocaml.ocaml_default
+            Ocaml.Repr.Cell f -> x, f.Ocaml.ocaml_default
           | _ -> assert false
     ) a
   in
@@ -1219,7 +1219,7 @@ and make_table_reader deref ~ocaml_version loc list_kind x =
   in
   let fields =
     match deref x with
-        Record (loc, a, `Record o, `Record) ->
+        Record (loc, a, Record o, `Record) ->
           (match o with
                Record -> ()
              | Object ->

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -131,9 +131,9 @@ val %s_of_string :%s
 
 let rec get_biniou_tag (x : ob_mapping) =
   match x with
-    Unit (_, Unit, `Unit) -> "Bi_io.unit_tag"
-  | Bool (_, Bool, `Bool) -> "Bi_io.bool_tag"
-  | Int (_, Int _, `Int b) ->
+    Unit (_, Unit, Unit) -> "Bi_io.unit_tag"
+  | Bool (_, Bool, Bool) -> "Bi_io.bool_tag"
+  | Int (_, Int _, Int b) ->
       (match b with
          `Uvint -> "Bi_io.uvint_tag"
        | `Svint -> "Bi_io.svint_tag"
@@ -142,28 +142,28 @@ let rec get_biniou_tag (x : ob_mapping) =
        | `Int32 -> "Bi_io.int32_tag"
        | `Int64 -> "Bi_io.int64_tag"
       )
-  | Float (_, Float, `Float b) ->
+  | Float (_, Float, Float b) ->
       (match b with
          `Float32 -> "Bi_io.float32_tag"
        | `Float64 -> "Bi_io.float64_tag"
       )
-  | String (_, String, `String) -> "Bi_io.string_tag"
-  | Sum (_, _, Sum _, `Sum) -> "Bi_io.variant_tag"
-  | Record (_, _, Record _, `Record) -> "Bi_io.record_tag"
-  | Tuple (_, _, Tuple, `Tuple) -> "Bi_io.tuple_tag"
-  | List (_, _, List _, `List b) ->
+  | String (_, String, String) -> "Bi_io.string_tag"
+  | Sum (_, _, Sum _, Sum) -> "Bi_io.variant_tag"
+  | Record (_, _, Record _, Record) -> "Bi_io.record_tag"
+  | Tuple (_, _, Tuple, Tuple) -> "Bi_io.tuple_tag"
+  | List (_, _, List _, List b) ->
       (match b with
          `Array -> "Bi_io.array_tag"
        | `Table -> "Bi_io.table_tag"
       )
-  | Option (_, _, Option, `Option)
-  | Nullable (_, _, Nullable, `Nullable) -> "Bi_io.num_variant_tag"
-  | Wrap (_, x, Wrap _, `Wrap) -> get_biniou_tag x
+  | Option (_, _, Option, Option)
+  | Nullable (_, _, Nullable, Nullable) -> "Bi_io.num_variant_tag"
+  | Wrap (_, x, Wrap _, Wrap) -> get_biniou_tag x
 
   | Name (_, s, _, None, None) -> sprintf "%s_tag" s
   | External (_, _, _,
               External (_, main_module, ext_name),
-              `External) ->
+              External) ->
       sprintf "%s.%s_tag" main_module ext_name
   | Tvar (_, s) -> sprintf "%s_tag" (Ox_emit.name_of_var s)
   | _ -> assert false
@@ -173,7 +173,7 @@ let get_fields deref a =
     fun x ->
       let ocaml_fname, ocaml_default, optional, unwrapped =
         match x.f_arepr, x.f_brepr with
-          Ocaml.Repr.Field o, `Field b ->
+          Ocaml.Repr.Field o, Biniou.Field b ->
             let ocaml_default =
               match x.f_kind with
                 With_default ->
@@ -227,11 +227,11 @@ let rec get_writer_name
 
   let un = if tagged then "" else "untagged_" in
   match x with
-    Unit (_, Unit, `Unit) ->
+    Unit (_, Unit, Unit) ->
       sprintf "Bi_io.write_%sunit" un
-  | Bool (_, Bool, `Bool) ->
+  | Bool (_, Bool, Bool) ->
       sprintf "Bi_io.write_%sbool" un
-  | Int (loc, Int o, `Int b) ->
+  | Int (loc, Int o, Int b) ->
       (match o, b with
          Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
        | Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
@@ -244,12 +244,12 @@ let rec get_writer_name
            error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
-  | Float (_, Float, `Float b) ->
+  | Float (_, Float, Float b) ->
       (match b with
          `Float32 -> sprintf "Bi_io.write_%sfloat32" un
        | `Float64 -> sprintf "Bi_io.write_%sfloat64" un
       )
-  | String (_, String, `String) ->
+  | String (_, String, String) ->
       sprintf "Bi_io.write_%sstring" un
 
   | Tvar (_, s) ->
@@ -263,7 +263,7 @@ let rec get_writer_name
 
   | External (_, _, args,
               External (_, main_module, ext_name),
-              `External) ->
+              External) ->
       let f = main_module ^ "." ^ name_f ext_name in
       let l = List.map get_writer_names args in
       let s = String.concat " " (f :: l) in
@@ -331,11 +331,11 @@ let rec get_reader_name
       sprintf "Atdgen_runtime.Ob_run.get_%s_reader" s
   in
   match x with
-    Unit (_, Unit, `Unit) -> xreader "unit"
+    Unit (_, Unit, Unit) -> xreader "unit"
 
-  | Bool (_, Bool, `Bool) -> xreader "bool"
+  | Bool (_, Bool, Bool) -> xreader "bool"
 
-  | Int (loc, Int o, `Int b) ->
+  | Int (loc, Int o, Int b) ->
       (match o, b with
          Int, `Uvint
        | Int, `Svint
@@ -348,13 +348,13 @@ let rec get_reader_name
            error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
-  | Float (_, Float, `Float b) ->
+  | Float (_, Float, Float b) ->
       (match b with
          `Float32 -> xreader "float32"
        | `Float64 -> xreader "float64"
       )
 
-  | String (_, String, `String) -> xreader "string"
+  | String (_, String, String) -> xreader "string"
 
   | Tvar (_, s) ->
       let name = Ox_emit.name_of_var s in
@@ -371,7 +371,7 @@ let rec get_reader_name
 
   | External (_, _, args,
               External (_, main_module, ext_name),
-              `External) ->
+              External) ->
       let f = main_module ^ "." ^ name_f ext_name in
       let l = List.map get_reader_names args in
       let s = String.concat " " (f :: l) in
@@ -409,7 +409,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
   | External _
   | Tvar _ -> [ `Line (get_writer_name ~tagged x) ]
 
-  | Sum (_, a, Sum x, `Sum) ->
+  | Sum (_, a, Sum x, Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -438,14 +438,14 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | Record (_, a, Record o, `Record) ->
+    | Record (_, a, Record o, Record) ->
         let body = make_record_writer deref tagged a o in
         [
           `Annot ("fun", `Line "fun ob x ->");
           `Block body;
         ]
 
-    | Tuple (_, a, Tuple, `Tuple) ->
+    | Tuple (_, a, Tuple, Tuple) ->
         let main =
           let len = Array.length a in
           let a =
@@ -478,7 +478,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | List (_, x, List o, `List b) ->
+    | List (_, x, List o, List b) ->
         (match o, b with
              List, `Array ->
                let tag = get_biniou_tag x in
@@ -510,15 +510,15 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
                ]
         )
 
-    | Option (_, x, Option, `Option)
-    | Nullable (_, x, Nullable, `Nullable) ->
+    | Option (_, x, Option, Option)
+    | Nullable (_, x, Nullable, Nullable) ->
         [
           `Line (sprintf "Atdgen_runtime.Ob_run.write_%soption (" un);
           `Block (make_writer ~tagged:true deref x);
           `Line ")";
         ]
 
-    | Wrap (_, x, Wrap o, `Wrap) ->
+    | Wrap (_, x, Wrap o, Wrap) ->
         let simple_writer = make_writer ~tagged deref x in
         (match o with
             None -> simple_writer
@@ -540,7 +540,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
 and make_variant_writer deref tick x : Indent.t list =
   let o =
     match x.var_arepr, x.var_brepr with
-        Variant o, `Variant -> o
+        Variant o, Variant -> o
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -658,7 +658,7 @@ and make_record_writer deref tagged a record_kind =
 and make_table_writer deref tagged list_kind x =
   let a, record_kind =
     match deref x with
-        Record (_, a, Record record_kind, `Record) -> a, record_kind
+        Record (_, a, Record record_kind, Record) -> a, record_kind
       | _ ->
           error (loc_of_mapping x) "Not a record type"
   in
@@ -897,7 +897,7 @@ let rec make_reader
     | External _
     | Tvar _ -> [ `Line (get_reader_name ~tagged x) ]
 
-    | Sum (_, a, Sum x, `Sum) ->
+    | Sum (_, a, Sum x, Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -927,7 +927,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.variant_tag body
 
-    | Record (loc, a, Record o, `Record) ->
+    | Record (loc, a, Record o, Record) ->
         (match o with
              Record -> ()
            | Object ->
@@ -936,11 +936,11 @@ let rec make_reader
         let body = make_record_reader deref ~ocaml_version type_annot a in
         wrap_body ~tagged Bi_io.record_tag body
 
-    | Tuple (_, a, Tuple, `Tuple) ->
+    | Tuple (_, a, Tuple, Tuple) ->
         let body = make_tuple_reader deref ~ocaml_version a in
         wrap_body ~tagged Bi_io.tuple_tag body
 
-    | List (loc, x, List o, `List b) ->
+    | List (loc, x, List o, List b) ->
         (match o, b with
              List, `Array ->
                let f =
@@ -982,8 +982,8 @@ let rec make_reader
                                      Bi_io.array_tag, body2 ]
         )
 
-    | Option (_, x, Option, `Option)
-    | Nullable (_, x, Nullable, `Nullable) ->
+    | Option (_, x, Option, Option)
+    | Nullable (_, x, Nullable, Nullable) ->
         let body = [
           `Line "match Char.code (Bi_inbuf.read_char ib) with";
           `Block [
@@ -1005,7 +1005,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.num_variant_tag body
 
-    | Wrap (_, x, Wrap o, `Wrap) ->
+    | Wrap (_, x, Wrap o, Wrap) ->
         let simple_reader = make_reader deref ~tagged ~ocaml_version x in
         (match o with
             None -> simple_reader
@@ -1035,7 +1035,7 @@ let rec make_reader
 and make_variant_reader ~ocaml_version deref type_annot tick x : Indent.t list =
   let o =
     match x.var_arepr, x.var_brepr with
-        Variant o, `Variant -> o
+        Variant o, Variant -> o
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -1219,7 +1219,7 @@ and make_table_reader deref ~ocaml_version loc list_kind x =
   in
   let fields =
     match deref x with
-        Record (loc, a, Record o, `Record) ->
+        Record (loc, a, Record o, Record) ->
           (match o with
                Record -> ()
              | Object ->

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -131,42 +131,42 @@ val %s_of_string :%s
 
 let rec get_biniou_tag (x : ob_mapping) =
   match x with
-      `Unit (_, `Unit, `Unit) -> "Bi_io.unit_tag"
-    | `Bool (_, `Bool, `Bool) -> "Bi_io.bool_tag"
-    | `Int (_, `Int _, `Int b) ->
-        (match b with
-             `Uvint -> "Bi_io.uvint_tag"
-           | `Svint -> "Bi_io.svint_tag"
-           | `Int8 -> "Bi_io.int8_tag"
-           | `Int16 -> "Bi_io.int16_tag"
-           | `Int32 -> "Bi_io.int32_tag"
-           | `Int64 -> "Bi_io.int64_tag"
-        )
-    | `Float (_, `Float, `Float b) ->
-        (match b with
-            `Float32 -> "Bi_io.float32_tag"
-          | `Float64 -> "Bi_io.float64_tag"
-        )
-    | `String (_, `String, `String) -> "Bi_io.string_tag"
-    | `Sum (_, _, `Sum _, `Sum) -> "Bi_io.variant_tag"
-    | `Record (_, _, `Record _, `Record) -> "Bi_io.record_tag"
-    | `Tuple (_, _, `Tuple, `Tuple) -> "Bi_io.tuple_tag"
-    | `List (_, _, `List _, `List b) ->
-        (match b with
-             `Array -> "Bi_io.array_tag"
-           | `Table -> "Bi_io.table_tag"
-        )
-    | `Option (_, _, `Option, `Option)
-    | `Nullable (_, _, `Nullable, `Nullable) -> "Bi_io.num_variant_tag"
-    | `Wrap (_, x, `Wrap _, `Wrap) -> get_biniou_tag x
+    Unit (_, `Unit, `Unit) -> "Bi_io.unit_tag"
+  | Bool (_, `Bool, `Bool) -> "Bi_io.bool_tag"
+  | Int (_, `Int _, `Int b) ->
+      (match b with
+         `Uvint -> "Bi_io.uvint_tag"
+       | `Svint -> "Bi_io.svint_tag"
+       | `Int8 -> "Bi_io.int8_tag"
+       | `Int16 -> "Bi_io.int16_tag"
+       | `Int32 -> "Bi_io.int32_tag"
+       | `Int64 -> "Bi_io.int64_tag"
+      )
+  | Float (_, `Float, `Float b) ->
+      (match b with
+         `Float32 -> "Bi_io.float32_tag"
+       | `Float64 -> "Bi_io.float64_tag"
+      )
+  | String (_, `String, `String) -> "Bi_io.string_tag"
+  | Sum (_, _, `Sum _, `Sum) -> "Bi_io.variant_tag"
+  | Record (_, _, `Record _, `Record) -> "Bi_io.record_tag"
+  | Tuple (_, _, `Tuple, `Tuple) -> "Bi_io.tuple_tag"
+  | List (_, _, `List _, `List b) ->
+      (match b with
+         `Array -> "Bi_io.array_tag"
+       | `Table -> "Bi_io.table_tag"
+      )
+  | Option (_, _, `Option, `Option)
+  | Nullable (_, _, `Nullable, `Nullable) -> "Bi_io.num_variant_tag"
+  | Wrap (_, x, `Wrap _, `Wrap) -> get_biniou_tag x
 
-    | `Name (_, s, _, None, None) -> sprintf "%s_tag" s
-    | `External (_, _, _,
-                 `External (_, main_module, ext_name),
-                 `External) ->
-        sprintf "%s.%s_tag" main_module ext_name
-    | `Tvar (_, s) -> sprintf "%s_tag" (Ox_emit.name_of_var s)
-    | _ -> assert false
+  | Name (_, s, _, None, None) -> sprintf "%s_tag" s
+  | External (_, _, _,
+              `External (_, main_module, ext_name),
+              `External) ->
+      sprintf "%s.%s_tag" main_module ext_name
+  | Tvar (_, s) -> sprintf "%s_tag" (Ox_emit.name_of_var s)
+  | _ -> assert false
 
 let get_fields deref a =
   List.map (
@@ -217,60 +217,60 @@ let rec get_writer_name
 
   let name_f =
     match name_f with
-        Some f -> f
-      | None ->
-          if tagged then
-            (fun s -> "write_" ^ s)
-          else
-            (fun s -> "write_untagged_" ^ s)
+      Some f -> f
+    | None ->
+        if tagged then
+          (fun s -> "write_" ^ s)
+        else
+          (fun s -> "write_untagged_" ^ s)
   in
 
   let un = if tagged then "" else "untagged_" in
   match x with
-      `Unit (_, `Unit, `Unit) ->
-        sprintf "Bi_io.write_%sunit" un
-    | `Bool (_, `Bool, `Bool) ->
-        sprintf "Bi_io.write_%sbool" un
-    | `Int (loc, `Int o, `Int b) ->
-        (match o, b with
-             Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
-           | Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
-           | Char, `Int8 -> sprintf "Bi_io.write_%schar" un
-           | Int, `Int8 -> sprintf "Bi_io.write_%sint8" un
-           | Int, `Int16 -> sprintf "Bi_io.write_%sint16" un
-           | Int32, `Int32 -> sprintf "Bi_io.write_%sint32" un
-           | Int64, `Int64 -> sprintf "Bi_io.write_%sint64" un
-           | _ ->
-               error loc "Unsupported combination of OCaml/Biniou int types"
-        )
+    Unit (_, `Unit, `Unit) ->
+      sprintf "Bi_io.write_%sunit" un
+  | Bool (_, `Bool, `Bool) ->
+      sprintf "Bi_io.write_%sbool" un
+  | Int (loc, `Int o, `Int b) ->
+      (match o, b with
+         Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
+       | Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
+       | Char, `Int8 -> sprintf "Bi_io.write_%schar" un
+       | Int, `Int8 -> sprintf "Bi_io.write_%sint8" un
+       | Int, `Int16 -> sprintf "Bi_io.write_%sint16" un
+       | Int32, `Int32 -> sprintf "Bi_io.write_%sint32" un
+       | Int64, `Int64 -> sprintf "Bi_io.write_%sint64" un
+       | _ ->
+           error loc "Unsupported combination of OCaml/Biniou int types"
+      )
 
-    | `Float (_, `Float, `Float b) ->
-        (match b with
-            `Float32 -> sprintf "Bi_io.write_%sfloat32" un
-          | `Float64 -> sprintf "Bi_io.write_%sfloat64" un
-        )
-    | `String (_, `String, `String) ->
-        sprintf "Bi_io.write_%sstring" un
+  | Float (_, `Float, `Float b) ->
+      (match b with
+         `Float32 -> sprintf "Bi_io.write_%sfloat32" un
+       | `Float64 -> sprintf "Bi_io.write_%sfloat64" un
+      )
+  | String (_, `String, `String) ->
+      sprintf "Bi_io.write_%sstring" un
 
-    | `Tvar (_, s) ->
-        sprintf "write_%s%s" un (Ox_emit.name_of_var s)
+  | Tvar (_, s) ->
+      sprintf "write_%s%s" un (Ox_emit.name_of_var s)
 
-    | `Name (_, s, args, None, None) ->
-        let l = List.map get_writer_names args in
-        let s = String.concat " " (name_f s :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | Name (_, s, args, None, None) ->
+      let l = List.map get_writer_names args in
+      let s = String.concat " " (name_f s :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | `External (_, _, args,
-                 `External (_, main_module, ext_name),
-                 `External) ->
-        let f = main_module ^ "." ^ name_f ext_name in
-        let l = List.map get_writer_names args in
-        let s = String.concat " " (f :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | External (_, _, args,
+              `External (_, main_module, ext_name),
+              `External) ->
+      let f = main_module ^ "." ^ name_f ext_name in
+      let l = List.map get_writer_names args in
+      let s = String.concat " " (f :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | _ -> assert false
+  | _ -> assert false
 
 and get_writer_names x =
   let tag = get_biniou_tag x in
@@ -280,15 +280,15 @@ and get_writer_names x =
 
 
 let get_left_writer_name ~tagged name param =
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
   get_writer_name ~tagged
-    (`Name (dummy_loc, name, args, None, None))
+    (Name (dummy_loc, name, args, None, None))
 
 let get_left_to_string_name name param =
   let name_f s = "string_of_" ^ s in
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
   get_writer_name ~tagged:true ~name_f
-    (`Name (dummy_loc, name, args, None, None))
+    (Name (dummy_loc, name, args, None, None))
 
 (*
 let make_writer_name tagged loc name args =
@@ -316,12 +316,12 @@ let rec get_reader_name
 
   let name_f =
     match name_f with
-        Some f -> f
-      | None ->
-          if tagged then
-            (fun s -> "read_" ^ s)
-          else
-            (fun s -> sprintf "get_%s_reader" s)
+      Some f -> f
+    | None ->
+        if tagged then
+          (fun s -> "read_" ^ s)
+        else
+          (fun s -> sprintf "get_%s_reader" s)
   in
 
   let xreader s =
@@ -331,54 +331,54 @@ let rec get_reader_name
       sprintf "Atdgen_runtime.Ob_run.get_%s_reader" s
   in
   match x with
-      `Unit (_, `Unit, `Unit) -> xreader "unit"
+    Unit (_, `Unit, `Unit) -> xreader "unit"
 
-    | `Bool (_, `Bool, `Bool) -> xreader "bool"
+  | Bool (_, `Bool, `Bool) -> xreader "bool"
 
-    | `Int (loc, `Int o, `Int b) ->
-        (match o, b with
-             Int, `Uvint
-           | Int, `Svint
-           | Int, `Int8
-           | Int, `Int16 -> xreader "int"
-           | Char, `Int8 -> xreader "char"
-           | Int32, `Int32 -> xreader "int32"
-           | Int64, `Int64 -> xreader "int64"
-           | _ ->
-               error loc "Unsupported combination of OCaml/Biniou int types"
-        )
+  | Int (loc, `Int o, `Int b) ->
+      (match o, b with
+         Int, `Uvint
+       | Int, `Svint
+       | Int, `Int8
+       | Int, `Int16 -> xreader "int"
+       | Char, `Int8 -> xreader "char"
+       | Int32, `Int32 -> xreader "int32"
+       | Int64, `Int64 -> xreader "int64"
+       | _ ->
+           error loc "Unsupported combination of OCaml/Biniou int types"
+      )
 
-    | `Float (_, `Float, `Float b) ->
-        (match b with
-            `Float32 -> xreader "float32"
-          | `Float64 -> xreader "float64"
-        )
+  | Float (_, `Float, `Float b) ->
+      (match b with
+         `Float32 -> xreader "float32"
+       | `Float64 -> xreader "float64"
+      )
 
-    | `String (_, `String, `String) -> xreader "string"
+  | String (_, `String, `String) -> xreader "string"
 
-    | `Tvar (_, s) ->
-        let name = Ox_emit.name_of_var s in
-        if tagged then
-          sprintf "read_%s" name
-        else
-          sprintf "get_%s_reader" name
+  | Tvar (_, s) ->
+      let name = Ox_emit.name_of_var s in
+      if tagged then
+        sprintf "read_%s" name
+      else
+        sprintf "get_%s_reader" name
 
-    | `Name (_, s, args, None, None) ->
-        let l = List.map get_reader_names args in
-        let s = String.concat " " (name_f s :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | Name (_, s, args, None, None) ->
+      let l = List.map get_reader_names args in
+      let s = String.concat " " (name_f s :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | `External (_, _, args,
-                 `External (_, main_module, ext_name),
-                 `External) ->
-        let f = main_module ^ "." ^ name_f ext_name in
-        let l = List.map get_reader_names args in
-        let s = String.concat " " (f :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | External (_, _, args,
+              `External (_, main_module, ext_name),
+              `External) ->
+      let f = main_module ^ "." ^ name_f ext_name in
+      let l = List.map get_reader_names args in
+      let s = String.concat " " (f :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | _ -> assert false
+  | _ -> assert false
 
 and get_reader_names x =
   let get_reader = get_reader_name ~paren:true ~tagged:false x in
@@ -387,29 +387,29 @@ and get_reader_names x =
 
 
 let get_left_reader_name ~tagged name param =
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
-  get_reader_name ~tagged (`Name (dummy_loc, name, args, None, None))
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
+  get_reader_name ~tagged (Name (dummy_loc, name, args, None, None))
 
 let get_left_of_string_name name param =
   let name_f s = s ^ "_of_string" in
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
   get_reader_name ~name_f ~tagged:true
-    (`Name (dummy_loc, name, args, None, None))
+    (Name (dummy_loc, name, args, None, None))
 
 
 let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
   let un = if tagged then "" else "untagged_" in
   match x with
-      `Unit _
-    | `Bool _
-    | `Int _
-    | `Float _
-    | `String _
-    | `Name _
-    | `External _
-    | `Tvar _ -> [ `Line (get_writer_name ~tagged x) ]
+    Unit _
+  | Bool _
+  | Int _
+  | Float _
+  | String _
+  | Name _
+  | External _
+  | Tvar _ -> [ `Line (get_writer_name ~tagged x) ]
 
-    | `Sum (_, a, `Sum x, `Sum) ->
+  | Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -438,14 +438,14 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | `Record (_, a, `Record o, `Record) ->
+    | Record (_, a, `Record o, `Record) ->
         let body = make_record_writer deref tagged a o in
         [
           `Annot ("fun", `Line "fun ob x ->");
           `Block body;
         ]
 
-    | `Tuple (_, a, `Tuple, `Tuple) ->
+    | Tuple (_, a, `Tuple, `Tuple) ->
         let main =
           let len = Array.length a in
           let a =
@@ -478,7 +478,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
           `Block body;
         ]
 
-    | `List (_, x, `List o, `List b) ->
+    | List (_, x, `List o, `List b) ->
         (match o, b with
              List, `Array ->
                let tag = get_biniou_tag x in
@@ -510,15 +510,15 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
                ]
         )
 
-    | `Option (_, x, `Option, `Option)
-    | `Nullable (_, x, `Nullable, `Nullable) ->
+    | Option (_, x, `Option, `Option)
+    | Nullable (_, x, `Nullable, `Nullable) ->
         [
           `Line (sprintf "Atdgen_runtime.Ob_run.write_%soption (" un);
           `Block (make_writer ~tagged:true deref x);
           `Line ")";
         ]
 
-    | `Wrap (_, x, `Wrap o, `Wrap) ->
+    | Wrap (_, x, `Wrap o, `Wrap) ->
         let simple_writer = make_writer ~tagged deref x in
         (match o with
             None -> simple_writer
@@ -658,7 +658,7 @@ and make_record_writer deref tagged a record_kind =
 and make_table_writer deref tagged list_kind x =
   let a, record_kind =
     match deref x with
-        `Record (_, a, `Record record_kind, `Record) -> a, record_kind
+        Record (_, a, `Record record_kind, `Record) -> a, record_kind
       | _ ->
           error (loc_of_mapping x) "Not a record type"
   in
@@ -888,16 +888,16 @@ let rec make_reader
     deref ~tagged ~ocaml_version ?type_annot (x : ob_mapping)
     : Indent.t list =
   match x with
-      `Unit _
-    | `Bool _
-    | `Int _
-    | `Float _
-    | `String _
-    | `Name _
-    | `External _
-    | `Tvar _ -> [ `Line (get_reader_name ~tagged x) ]
+      Unit _
+    | Bool _
+    | Int _
+    | Float _
+    | String _
+    | Name _
+    | External _
+    | Tvar _ -> [ `Line (get_reader_name ~tagged x) ]
 
-    | `Sum (_, a, `Sum x, `Sum) ->
+    | Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -927,7 +927,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.variant_tag body
 
-    | `Record (loc, a, `Record o, `Record) ->
+    | Record (loc, a, `Record o, `Record) ->
         (match o with
              `Record -> ()
            | `Object ->
@@ -936,11 +936,11 @@ let rec make_reader
         let body = make_record_reader deref ~ocaml_version type_annot a in
         wrap_body ~tagged Bi_io.record_tag body
 
-    | `Tuple (_, a, `Tuple, `Tuple) ->
+    | Tuple (_, a, `Tuple, `Tuple) ->
         let body = make_tuple_reader deref ~ocaml_version a in
         wrap_body ~tagged Bi_io.tuple_tag body
 
-    | `List (loc, x, `List o, `List b) ->
+    | List (loc, x, `List o, `List b) ->
         (match o, b with
              List, `Array ->
                let f =
@@ -982,8 +982,8 @@ let rec make_reader
                                      Bi_io.array_tag, body2 ]
         )
 
-    | `Option (_, x, `Option, `Option)
-    | `Nullable (_, x, `Nullable, `Nullable) ->
+    | Option (_, x, `Option, `Option)
+    | Nullable (_, x, `Nullable, `Nullable) ->
         let body = [
           `Line "match Char.code (Bi_inbuf.read_char ib) with";
           `Block [
@@ -1005,7 +1005,7 @@ let rec make_reader
         in
         wrap_body ~tagged Bi_io.num_variant_tag body
 
-    | `Wrap (_, x, `Wrap o, `Wrap) ->
+    | Wrap (_, x, `Wrap o, `Wrap) ->
         let simple_reader = make_reader deref ~tagged ~ocaml_version x in
         (match o with
             None -> simple_reader
@@ -1219,7 +1219,7 @@ and make_table_reader deref ~ocaml_version loc list_kind x =
   in
   let fields =
     match deref x with
-        `Record (loc, a, `Record o, `Record) ->
+        Record (loc, a, `Record o, `Record) ->
           (match o with
                `Record -> ()
              | `Object ->

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -233,13 +233,13 @@ let rec get_writer_name
         sprintf "Bi_io.write_%sbool" un
     | `Int (loc, `Int o, `Int b) ->
         (match o, b with
-             `Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
-           | `Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
-           | `Char, `Int8 -> sprintf "Bi_io.write_%schar" un
-           | `Int, `Int8 -> sprintf "Bi_io.write_%sint8" un
-           | `Int, `Int16 -> sprintf "Bi_io.write_%sint16" un
-           | `Int32, `Int32 -> sprintf "Bi_io.write_%sint32" un
-           | `Int64, `Int64 -> sprintf "Bi_io.write_%sint64" un
+             Int, `Uvint -> sprintf "Bi_io.write_%suvint" un
+           | Int, `Svint -> sprintf "Bi_io.write_%ssvint" un
+           | Char, `Int8 -> sprintf "Bi_io.write_%schar" un
+           | Int, `Int8 -> sprintf "Bi_io.write_%sint8" un
+           | Int, `Int16 -> sprintf "Bi_io.write_%sint16" un
+           | Int32, `Int32 -> sprintf "Bi_io.write_%sint32" un
+           | Int64, `Int64 -> sprintf "Bi_io.write_%sint64" un
            | _ ->
                error loc "Unsupported combination of OCaml/Biniou int types"
         )
@@ -337,13 +337,13 @@ let rec get_reader_name
 
     | `Int (loc, `Int o, `Int b) ->
         (match o, b with
-             `Int, `Uvint
-           | `Int, `Svint
-           | `Int, `Int8
-           | `Int, `Int16 -> xreader "int"
-           | `Char, `Int8 -> xreader "char"
-           | `Int32, `Int32 -> xreader "int32"
-           | `Int64, `Int64 -> xreader "int64"
+             Int, `Uvint
+           | Int, `Svint
+           | Int, `Int8
+           | Int, `Int16 -> xreader "int"
+           | Char, `Int8 -> xreader "char"
+           | Int32, `Int32 -> xreader "int32"
+           | Int64, `Int64 -> xreader "int64"
            | _ ->
                error loc "Unsupported combination of OCaml/Biniou int types"
         )

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -412,8 +412,8 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
     | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
-              `Classic -> ""
-            | `Poly -> "`"
+              Classic -> ""
+            | Poly -> "`"
         in
         let match_ =
           [
@@ -900,8 +900,8 @@ let rec make_reader
     | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
-              `Classic -> ""
-            | `Poly -> "`"
+              Classic -> ""
+            | Poly -> "`"
         in
         let body =
           [

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -480,7 +480,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
 
     | `List (_, x, `List o, `List b) ->
         (match o, b with
-             `List, `Array ->
+             List, `Array ->
                let tag = get_biniou_tag x in
                [
                  `Line (sprintf "Atdgen_runtime.Ob_run.write_%slist" un);
@@ -491,7 +491,7 @@ let rec make_writer ~tagged deref (x : ob_mapping) : Indent.t list =
                    `Line ")";
                  ]
                ]
-           | `Array, `Array ->
+           | Array, `Array ->
                let tag = get_biniou_tag x in
                [
                  `Line (sprintf "Atdgen_runtime.Ob_run.write_%sarray" un);
@@ -669,13 +669,13 @@ and make_table_writer deref tagged list_kind x =
   in
   let let_len =
     match list_kind with
-        `List -> `Line "let len = List.length x in"
-      | `Array -> `Line "let len = Array.length x in"
+        List -> `Line "let len = List.length x in"
+      | Array -> `Line "let len = Array.length x in"
   in
   let iter2 =
     match list_kind with
-        `List -> "Atdgen_runtime.Ob_run.list_iter2"
-      | `Array -> "Atdgen_runtime.Ob_run.array_iter2"
+        List -> "Atdgen_runtime.Ob_run.list_iter2"
+      | Array -> "Atdgen_runtime.Ob_run.array_iter2"
   in
   let l = Array.to_list a in
   let write_header =
@@ -942,7 +942,7 @@ let rec make_reader
 
     | `List (loc, x, `List o, `List b) ->
         (match o, b with
-             `List, `Array ->
+             List, `Array ->
                let f =
                  if tagged then "Atdgen_runtime.Ob_run.read_list"
                  else "Atdgen_runtime.Ob_run.get_list_reader"
@@ -952,7 +952,7 @@ let rec make_reader
                  `Block (make_reader deref ~ocaml_version ~tagged:false x);
                  `Line ")";
                ]
-           | `Array, `Array ->
+           | Array, `Array ->
                let f =
                  if tagged then "Atdgen_runtime.Ob_run.read_array"
                  else "Atdgen_runtime.Ob_run.get_array_reader"
@@ -969,8 +969,8 @@ let rec make_reader
                let body2 =
                  let f =
                    match list_kind with
-                       `List -> "Atdgen_runtime.Ob_run.read_list_value"
-                     | `Array -> "Atdgen_runtime.Ob_run.read_array_value"
+                       List -> "Atdgen_runtime.Ob_run.read_list_value"
+                     | Array -> "Atdgen_runtime.Ob_run.read_array_value"
                  in
                  [
                    `Line (f ^ " (");
@@ -1214,8 +1214,8 @@ and make_tuple_reader deref ~ocaml_version a =
 and make_table_reader deref ~ocaml_version loc list_kind x =
   let empty_list, to_list =
     match list_kind with
-        `List -> "[ ]", (fun s -> "Array.to_list " ^ s)
-      | `Array -> "[| |]", (fun s -> s)
+        List -> "[ ]", (fun s -> "Array.to_list " ^ s)
+      | Array -> "[| |]", (fun s -> s)
   in
   let fields =
     match deref x with

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -3,7 +3,7 @@ open Error
 open Mapping
 
 type ob_mapping =
-    (Ocaml.atd_ocaml_repr, Biniou.biniou_repr) Mapping.mapping
+    (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.mapping
 
 (*
   Translation of the types into the ocaml/biniou mapping.

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -126,14 +126,14 @@ and mapping_of_field ocaml_field_prefix = function
       let fvalue = mapping_of_expr x in
       let ocaml_default, biniou_unwrapped =
         match fk, Ocaml.get_ocaml_default an with
-            `Required, None -> None, false
-          | `Optional, None -> Some "None", true
-          | (`Required | `Optional), Some _ ->
-              error loc "Superfluous default OCaml value"
-          | `With_default, Some s -> Some s, false
-          | `With_default, None ->
-              (* will try to determine implicit default value later *)
-              None, false
+          Required, None -> None, false
+        | Optional, None -> Some "None", true
+        | (Required | Optional), Some _ ->
+            error loc "Superfluous default OCaml value"
+        | With_default, Some s -> Some s, false
+        | With_default, None ->
+            (* will try to determine implicit default value later *)
+            None, false
       in
       let ocaml_fname = Ocaml.get_ocaml_fname (ocaml_field_prefix ^ s) an in
       let ocaml_mutable = Ocaml.get_ocaml_mutable an in

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -3,7 +3,7 @@ open Error
 open Mapping
 
 type ob_mapping =
-    (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.mapping
+  (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.mapping
 
 (*
   Translation of the types into the ocaml/biniou mapping.
@@ -11,51 +11,51 @@ type ob_mapping =
 
 let rec mapping_of_expr (x : type_expr) : ob_mapping =
   match x with
-    `Sum (loc, l, an) ->
+    Sum (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
       let biniou_t = `Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, biniou_t)
 
-  | `Record (loc, l, an) ->
+  | Record (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
       let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
       let biniou_t = `Record in
       Record (loc,
-               Array.of_list
-                 (List.map (mapping_of_field ocaml_field_prefix) l),
-               ocaml_t, biniou_t)
+              Array.of_list
+                (List.map (mapping_of_field ocaml_field_prefix) l),
+              ocaml_t, biniou_t)
 
-  | `Tuple (loc, l, _) ->
+  | Tuple (loc, l, _) ->
       let ocaml_t = Ocaml.Repr.Tuple in
       let biniou_t = `Tuple in
       Tuple (loc, Array.of_list (List.map mapping_of_cell l),
-              ocaml_t, biniou_t)
+             ocaml_t, biniou_t)
 
-  | `List (loc, x, an) ->
+  | List (loc, x, an) ->
       let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
       let biniou_t = `List (Biniou.get_biniou_list an) in
       List (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-  | `Option (loc, x, _) ->
+  | Option (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Option in
       let biniou_t = `Option in
       Option (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-  | `Nullable (loc, x, _) ->
+  | Nullable (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Nullable in
       let biniou_t = `Nullable in
       Nullable (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
-  | `Shared (_, _, _) ->
+  | Shared (_, _, _) ->
       failwith "Sharing is no longer supported"
 
-  | `Wrap (loc, x, a) ->
+  | Wrap (loc, x, a) ->
       let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc a) in
       let json_t = `Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
-  | `Name (loc, (_, s, l), an) ->
+  | Name (loc, (_, s, l), an) ->
       (match s with
          "unit" ->
            Unit (loc, Unit, `Unit)
@@ -73,7 +73,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
        | s ->
            Name (loc, s, List.map mapping_of_expr l, None, None)
       )
-  | `Tvar (loc, s) ->
+  | Tvar (loc, s) ->
       Tvar (loc, s)
 
 and mapping_of_cell (loc, x, an) =

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -13,14 +13,14 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
   match x with
     Sum (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
-      let biniou_t = `Sum in
+      let biniou_t = Biniou.Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, biniou_t)
 
   | Record (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
       let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
-      let biniou_t = `Record in
+      let biniou_t = Biniou.Record in
       Record (loc,
               Array.of_list
                 (List.map (mapping_of_field ocaml_field_prefix) l),
@@ -28,23 +28,23 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
 
   | Tuple (loc, l, _) ->
       let ocaml_t = Ocaml.Repr.Tuple in
-      let biniou_t = `Tuple in
+      let biniou_t = Biniou.Tuple in
       Tuple (loc, Array.of_list (List.map mapping_of_cell l),
              ocaml_t, biniou_t)
 
   | List (loc, x, an) ->
       let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
-      let biniou_t = `List (Biniou.get_biniou_list an) in
+      let biniou_t = Biniou.List (Biniou.get_biniou_list an) in
       List (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
   | Option (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Option in
-      let biniou_t = `Option in
+      let biniou_t = Biniou.Option in
       Option (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
   | Nullable (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Nullable in
-      let biniou_t = `Nullable in
+      let biniou_t = Biniou.Nullable in
       Nullable (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
   | Shared (_, _, _) ->
@@ -52,24 +52,24 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
 
   | Wrap (loc, x, a) ->
       let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc a) in
-      let json_t = `Wrap in
+      let json_t = Biniou.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | Name (loc, (_, s, l), an) ->
       (match s with
          "unit" ->
-           Unit (loc, Unit, `Unit)
+           Unit (loc, Unit, Biniou.Unit)
        | "bool" ->
-           Bool (loc, Bool, `Bool)
+           Bool (loc, Bool, Biniou.Bool)
        | "int" ->
            let o = Ocaml.get_ocaml_int an in
            let b = Biniou.get_biniou_int an in
-           Int (loc, Int o, `Int b)
+           Int (loc, Int o, Biniou.Int b)
        | "float" ->
            let b = Biniou.get_biniou_float an in
-           Float (loc, Float, `Float b)
+           Float (loc, Float, Biniou.Float b)
        | "string" ->
-           String (loc, String, `String)
+           String (loc, String, Biniou.String)
        | s ->
            Name (loc, s, List.map mapping_of_expr l, None, None)
       )
@@ -87,7 +87,7 @@ and mapping_of_cell (loc, x, an) =
       ocaml_fdoc = doc;
     }
   in
-  let biniou_t = `Cell in
+  let biniou_t = Biniou.Cell in
   {
     cel_loc = loc;
     cel_value = mapping_of_expr x;
@@ -106,7 +106,7 @@ and mapping_of_variant = function
           ocaml_vdoc = doc;
         }
       in
-      let biniou_t = `Variant in
+      let biniou_t = Biniou.Variant in
       let arg =
         match o with
           None -> None
@@ -150,7 +150,7 @@ and mapping_of_field ocaml_field_prefix = function
           ocaml_fdoc = doc;
         };
 
-        f_brepr = `Field { Biniou.biniou_unwrapped = biniou_unwrapped };
+        f_brepr = Biniou.Field { Biniou.biniou_unwrapped = biniou_unwrapped };
       }
 
   | `Inherit _ -> assert false
@@ -169,7 +169,7 @@ let def_of_atd (loc, (name, param, an), x) =
              Some (External
                      (loc, name, args,
                       Ocaml.Repr.External (types_module, main_module, ext_name),
-                      `External)
+                      Biniou.External)
                   )
         )
     | None -> Some (mapping_of_expr x)
@@ -182,7 +182,7 @@ let def_of_atd (loc, (name, param, an), x) =
     def_arepr =
       Ocaml.Repr.Def { Ocaml.ocaml_predef = ocaml_predef;
                        ocaml_ddoc = doc; };
-    def_brepr = `Def;
+    def_brepr = Biniou.Def;
   }
 
 let defs_of_atd_module l =

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -186,7 +186,7 @@ let def_of_atd (loc, (name, param, an), x) =
   }
 
 let defs_of_atd_module l =
-  List.map (function `Type def -> def_of_atd def) l
+  List.map (function Atd.Ast.Type def -> def_of_atd def) l
 
 let defs_of_atd_modules l =
   List.map (fun (is_rec, l) -> (is_rec, defs_of_atd_module l)) l

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -97,7 +97,7 @@ and mapping_of_cell (loc, x, an) =
 
 
 and mapping_of_variant = function
-    `Variant (loc, (s, an), o) ->
+    Variant (loc, (s, an), o) ->
       let ocaml_cons = Ocaml.get_ocaml_cons s an in
       let doc = Doc.get_doc loc an in
       let ocaml_t =
@@ -109,8 +109,8 @@ and mapping_of_variant = function
       let biniou_t = `Variant in
       let arg =
         match o with
-            None -> None
-          | Some x -> Some (mapping_of_expr x) in
+          None -> None
+        | Some x -> Some (mapping_of_expr x) in
       {
         var_loc = loc;
         var_cons = s;
@@ -119,7 +119,7 @@ and mapping_of_variant = function
         var_brepr = biniou_t
       }
 
-  | `Inherit _ -> assert false
+  | Inherit _ -> assert false
 
 and mapping_of_field ocaml_field_prefix = function
     `Field (loc, (s, fk, an), x) ->

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -156,34 +156,9 @@ and mapping_of_field ocaml_field_prefix = function
   | `Inherit _ -> assert false
 
 
-let def_of_atd (loc, (name, param, an), x) =
-  let ocaml_predef = Ocaml.get_ocaml_predef Biniou an in
-  let doc = Doc.get_doc loc an in
-  let o =
-    match as_abstract x with
-      Some (_, _) ->
-        (match Ocaml.get_ocaml_module_and_t Biniou name an with
-           None -> None
-         | Some (types_module, main_module, ext_name) ->
-             let args = List.map (fun s -> Tvar (loc, s)) param in
-             Some (External
-                     (loc, name, args,
-                      Ocaml.Repr.External (types_module, main_module, ext_name),
-                      Biniou.External)
-                  )
-        )
-    | None -> Some (mapping_of_expr x)
-  in
-  {
-    def_loc = loc;
-    def_name = name;
-    def_param = param;
-    def_value = o;
-    def_arepr =
-      Ocaml.Repr.Def { Ocaml.ocaml_predef = ocaml_predef;
-                       ocaml_ddoc = doc; };
-    def_brepr = Biniou.Def;
-  }
+let def_of_atd atd =
+  Ox_emit.def_of_atd atd ~target:Biniou ~external_:Biniou.External
+    ~mapping_of_expr ~def:Biniou.Def
 
 let defs_of_atd_module l =
   List.map (function Atd.Ast.Type def -> def_of_atd def) l

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -157,12 +157,12 @@ and mapping_of_field ocaml_field_prefix = function
 
 
 let def_of_atd (loc, (name, param, an), x) =
-  let ocaml_predef = Ocaml.get_ocaml_predef `Biniou an in
+  let ocaml_predef = Ocaml.get_ocaml_predef Biniou an in
   let doc = Doc.get_doc loc an in
   let o =
     match as_abstract x with
         Some (_, _) ->
-          (match Ocaml.get_ocaml_module_and_t `Biniou name an with
+          (match Ocaml.get_ocaml_module_and_t Biniou name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->
                  let args = List.map (fun s -> `Tvar (loc, s)) param in

--- a/atdgen/src/ob_mapping.mli
+++ b/atdgen/src/ob_mapping.mli
@@ -3,7 +3,7 @@
     Please don't rely on them in any way.*)
 
 type ob_mapping =
-    (Ocaml.atd_ocaml_repr, Biniou.biniou_repr) Mapping.mapping
+    (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.mapping
 
 
 val defs_of_atd_modules :
@@ -12,5 +12,5 @@ val defs_of_atd_modules :
         Atd.Ast.loc * (string * string list * Atd.Annot.t) * Atd.Ast.type_expr ]
      list)
     list ->
-  ('a * (Ocaml.atd_ocaml_repr, Biniou.biniou_repr) Mapping.def list)
+  ('a * (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.def list)
     list

--- a/atdgen/src/ob_mapping.mli
+++ b/atdgen/src/ob_mapping.mli
@@ -6,11 +6,6 @@ type ob_mapping =
     (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.mapping
 
 
-val defs_of_atd_modules :
-  ('a *
-   [< `Type of
-        Atd.Ast.loc * (string * string list * Atd.Annot.t) * Atd.Ast.type_expr ]
-     list)
-    list ->
-  ('a * (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.def list)
-    list
+val defs_of_atd_modules
+  : ('a * Atd.Ast.module_body) list
+  -> ('a * (Ocaml.Repr.t, Biniou.biniou_repr) Mapping.def list) list

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -813,20 +813,20 @@ let map_record_creator_field deref x =
   let fname = o.ocaml_fname in
   let impl2 = sprintf "\n    %s = %s;" fname fname in
   match x.f_kind with
-      `Required ->
+      Required ->
         let t = ocaml_of_expr (ocaml_of_expr_mapping x.f_value) in
         let intf = sprintf "\n  %s: %s ->" fname t in
         let impl1 = sprintf "\n  ~%s" fname in
         intf, impl1, impl2
 
-    | `Optional ->
+    | Optional ->
         let x = unwrap_option deref x.f_value in
         let t = ocaml_of_expr (ocaml_of_expr_mapping x) in
         let intf = sprintf "\n  ?%s: %s ->" fname t in
         let impl1 = sprintf "\n  ?%s" fname in
         intf, impl1, impl2
 
-    | `With_default ->
+    | With_default ->
         let t = ocaml_of_expr (ocaml_of_expr_mapping x.f_value) in
         let intf = sprintf "\n  ?%s: %s ->" fname t in
         let impl1 =

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -396,33 +396,33 @@ let map_module ~target ~type_aliases (l : module_body) : ocaml_module_body =
 
 let rec ocaml_of_expr_mapping (x : (atd_ocaml_repr, _) mapping) : ocaml_expr =
   match x with
-      `Unit (_, `Unit, _) -> `Name ("unit", [])
-    | `Bool (_, `Bool, _) -> `Name ("bool", [])
-    | `Int (_, `Int x, _) -> `Name (string_of_ocaml_int x, [])
-    | `Float (_, `Float, _) -> `Name ("float", [])
-    | `String (_, `String, _) -> `Name ("string", [])
-    | `Sum (_, a, `Sum kind, _) ->
-        let l = Array.to_list a in
-        `Sum (kind, List.map ocaml_of_variant_mapping l)
-    | `Record (_, a, `Record _, _) ->
-        let l = Array.to_list a in
-        `Record (`Record, List.map ocaml_of_field_mapping l)
-    | `Tuple (_, a, _, _) ->
-        let l = Array.to_list a in
-        `Tuple (List.map (fun x -> ocaml_of_expr_mapping x.cel_value) l)
-    | `List (_, x, `List kind, _) ->
-        `Name (string_of_ocaml_list kind, [ocaml_of_expr_mapping x])
-    | `Option (_, x, `Option, _) ->
-        `Name ("option", [ocaml_of_expr_mapping x])
-    | `Nullable (_, x, `Nullable, _) ->
-        `Name ("option", [ocaml_of_expr_mapping x])
-    | `Wrap _ ->
-        assert false
-    | `Name (_, s, l, _, _) ->
-        `Name (s, List.map ocaml_of_expr_mapping l)
-    | `Tvar (_, s) ->
-        `Tvar s
-    | _ -> assert false
+    Unit (_, `Unit, _) -> `Name ("unit", [])
+  | Bool (_, `Bool, _) -> `Name ("bool", [])
+  | Int (_, `Int x, _) -> `Name (string_of_ocaml_int x, [])
+  | Float (_, `Float, _) -> `Name ("float", [])
+  | String (_, `String, _) -> `Name ("string", [])
+  | Sum (_, a, `Sum kind, _) ->
+      let l = Array.to_list a in
+      `Sum (kind, List.map ocaml_of_variant_mapping l)
+  | Record (_, a, `Record _, _) ->
+      let l = Array.to_list a in
+      `Record (`Record, List.map ocaml_of_field_mapping l)
+  | Tuple (_, a, _, _) ->
+      let l = Array.to_list a in
+      `Tuple (List.map (fun x -> ocaml_of_expr_mapping x.cel_value) l)
+  | List (_, x, `List kind, _) ->
+      `Name (string_of_ocaml_list kind, [ocaml_of_expr_mapping x])
+  | Option (_, x, `Option, _) ->
+      `Name ("option", [ocaml_of_expr_mapping x])
+  | Nullable (_, x, `Nullable, _) ->
+      `Name ("option", [ocaml_of_expr_mapping x])
+  | Wrap _ ->
+      assert false
+  | Name (_, s, l, _, _) ->
+      `Name (s, List.map ocaml_of_expr_mapping l)
+  | Tvar (_, s) ->
+      `Tvar s
+  | _ -> assert false
 
 and ocaml_of_variant_mapping x =
   let o =
@@ -775,33 +775,33 @@ let ocaml_of_atd ?(pp_convs=Ppx []) ~target ~type_aliases
 
 let unwrap_option deref x =
   match deref x with
-      `Option (_, x, _, _)
-    | `Nullable (_, x, _, _) -> x
-    | `Name (loc, s, _, _, _) ->
-        Error.error loc ("Not an option type: " ^ s)
-    | x ->
-        Error.error (loc_of_mapping x) "Not an option type"
+    Option (_, x, _, _)
+  | Nullable (_, x, _, _) -> x
+  | Name (loc, s, _, _, _) ->
+      Error.error loc ("Not an option type: " ^ s)
+  | x ->
+      Error.error (loc_of_mapping x) "Not an option type"
 
 
 
 let get_implicit_ocaml_default deref x =
   match deref x with
-      `Unit (_, `Unit, _) -> Some "()"
-    | `Bool (_, `Bool, _) -> Some "false"
-    | `Int (_, `Int o, _) ->
-        Some (match o with
-                  Int -> "0"
-                | Char -> "'\000'"
-                | Int32 -> "0l"
-                | Int64 -> "0L"
-                | Float -> "0.")
-    | `Float (_, `Float, _) -> Some "0.0"
-    | `String (_, `String, _) -> Some "\"\""
-    | `List (_, _, `List List, _) -> Some "[]"
-    | `List (_, _, `List Array, _) -> Some "[||]"
-    | `Option (_, _, `Option, _) -> Some "None"
-    | `Nullable (_, _, `Nullable, _) -> Some "None"
-    | _ -> None
+    Unit (_, `Unit, _) -> Some "()"
+  | Bool (_, `Bool, _) -> Some "false"
+  | Int (_, `Int o, _) ->
+      Some (match o with
+          Int -> "0"
+        | Char -> "'\000'"
+        | Int32 -> "0l"
+        | Int64 -> "0L"
+        | Float -> "0.")
+  | Float (_, `Float, _) -> Some "0.0"
+  | String (_, `String, _) -> Some "\"\""
+  | List (_, _, `List List, _) -> Some "[]"
+  | List (_, _, `List Array, _) -> Some "[||]"
+  | Option (_, _, `Option, _) -> Some "None"
+  | Nullable (_, _, `Nullable, _) -> Some "None"
+  | _ -> None
 
 
 let map_record_creator_field deref x =

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -20,7 +20,7 @@ type pp_convs =
 type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 
-type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
+type atd_ocaml_int = Int | Char | Int32 | Int64 | Float
 type atd_ocaml_list = List | Array
 
 type atd_ocaml_wrap = {
@@ -79,20 +79,20 @@ type target = [ `Default | `Biniou | `Json | `Validate ]
 
 let ocaml_int_of_string s : atd_ocaml_int option =
   match s with
-      "int" -> Some `Int
-    | "char" -> Some `Char
-    | "int32" -> Some `Int32
-    | "int64" -> Some `Int64
-    | "float" -> Some `Float
+      "int" -> Some Int
+    | "char" -> Some Char
+    | "int32" -> Some Int32
+    | "int64" -> Some Int64
+    | "float" -> Some Float
     | _ -> None
 
 let string_of_ocaml_int (x : atd_ocaml_int) =
   match x with
-      `Int -> "int"
-    | `Char -> "Char.t"
-    | `Int32 -> "Int32.t"
-    | `Int64 -> "Int64.t"
-    | `Float -> "float"
+      Int -> "int"
+    | Char -> "Char.t"
+    | Int32 -> "Int32.t"
+    | Int64 -> "Int64.t"
+    | Float -> "float"
 
 let ocaml_sum_of_string s : atd_ocaml_sum option =
   match s with
@@ -118,7 +118,7 @@ let string_of_ocaml_list (x : atd_ocaml_list) =
     | Array -> "Atdgen_runtime.Util.ocaml_array"
 
 let get_ocaml_int an =
-  Atd.Annot.get_field ocaml_int_of_string `Int ["ocaml"] "repr" an
+  Atd.Annot.get_field ocaml_int_of_string Int ["ocaml"] "repr" an
 
 let get_ocaml_type_path atd_name an =
   let x =
@@ -790,11 +790,11 @@ let get_implicit_ocaml_default deref x =
     | `Bool (_, `Bool, _) -> Some "false"
     | `Int (_, `Int o, _) ->
         Some (match o with
-                  `Int -> "0"
-                | `Char -> "'\000'"
-                | `Int32 -> "0l"
-                | `Int64 -> "0L"
-                | `Float -> "0.")
+                  Int -> "0"
+                | Char -> "'\000'"
+                | Int32 -> "0l"
+                | Int64 -> "0L"
+                | Float -> "0.")
     | `Float (_, `Float, _) -> Some "0.0"
     | `String (_, `String, _) -> Some "\"\""
     | `List (_, _, `List List, _) -> Some "[]"

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -382,7 +382,7 @@ let rec select f = function
 
 let map_module ~target ~type_aliases (l : module_body) : ocaml_module_body =
   select (
-    fun (`Type td) ->
+    fun (Atd.Ast.Type td) ->
       match map_def ~target ~type_aliases td with
           None -> None
         | Some x -> Some (`Type x)

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -21,7 +21,7 @@ type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 
 type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
-type atd_ocaml_list = [ `List | `Array ]
+type atd_ocaml_list = List | Array
 
 type atd_ocaml_wrap = {
   ocaml_wrap_t : string;
@@ -108,14 +108,14 @@ let ocaml_record_of_string s : atd_ocaml_record option =
 
 let ocaml_list_of_string s : atd_ocaml_list option =
   match s with
-      "list" -> Some `List
-    | "array" -> Some `Array
+      "list" -> Some List
+    | "array" -> Some Array
     | _ -> None
 
 let string_of_ocaml_list (x : atd_ocaml_list) =
   match x with
-      `List -> "list"
-    | `Array -> "Atdgen_runtime.Util.ocaml_array"
+      List -> "list"
+    | Array -> "Atdgen_runtime.Util.ocaml_array"
 
 let get_ocaml_int an =
   Atd.Annot.get_field ocaml_int_of_string `Int ["ocaml"] "repr" an
@@ -155,7 +155,7 @@ let get_ocaml_record an =
   Atd.Annot.get_field ocaml_record_of_string `Record ["ocaml"] "repr" an
 
 let get_ocaml_list an =
-  Atd.Annot.get_field ocaml_list_of_string `List ["ocaml"] "repr" an
+  Atd.Annot.get_field ocaml_list_of_string List ["ocaml"] "repr" an
 
 let get_ocaml_wrap loc an =
   let module_ =
@@ -490,7 +490,7 @@ let vlist = {
 
 let make_atom s = Atom (s, atom)
 
-let horizontal_sequence l = List (("", "", "", shlist), l)
+let horizontal_sequence l = Easy_format.List (("", "", "", shlist), l)
 
 let rec insert sep = function
     [] | [_] as l -> l
@@ -510,7 +510,7 @@ let vertical_sequence ?(skip_lines = 0) l =
       in
       insert sep l
   in
-  List (("", "", "", rlist), l)
+  Easy_format.List (("", "", "", rlist), l)
 
 let escape f s =
   let buf = Buffer.create (2 * String.length s) in
@@ -573,14 +573,14 @@ let make_ocamldoc_comment (`Text l) =
         [] | [_] -> vlist1
       | _ -> vlist
   in
-  List (("(**", "", "*)", xlist), blocks)
+  Easy_format.List (("(**", "", "*)", xlist), blocks)
 
 let prepend_ocamldoc_comment doc x =
   match doc with
       None -> x
     | Some y ->
         let comment = make_ocamldoc_comment y in
-        List (("", "", "", rlist), [comment;x])
+        Easy_format.List (("", "", "", rlist), [comment;x])
 
 let append_ocamldoc_comment x doc =
   match doc with
@@ -797,8 +797,8 @@ let get_implicit_ocaml_default deref x =
                 | `Float -> "0.")
     | `Float (_, `Float, _) -> Some "0.0"
     | `String (_, `String, _) -> Some "\"\""
-    | `List (_, _, `List `List, _) -> Some "[]"
-    | `List (_, _, `List `Array, _) -> Some "[||]"
+    | `List (_, _, `List List, _) -> Some "[]"
+    | `List (_, _, `List Array, _) -> Some "[||]"
     | `Option (_, _, `Option, _) -> Some "None"
     | `Nullable (_, _, `Nullable, _) -> Some "None"
     | _ -> None

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -74,7 +74,7 @@ type atd_ocaml_repr =
     | `Def of atd_ocaml_def
     ]
 
-type target = [ `Default | `Biniou | `Json | `Validate ]
+type target = Default | Biniou | Json | Validate
 
 
 let ocaml_int_of_string s : atd_ocaml_int option =
@@ -140,10 +140,10 @@ let get_ocaml_type_path atd_name an =
 
 let path_of_target (target : target) =
   match target with
-      `Default -> [ "ocaml" ]
-    | `Biniou -> [ "ocaml_biniou"; "ocaml" ]
-    | `Json -> [ "ocaml_json"; "ocaml" ]
-    | `Validate -> [ "ocaml_validate"; "ocaml" ]
+      Default -> [ "ocaml" ]
+    | Biniou -> [ "ocaml_biniou"; "ocaml" ]
+    | Json -> [ "ocaml_json"; "ocaml" ]
+    | Validate -> [ "ocaml_validate"; "ocaml" ]
 
 let get_ocaml_sum an =
   Atd.Annot.get_field ocaml_sum_of_string Poly ["ocaml"] "repr" an
@@ -215,10 +215,10 @@ let get_ocaml_module target an =
               let type_module = s ^ "_t" in
               let main_module =
                 match target with
-                    `Default -> type_module
-                  | `Biniou -> s ^ "_b"
-                  | `Json -> s ^ "_j"
-                  | `Validate -> s ^ "_v"
+                    Default -> type_module
+                  | Biniou -> s ^ "_b"
+                  | Json -> s ^ "_j"
+                  | Validate -> s ^ "_v"
               in
               Some (type_module, main_module)
 

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -48,31 +48,30 @@ type atd_ocaml_def = {
 
 module Repr = struct
   type t =
-    [ `Unit
-    | `Bool
-    | `Int of atd_ocaml_int
-    | `Float
-    | `String
-    | `Sum of atd_ocaml_sum
-    | `Record of atd_ocaml_record
-    | `Tuple
-    | `List of atd_ocaml_list
-    | `Option
-    | `Nullable
-    | `Wrap of atd_ocaml_wrap option
-    | `Name of string
-    | `External of (string * string * string)
+    | Unit
+    | Bool
+    | Int of atd_ocaml_int
+    | Float
+    | String
+    | Sum of atd_ocaml_sum
+    | Record of atd_ocaml_record
+    | Tuple
+    | List of atd_ocaml_list
+    | Option
+    | Nullable
+    | Wrap of atd_ocaml_wrap option
+    | Name of string
+    | External of (string * string * string)
         (*
           (module providing the type,
            module providing everything else,
            type name)
         *)
 
-    | `Cell of atd_ocaml_field
-    | `Field of atd_ocaml_field
-    | `Variant of atd_ocaml_variant
-    | `Def of atd_ocaml_def
-    ]
+    | Cell of atd_ocaml_field
+    | Field of atd_ocaml_field
+    | Variant of atd_ocaml_variant
+    | Def of atd_ocaml_def
 end
 
 type target = Default | Biniou | Json | Validate
@@ -397,25 +396,25 @@ let map_module ~target ~type_aliases (l : module_body) : ocaml_module_body =
 
 let rec ocaml_of_expr_mapping (x : (Repr.t, _) mapping) : ocaml_expr =
   match x with
-    Unit (_, `Unit, _) -> `Name ("unit", [])
-  | Bool (_, `Bool, _) -> `Name ("bool", [])
-  | Int (_, `Int x, _) -> `Name (string_of_ocaml_int x, [])
-  | Float (_, `Float, _) -> `Name ("float", [])
-  | String (_, `String, _) -> `Name ("string", [])
-  | Sum (_, a, `Sum kind, _) ->
+    Unit (_, Unit, _) -> `Name ("unit", [])
+  | Bool (_, Bool, _) -> `Name ("bool", [])
+  | Int (_, Int x, _) -> `Name (string_of_ocaml_int x, [])
+  | Float (_, Float, _) -> `Name ("float", [])
+  | String (_, String, _) -> `Name ("string", [])
+  | Sum (_, a, Sum kind, _) ->
       let l = Array.to_list a in
       `Sum (kind, List.map ocaml_of_variant_mapping l)
-  | Record (_, a, `Record _, _) ->
+  | Record (_, a, Record _, _) ->
       let l = Array.to_list a in
       `Record (Record, List.map ocaml_of_field_mapping l)
   | Tuple (_, a, _, _) ->
       let l = Array.to_list a in
       `Tuple (List.map (fun x -> ocaml_of_expr_mapping x.cel_value) l)
-  | List (_, x, `List kind, _) ->
+  | List (_, x, List kind, _) ->
       `Name (string_of_ocaml_list kind, [ocaml_of_expr_mapping x])
-  | Option (_, x, `Option, _) ->
+  | Option (_, x, Option, _) ->
       `Name ("option", [ocaml_of_expr_mapping x])
-  | Nullable (_, x, `Nullable, _) ->
+  | Nullable (_, x, Nullable, _) ->
       `Name ("option", [ocaml_of_expr_mapping x])
   | Wrap _ ->
       assert false
@@ -428,7 +427,7 @@ let rec ocaml_of_expr_mapping (x : (Repr.t, _) mapping) : ocaml_expr =
 and ocaml_of_variant_mapping x =
   let o =
     match x.var_arepr with
-        `Variant o -> o
+        Variant o -> o
       | _ -> assert false
   in
   (o.ocaml_cons, omap ocaml_of_expr_mapping x.var_arg, o.ocaml_vdoc)
@@ -436,7 +435,7 @@ and ocaml_of_variant_mapping x =
 and ocaml_of_field_mapping x =
   let o =
     match x.f_arepr with
-        `Field o -> o
+        Field o -> o
       | _ -> assert false
   in
   let v = ocaml_of_expr_mapping x.f_value in
@@ -787,28 +786,28 @@ let unwrap_option deref x =
 
 let get_implicit_ocaml_default deref x =
   match deref x with
-    Unit (_, `Unit, _) -> Some "()"
-  | Bool (_, `Bool, _) -> Some "false"
-  | Int (_, `Int o, _) ->
+    Unit (_, Repr.Unit, _) -> Some "()"
+  | Bool (_, Bool, _) -> Some "false"
+  | Int (_, Int o, _) ->
       Some (match o with
           Int -> "0"
         | Char -> "'\000'"
         | Int32 -> "0l"
         | Int64 -> "0L"
         | Float -> "0.")
-  | Float (_, `Float, _) -> Some "0.0"
-  | String (_, `String, _) -> Some "\"\""
-  | List (_, _, `List List, _) -> Some "[]"
-  | List (_, _, `List Array, _) -> Some "[||]"
-  | Option (_, _, `Option, _) -> Some "None"
-  | Nullable (_, _, `Nullable, _) -> Some "None"
+  | Float (_, Float, _) -> Some "0.0"
+  | String (_, String, _) -> Some "\"\""
+  | List (_, _, List List, _) -> Some "[]"
+  | List (_, _, List Array, _) -> Some "[||]"
+  | Option (_, _, Option, _) -> Some "None"
+  | Nullable (_, _, Nullable, _) -> Some "None"
   | _ -> None
 
 
 let map_record_creator_field deref x =
   let o =
     match x.f_arepr with
-        `Field o -> o
+        Repr.Field o -> o
       | _ -> assert false
   in
   let fname = o.ocaml_fname in

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -17,7 +17,7 @@ type pp_convs =
 
 (* Type mapping from ATD to OCaml *)
 
-type atd_ocaml_sum = [ `Classic | `Poly ]
+type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 
 type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
@@ -96,8 +96,8 @@ let string_of_ocaml_int (x : atd_ocaml_int) =
 
 let ocaml_sum_of_string s : atd_ocaml_sum option =
   match s with
-      "classic" -> Some `Classic
-    | "poly" -> Some `Poly
+      "classic" -> Some Classic
+    | "poly" -> Some Poly
     | _ -> None
 
 let ocaml_record_of_string s : atd_ocaml_record option =
@@ -146,7 +146,7 @@ let path_of_target (target : target) =
     | `Validate -> [ "ocaml_validate"; "ocaml" ]
 
 let get_ocaml_sum an =
-  Atd.Annot.get_field ocaml_sum_of_string `Poly ["ocaml"] "repr" an
+  Atd.Annot.get_field ocaml_sum_of_string Poly ["ocaml"] "repr" an
 
 let get_ocaml_field_prefix an =
   Atd.Annot.get_field (fun s -> Some s) "" ["ocaml"] "field_prefix" an
@@ -357,7 +357,7 @@ let map_def
             let alias = Some (module_path ^ "." ^ ext_name, param) in
             let x =
               match map_expr x with
-                  `Sum (`Classic, _)
+                  `Sum (Classic, _)
                 | `Record (`Record, _) as x -> Some x
                 | _ -> None
             in
@@ -673,8 +673,8 @@ and format_type_expr x =
       `Sum (kind, l) ->
         let op, cl =
           match kind with
-              `Classic -> "", ""
-            | `Poly -> "[", "]"
+              Classic -> "", ""
+            | Poly -> "[", "]"
         in
         List (
             (op, "|", cl, llist),
@@ -722,8 +722,8 @@ and format_field ((s, is_mutable), t, doc) =
 and format_variant kind (s, o, doc) =
   let s =
     match kind with
-        `Classic -> s
-      | `Poly -> "`" ^ s
+        Classic -> s
+      | Poly -> "`" ^ s
   in
   let cons = make_atom s in
   let variant =

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -46,9 +46,9 @@ type atd_ocaml_def = {
   ocaml_ddoc : Doc.doc option;
 }
 
-type atd_ocaml_repr =
-    [
-    | `Unit
+module Repr = struct
+  type t =
+    [ `Unit
     | `Bool
     | `Int of atd_ocaml_int
     | `Float
@@ -73,6 +73,7 @@ type atd_ocaml_repr =
     | `Variant of atd_ocaml_variant
     | `Def of atd_ocaml_def
     ]
+end
 
 type target = Default | Biniou | Json | Validate
 
@@ -394,7 +395,7 @@ let map_module ~target ~type_aliases (l : module_body) : ocaml_module_body =
 *)
 
 
-let rec ocaml_of_expr_mapping (x : (atd_ocaml_repr, _) mapping) : ocaml_expr =
+let rec ocaml_of_expr_mapping (x : (Repr.t, _) mapping) : ocaml_expr =
   match x with
     Unit (_, `Unit, _) -> `Name ("unit", [])
   | Bool (_, `Bool, _) -> `Name ("bool", [])

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -308,23 +308,23 @@ let rec map_expr (x : type_expr) : ocaml_expr =
 
 and map_variant (x : variant) : ocaml_variant =
   match x with
-      `Inherit _ -> assert false
-    | `Variant (loc, (s, an), o) ->
-        let s = get_ocaml_cons s an in
-        (s, omap map_expr o, Doc.get_doc loc an)
+    Inherit _ -> assert false
+  | Variant (loc, (s, an), o) ->
+      let s = get_ocaml_cons s an in
+      (s, omap map_expr o, Doc.get_doc loc an)
 
 and map_field ocaml_field_prefix (x : field) : ocaml_field =
   match x with
-      `Inherit _ -> assert false
-    | `Field (loc, (atd_fname, _, an), x) ->
-        let ocaml_fname =
-          get_ocaml_fname (ocaml_field_prefix ^ atd_fname) an in
-        let fname =
-          if ocaml_fname = atd_fname then ocaml_fname
-          else sprintf "%s (*atd %s *)" ocaml_fname atd_fname
-        in
-        let is_mutable = get_ocaml_mutable an in
-        ((fname, is_mutable), map_expr x, Doc.get_doc loc an)
+    `Inherit _ -> assert false
+  | `Field (loc, (atd_fname, _, an), x) ->
+      let ocaml_fname =
+        get_ocaml_fname (ocaml_field_prefix ^ atd_fname) an in
+      let fname =
+        if ocaml_fname = atd_fname then ocaml_fname
+        else sprintf "%s (*atd %s *)" ocaml_fname atd_fname
+      in
+      let is_mutable = get_ocaml_mutable an in
+      ((fname, is_mutable), map_expr x, Doc.get_doc loc an)
 
 let map_def
     ~(target : target)

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -274,37 +274,37 @@ let omap f = function None -> None | Some x -> Some (f x)
 
 let rec map_expr (x : type_expr) : ocaml_expr =
   match x with
-      `Sum (_, l, an) ->
-        let kind = get_ocaml_sum an in
-        `Sum (kind, List.map map_variant l)
-    | `Record (loc, l, an) ->
-        let kind = get_ocaml_record an in
-        let field_prefix = get_ocaml_field_prefix an in
-        if l = [] then
-          Error.error loc "Empty record (not valid in OCaml)"
-        else
-          `Record (kind, List.map (map_field field_prefix) l)
-    | `Tuple (_, l, _) ->
-        `Tuple (List.map (fun (_, x, _) -> map_expr x) l)
-    | `List (_, x, an) ->
-        let s = string_of_ocaml_list (get_ocaml_list an) in
-        `Name (s, [map_expr x])
-    | `Option (_, x, _) ->
-        `Name ("option", [map_expr x])
-    | `Nullable (_, x, _) ->
-        `Name ("option", [map_expr x])
-    | `Shared (_, _, _) ->
-        failwith "Sharing is not supported"
-    | `Wrap (loc, x, a) ->
-        (match get_ocaml_wrap loc a with
-            None -> map_expr x
-          | Some { ocaml_wrap_t ; _ } -> `Name (ocaml_wrap_t, [])
-        )
-    | `Name (_, (_2, s, l), an) ->
-        let s = get_ocaml_type_path s an in
-        `Name (s, List.map map_expr l)
-    | `Tvar (_, s) ->
-        `Tvar s
+    Atd.Ast.Sum (_, l, an) ->
+      let kind = get_ocaml_sum an in
+      `Sum (kind, List.map map_variant l)
+  | Record (loc, l, an) ->
+      let kind = get_ocaml_record an in
+      let field_prefix = get_ocaml_field_prefix an in
+      if l = [] then
+        Error.error loc "Empty record (not valid in OCaml)"
+      else
+        `Record (kind, List.map (map_field field_prefix) l)
+  | Tuple (_, l, _) ->
+      `Tuple (List.map (fun (_, x, _) -> map_expr x) l)
+  | List (_, x, an) ->
+      let s = string_of_ocaml_list (get_ocaml_list an) in
+      `Name (s, [map_expr x])
+  | Option (_, x, _) ->
+      `Name ("option", [map_expr x])
+  | Nullable (_, x, _) ->
+      `Name ("option", [map_expr x])
+  | Shared (_, _, _) ->
+      failwith "Sharing is not supported"
+  | Wrap (loc, x, a) ->
+      (match get_ocaml_wrap loc a with
+         None -> map_expr x
+       | Some { ocaml_wrap_t ; _ } -> `Name (ocaml_wrap_t, [])
+      )
+  | Name (_, (_2, s, l), an) ->
+      let s = get_ocaml_type_path s an in
+      `Name (s, List.map map_expr l)
+  | Tvar (_, s) ->
+      `Tvar s
 
 and map_variant (x : variant) : ocaml_variant =
   match x with

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -18,7 +18,7 @@ type pp_convs =
 (* Type mapping from ATD to OCaml *)
 
 type atd_ocaml_sum = Classic | Poly
-type atd_ocaml_record = [ `Record | `Object ]
+type atd_ocaml_record = Record | Object
 
 type atd_ocaml_int = Int | Char | Int32 | Int64 | Float
 type atd_ocaml_list = List | Array
@@ -102,8 +102,8 @@ let ocaml_sum_of_string s : atd_ocaml_sum option =
 
 let ocaml_record_of_string s : atd_ocaml_record option =
   match s with
-      "record" -> Some `Record
-    | "object" -> Some `Object
+      "record" -> Some Record
+    | "object" -> Some Object
     | _ -> None
 
 let ocaml_list_of_string s : atd_ocaml_list option =
@@ -152,7 +152,7 @@ let get_ocaml_field_prefix an =
   Atd.Annot.get_field (fun s -> Some s) "" ["ocaml"] "field_prefix" an
 
 let get_ocaml_record an =
-  Atd.Annot.get_field ocaml_record_of_string `Record ["ocaml"] "repr" an
+  Atd.Annot.get_field ocaml_record_of_string Record ["ocaml"] "repr" an
 
 let get_ocaml_list an =
   Atd.Annot.get_field ocaml_list_of_string List ["ocaml"] "repr" an
@@ -358,7 +358,7 @@ let map_def
             let x =
               match map_expr x with
                   `Sum (Classic, _)
-                | `Record (`Record, _) as x -> Some x
+                | `Record (Record, _) as x -> Some x
                 | _ -> None
             in
             (alias, x)
@@ -406,7 +406,7 @@ let rec ocaml_of_expr_mapping (x : (atd_ocaml_repr, _) mapping) : ocaml_expr =
       `Sum (kind, List.map ocaml_of_variant_mapping l)
   | Record (_, a, `Record _, _) ->
       let l = Array.to_list a in
-      `Record (`Record, List.map ocaml_of_field_mapping l)
+      `Record (Record, List.map ocaml_of_field_mapping l)
   | Tuple (_, a, _, _) ->
       let l = Array.to_list a in
       `Tuple (List.map (fun x -> ocaml_of_expr_mapping x.cel_value) l)
@@ -683,8 +683,8 @@ and format_type_expr x =
     | `Record (kind, l) ->
         let op, cl =
           match kind with
-              `Record -> "{", "}"
-            | `Object -> "<", ">"
+              Record -> "{", "}"
+            | Object -> "<", ">"
         in
         List (
           (op, ";", cl, list),

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -88,7 +88,7 @@ val get_ocaml_module_and_t
 
 
 val get_implicit_ocaml_default
-  : ('a -> (Repr.t, 'b) Atdgen_emit.Mapping.mapping)
+  : ('a -> (Repr.t, 'b) Mapping.mapping)
   -> 'a
   -> string option
 

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -33,31 +33,30 @@ type atd_ocaml_def = {
 
 module Repr : sig
   type t =
-    [ `Unit
-    | `Bool
-    | `Int of atd_ocaml_int
-    | `Float
-    | `String
-    | `Sum of atd_ocaml_sum
-    | `Record of atd_ocaml_record
-    | `Tuple
-    | `List of atd_ocaml_list
-    | `Option
-    | `Nullable
-    | `Wrap of atd_ocaml_wrap option
-    | `Name of string
-    | `External of (string * string * string)
+    | Unit
+    | Bool
+    | Int of atd_ocaml_int
+    | Float
+    | String
+    | Sum of atd_ocaml_sum
+    | Record of atd_ocaml_record
+    | Tuple
+    | List of atd_ocaml_list
+    | Option
+    | Nullable
+    | Wrap of atd_ocaml_wrap option
+    | Name of string
+    | External of (string * string * string)
         (*
           (module providing the type,
            module providing everything else,
            type name)
         *)
 
-    | `Cell of atd_ocaml_field
-    | `Field of atd_ocaml_field
-    | `Variant of atd_ocaml_variant
-    | `Def of atd_ocaml_def
-    ]
+    | Cell of atd_ocaml_field
+    | Field of atd_ocaml_field
+    | Variant of atd_ocaml_variant
+    | Def of atd_ocaml_def
 end
 val get_ocaml_sum : Atd.Annot.t -> atd_ocaml_sum
 
@@ -89,17 +88,7 @@ val get_ocaml_module_and_t
 
 
 val get_implicit_ocaml_default
-  : ('a ->
-     ([> `Bool
-      | `Float
-      | `Int of atd_ocaml_int
-      | `List of atd_ocaml_list
-      | `Nullable
-      | `Option
-      | `String
-      | `Unit ],
-      'b)
-       Atdgen_emit__Mapping.mapping)
+  : ('a -> (Repr.t, 'b) Atdgen_emit__Mapping.mapping)
   -> 'a
   -> string option
 

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -4,7 +4,7 @@ type pp_convs =
 
 type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
-type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
+type atd_ocaml_int = Int | Char | Int32 | Int64 | Float
 type atd_ocaml_list = List | Array
 type target = [ `Default | `Biniou | `Json | `Validate ]
 

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -88,14 +88,16 @@ val get_ocaml_module_and_t
 
 val get_implicit_ocaml_default
   : ('a ->
-     [> `Bool of 'b * [> `Bool ] * 'c
-     | `Float of 'd * [> `Float ] * 'e
-     | `Int of 'f * [> `Int of atd_ocaml_int ] * 'g
-     | `List of 'h * 'i * [> `List of atd_ocaml_list] * 'j
-     | `Nullable of 'k * 'l * [> `Nullable ] * 'm
-     | `Option of 'n * 'o * [> `Option ] * 'p
-     | `String of 'q * [> `String ] * 'r
-     | `Unit of 's * [> `Unit ] * 't ])
+     ([> `Bool
+      | `Float
+      | `Int of atd_ocaml_int
+      | `List of atd_ocaml_list
+      | `Nullable
+      | `Option
+      | `String
+      | `Unit ],
+      'b)
+       Atdgen_emit__Mapping.mapping)
   -> 'a
   -> string option
 

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -90,8 +90,7 @@ val get_implicit_ocaml_default
   : ('a ->
      [> `Bool of 'b * [> `Bool ] * 'c
      | `Float of 'd * [> `Float ] * 'e
-     | `Int of
-          'f * [> `Int of [< `Char | `Float | `Int | `Int32 | `Int64 ] ] * 'g
+     | `Int of 'f * [> `Int of atd_ocaml_int ] * 'g
      | `List of 'h * 'i * [> `List of atd_ocaml_list] * 'j
      | `Nullable of 'k * 'l * [> `Nullable ] * 'm
      | `Option of 'n * 'o * [> `Option ] * 'p

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -2,7 +2,7 @@ type pp_convs =
   | Camlp4 of string list
   | Ppx of string list
 
-type atd_ocaml_sum = [ `Classic | `Poly ]
+type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
 type atd_ocaml_list = [ `List | `Array ]

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -31,32 +31,34 @@ type atd_ocaml_def = {
   ocaml_ddoc : Doc.doc option;
 }
 
-type atd_ocaml_repr =
-  [ `Unit
-  | `Bool
-  | `Int of atd_ocaml_int
-  | `Float
-  | `String
-  | `Sum of atd_ocaml_sum
-  | `Record of atd_ocaml_record
-  | `Tuple
-  | `List of atd_ocaml_list
-  | `Option
-  | `Nullable
-  | `Wrap of atd_ocaml_wrap option
-  | `Name of string
-  | `External of (string * string * string)
+module Repr : sig
+  type t =
+    [ `Unit
+    | `Bool
+    | `Int of atd_ocaml_int
+    | `Float
+    | `String
+    | `Sum of atd_ocaml_sum
+    | `Record of atd_ocaml_record
+    | `Tuple
+    | `List of atd_ocaml_list
+    | `Option
+    | `Nullable
+    | `Wrap of atd_ocaml_wrap option
+    | `Name of string
+    | `External of (string * string * string)
         (*
           (module providing the type,
            module providing everything else,
            type name)
         *)
 
-  | `Cell of atd_ocaml_field
-  | `Field of atd_ocaml_field
-  | `Variant of atd_ocaml_variant
-  | `Def of atd_ocaml_def ]
-
+    | `Cell of atd_ocaml_field
+    | `Field of atd_ocaml_field
+    | `Variant of atd_ocaml_variant
+    | `Def of atd_ocaml_def
+    ]
+end
 val get_ocaml_sum : Atd.Annot.t -> atd_ocaml_sum
 
 val get_ocaml_record : Atd.Annot.t -> atd_ocaml_record
@@ -115,7 +117,7 @@ val ocaml_of_atd
 
 
 val map_record_creator_field
-  : ((atd_ocaml_repr, 'a) Mapping.mapping
-     -> (atd_ocaml_repr, 'b) Mapping.mapping)
-  -> (atd_ocaml_repr, 'a) Mapping.field_mapping
+  : ((Repr.t, 'a) Mapping.mapping
+     -> (Repr.t, 'b) Mapping.mapping)
+  -> (Repr.t, 'a) Mapping.field_mapping
   -> string * string * string

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -6,7 +6,7 @@ type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 type atd_ocaml_int = Int | Char | Int32 | Int64 | Float
 type atd_ocaml_list = List | Array
-type target = [ `Default | `Biniou | `Json | `Validate ]
+type target = Default | Biniou | Json | Validate
 
 type atd_ocaml_wrap = {
   ocaml_wrap_t : string;

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -5,7 +5,7 @@ type pp_convs =
 type atd_ocaml_sum = Classic | Poly
 type atd_ocaml_record = [ `Record | `Object ]
 type atd_ocaml_int = [ `Int | `Char | `Int32 | `Int64 | `Float ]
-type atd_ocaml_list = [ `List | `Array ]
+type atd_ocaml_list = List | Array
 type target = [ `Default | `Biniou | `Json | `Validate ]
 
 type atd_ocaml_wrap = {
@@ -92,7 +92,7 @@ val get_implicit_ocaml_default
      | `Float of 'd * [> `Float ] * 'e
      | `Int of
           'f * [> `Int of [< `Char | `Float | `Int | `Int32 | `Int64 ] ] * 'g
-     | `List of 'h * 'i * [> `List of [> `Array | `List ] ] * 'j
+     | `List of 'h * 'i * [> `List of atd_ocaml_list] * 'j
      | `Nullable of 'k * 'l * [> `Nullable ] * 'm
      | `Option of 'n * 'o * [> `Option ] * 'p
      | `String of 'q * [> `String ] * 'r

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -3,7 +3,7 @@ type pp_convs =
   | Ppx of string list
 
 type atd_ocaml_sum = Classic | Poly
-type atd_ocaml_record = [ `Record | `Object ]
+type atd_ocaml_record = Record | Object
 type atd_ocaml_int = Int | Char | Int32 | Int64 | Float
 type atd_ocaml_list = List | Array
 type target = Default | Biniou | Json | Validate

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -88,7 +88,7 @@ val get_ocaml_module_and_t
 
 
 val get_implicit_ocaml_default
-  : ('a -> (Repr.t, 'b) Atdgen_emit__Mapping.mapping)
+  : ('a -> (Repr.t, 'b) Atdgen_emit.Mapping.mapping)
   -> 'a
   -> string option
 

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1806,7 +1806,7 @@ let error_too_many_untypeds name untypeds =
 
 let check_atd (_head, body) =
   List.iter (function
-    | (`Type (loc, (name, _, _), `Sum (_, conss, _))) ->
+    | (Atd.Ast.Type (loc, (name, _, _), `Sum (_, conss, _))) ->
         begin match List.fold_left check_variant [] conss with
           | [] | [_] -> ()
           | untypeds ->

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -290,16 +290,16 @@ let rec get_writer_name
 
     | Float (_, `Float, `Float j) ->
         (match j with
-            `Float None ->
-              if p.std then "Yojson.Safe.write_std_float"
-              else "Yojson.Safe.write_float"
-          | `Float (Some precision) ->
-              if p.std then
-                sprintf "Yojson.Safe.write_std_float_prec %i" precision
-              else
-                sprintf "Yojson.Safe.write_float_prec %i" precision
-          | `Int ->
-              "Atdgen_runtime.Oj_run.write_float_as_int"
+           Float None ->
+             if p.std then "Yojson.Safe.write_std_float"
+             else "Yojson.Safe.write_float"
+         | Float (Some precision) ->
+             if p.std then
+               sprintf "Yojson.Safe.write_std_float_prec %i" precision
+             else
+               sprintf "Yojson.Safe.write_float_prec %i" precision
+         | Int ->
+             "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
     | String (_, `String, `String) ->

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -281,11 +281,11 @@ let rec get_writer_name
         "Yojson.Safe.write_bool"
     | `Int (_, `Int o, `Int) ->
         (match o with
-             `Int -> "Yojson.Safe.write_int"
-           | `Char ->  "Atdgen_runtime.Oj_run.write_int8"
-           | `Int32 -> "Atdgen_runtime.Oj_run.write_int32"
-           | `Int64 -> "Atdgen_runtime.Oj_run.write_int64"
-           | `Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
+             Int -> "Yojson.Safe.write_int"
+           | Char ->  "Atdgen_runtime.Oj_run.write_int8"
+           | Int32 -> "Atdgen_runtime.Oj_run.write_int32"
+           | Int64 -> "Atdgen_runtime.Oj_run.write_int64"
+           | Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
     | `Float (_, `Float, `Float j) ->
@@ -345,11 +345,11 @@ let rec get_reader_name
     | `Bool (_, `Bool, `Bool) -> "Atdgen_runtime.Oj_run.read_bool"
     | `Int (_, `Int o, `Int) ->
         (match o with
-             `Int -> "Atdgen_runtime.Oj_run.read_int"
-           | `Char -> "Atdgen_runtime.Oj_run.read_int8"
-           | `Int32 -> "Atdgen_runtime.Oj_run.read_int32"
-           | `Int64 -> "Atdgen_runtime.Oj_run.read_int64"
-           | `Float -> "Atdgen_runtime.Oj_run.read_number"
+             Int -> "Atdgen_runtime.Oj_run.read_int"
+           | Char -> "Atdgen_runtime.Oj_run.read_int8"
+           | Int32 -> "Atdgen_runtime.Oj_run.read_int32"
+           | Int64 -> "Atdgen_runtime.Oj_run.read_int64"
+           | Float -> "Atdgen_runtime.Oj_run.read_number"
         )
 
     | `Float (_, `Float, `Float _) -> "Atdgen_runtime.Oj_run.read_number"

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -15,8 +15,8 @@ open Oj_mapping
 *)
 
 type param = {
-  deref : (Ocaml.atd_ocaml_repr, Json.json_repr) Mapping.mapping ->
-               (Ocaml.atd_ocaml_repr, Json.json_repr) Mapping.mapping;
+  deref : (Ocaml.Repr.t, Json.json_repr) Mapping.mapping ->
+               (Ocaml.Repr.t, Json.json_repr) Mapping.mapping;
   std : bool;
   unknown_field_handler : string option;
     (* Optional handler that takes a field name as argument
@@ -135,11 +135,11 @@ let get_assoc_type deref loc x =
 
 
 type default_field =
-| Default of string
-| Checked of int
+  | Default of string
+  | Checked of int
 
 type parse_field = {
-  mapping     : (o, j) field_mapping;
+  mapping     : (Ocaml.Repr.t, Json.json_repr) field_mapping;
   default     : default_field;
   ocamlf      : Ocaml.atd_ocaml_field;
   jsonf       : Json.json_field;

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -670,8 +670,8 @@ and make_record_writer p a record_kind =
   in
   let v_of_field field =
     let dot = match record_kind with
-      | `Record -> "."
-      | `Object -> "#"
+      | Record -> "."
+      | Object -> "#"
     in
     let ocaml_fname = field.ocamlf.Ocaml.ocaml_fname in
     if is_optional field then
@@ -994,8 +994,8 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
 
     | Record (loc, a, `Record o, Record j) ->
         (match o with
-             `Record -> ()
-           | `Object ->
+             Record -> ()
+           | Object ->
                error loc "Sorry, OCaml objects are not supported"
         );
         [

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -158,19 +158,19 @@ let get_fields p a =
       match x.f_arepr, x.f_brepr with
         Ocaml.Repr.Field o, Json.Field j ->
           (match x.f_kind with
-            `With_default ->
-              (match o.Ocaml.ocaml_default with
-                None ->
-                  let d =
-                    Ocaml.get_implicit_ocaml_default
-                      p.deref x.f_value in
-                  (match d with
-                  | None -> error x.f_loc "Missing default field value"
-                  | Some d -> o, Default d, j, k)
-              | Some d -> o, Default d, j, k
-              )
-          | `Optional -> o, Default "None", j, k
-          | `Required -> o, Checked k, j, k+1
+             With_default ->
+               (match o.Ocaml.ocaml_default with
+                  None ->
+                    let d =
+                      Ocaml.get_implicit_ocaml_default
+                        p.deref x.f_value in
+                    (match d with
+                     | None -> error x.f_loc "Missing default field value"
+                     | Some d -> o, Default d, j, k)
+                | Some d -> o, Default d, j, k
+               )
+           | Optional -> o, Default "None", j, k
+           | Required -> o, Checked k, j, k+1
           )
       | _ -> assert false
     in
@@ -228,7 +228,7 @@ let get_fields p a =
         let mapping = {
           f_loc = synloc;
           f_name = f_name;
-          f_kind = `Required;
+          f_kind = Required;
           f_value = String (synloc, Ocaml.Repr.String, Json.String);
           f_arepr = Ocaml.Repr.Field ocamlf;
           f_brepr = Json.Field jsonf;

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -508,7 +508,7 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
 
   | List (loc, x, `List o, `List j) ->
       (match j with
-         `Array ->
+         Array ->
            let write =
              match o with
                List -> "Atdgen_runtime.Oj_run.write_list ("
@@ -520,7 +520,7 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
              `Line ")";
            ]
 
-       | `Object ->
+       | Object ->
            let k, v = get_assoc_type p.deref loc x in
            let write =
              match o with
@@ -1011,7 +1011,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
 
     | List (loc, x, `List o, `List j) ->
         (match j with
-             `Array ->
+             Array ->
                let read =
                  match o with
                      List -> "Atdgen_runtime.Oj_run.read_list ("
@@ -1023,7 +1023,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
                  `Line ")";
                ]
 
-           | `Object ->
+           | Object ->
                let k, v = get_assoc_type p.deref loc x in
                let read =
                  match o with

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -511,8 +511,8 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
              `Array ->
                let write =
                  match o with
-                     `List -> "Atdgen_runtime.Oj_run.write_list ("
-                   | `Array -> "Atdgen_runtime.Oj_run.write_array ("
+                     List -> "Atdgen_runtime.Oj_run.write_list ("
+                   | Array -> "Atdgen_runtime.Oj_run.write_array ("
                in
                [
                  `Line write;
@@ -524,8 +524,8 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
                let k, v = get_assoc_type p.deref loc x in
                let write =
                  match o with
-                     `List -> "Atdgen_runtime.Oj_run.write_assoc_list ("
-                   | `Array -> "Atdgen_runtime.Oj_run.write_assoc_array ("
+                     List -> "Atdgen_runtime.Oj_run.write_assoc_list ("
+                   | Array -> "Atdgen_runtime.Oj_run.write_assoc_array ("
                in
                [
                  `Line write;
@@ -1014,8 +1014,8 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
              `Array ->
                let read =
                  match o with
-                     `List -> "Atdgen_runtime.Oj_run.read_list ("
-                   | `Array -> "Atdgen_runtime.Oj_run.read_array ("
+                     List -> "Atdgen_runtime.Oj_run.read_list ("
+                   | Array -> "Atdgen_runtime.Oj_run.read_array ("
                in
                [
                  `Line read;
@@ -1027,8 +1027,8 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
                let k, v = get_assoc_type p.deref loc x in
                let read =
                  match o with
-                     `List -> "Atdgen_runtime.Oj_run.read_assoc_list ("
-                   | `Array -> "Atdgen_runtime.Oj_run.read_assoc_array ("
+                     List -> "Atdgen_runtime.Oj_run.read_assoc_list ("
+                   | Array -> "Atdgen_runtime.Oj_run.read_assoc_array ("
                in
                [
                  `Line read;

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -126,7 +126,7 @@ let is_json_string deref x =
 
 let get_assoc_type deref loc x =
   match deref x with
-  | Tuple (_, [| k; v |], `Tuple, Json.Tuple) ->
+  | Tuple (_, [| k; v |], Ocaml.Repr.Tuple, Json.Tuple) ->
       if not (is_json_string deref k.cel_value) then
         error loc "Due to <json repr=\"object\"> keys must be strings";
       (k.cel_value, v.cel_value)
@@ -156,7 +156,7 @@ let get_fields p a =
   let k, acc = Array.fold_left (fun (k,acc) (_, x) ->
     let ocamlf, default, jsonf, k =
       match x.f_arepr, x.f_brepr with
-        `Field o, Json.Field j ->
+        Ocaml.Repr.Field o, Json.Field j ->
           (match x.f_kind with
             `With_default ->
               (match o.Ocaml.ocaml_default with
@@ -229,8 +229,8 @@ let get_fields p a =
           f_loc = synloc;
           f_name = f_name;
           f_kind = `Required;
-          f_value = String (synloc, `String, Json.String);
-          f_arepr = `Field ocamlf;
+          f_value = String (synloc, Ocaml.Repr.String, Json.String);
+          f_arepr = Ocaml.Repr.Field ocamlf;
           f_brepr = Json.Field jsonf;
         } in
         let imp = {
@@ -275,11 +275,11 @@ let rec get_writer_name
     ?(name_f = fun s -> "write_" ^ s)
     p (x : oj_mapping) : string =
   match x with
-      Unit (_, `Unit, Unit) ->
+      Unit (_, Ocaml.Repr.Unit, Unit) ->
         "Yojson.Safe.write_null"
-    | Bool (_, `Bool, Bool) ->
+    | Bool (_, Bool, Bool) ->
         "Yojson.Safe.write_bool"
-    | Int (_, `Int o, Int) ->
+    | Int (_, Int o, Int) ->
         (match o with
              Int -> "Yojson.Safe.write_int"
            | Char ->  "Atdgen_runtime.Oj_run.write_int8"
@@ -288,7 +288,7 @@ let rec get_writer_name
            | Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
-    | Float (_, `Float, Float j) ->
+    | Float (_, Float, Float j) ->
         (match j with
            Float None ->
              if p.std then "Yojson.Safe.write_std_float"
@@ -302,7 +302,7 @@ let rec get_writer_name
              "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
-    | String (_, `String, String) ->
+    | String (_, String, String) ->
         "Yojson.Safe.write_string"
 
     | Tvar (_, s) -> "write_" ^ (Ox_emit.name_of_var s)
@@ -314,7 +314,7 @@ let rec get_writer_name
         else s
 
     | External (_, _, args,
-                 `External (_, main_module, ext_name),
+                 External (_, main_module, ext_name),
                  External) ->
         let f = main_module ^ "." ^ name_f ext_name in
         let l = List.map (get_writer_name ~paren:true p) args in
@@ -341,9 +341,9 @@ let rec get_reader_name
     p (x : oj_mapping) : string =
 
   match x with
-    Unit (_, `Unit, Unit) -> "Atdgen_runtime.Oj_run.read_null"
-  | Bool (_, `Bool, Bool) -> "Atdgen_runtime.Oj_run.read_bool"
-  | Int (_, `Int o, Int) ->
+    Unit (_, Unit, Unit) -> "Atdgen_runtime.Oj_run.read_null"
+  | Bool (_, Bool, Bool) -> "Atdgen_runtime.Oj_run.read_bool"
+  | Int (_, Int o, Int) ->
       (match o with
          Int -> "Atdgen_runtime.Oj_run.read_int"
        | Char -> "Atdgen_runtime.Oj_run.read_int8"
@@ -352,9 +352,9 @@ let rec get_reader_name
        | Float -> "Atdgen_runtime.Oj_run.read_number"
       )
 
-  | Float (_, `Float, Float _) -> "Atdgen_runtime.Oj_run.read_number"
+  | Float (_, Float, Float _) -> "Atdgen_runtime.Oj_run.read_number"
 
-  | String (_, `String, String) -> "Atdgen_runtime.Oj_run.read_string"
+  | String (_, String, String) -> "Atdgen_runtime.Oj_run.read_string"
 
   | Tvar (_, s) -> "read_" ^ Ox_emit.name_of_var s
 
@@ -365,7 +365,7 @@ let rec get_reader_name
       else s
 
   | External (_, _, args,
-              `External (_, main_module, ext_name),
+              External (_, main_module, ext_name),
               External) ->
       let f = main_module ^ "." ^ name_f ext_name in
       let l = List.map (get_reader_name ~paren:true p) args in
@@ -387,7 +387,7 @@ let get_left_of_string_name p name param =
 
 let destruct_sum (x : oj_mapping) =
   match x with
-    Sum (_, a, `Sum x, Sum) ->
+    Sum (_, a, Sum x, Sum) ->
       let tick = match x with Classic -> "" | Poly -> "`" in
       tick, a
   | Unit _ -> error (loc_of_mapping x) "Cannot destruct unit"
@@ -412,7 +412,7 @@ let make_sum_writer p sum f =
   let cases = Array.to_list (Array.map (fun x ->
     let o, j =
       match x.var_arepr, x.var_brepr with
-        `Variant o, Json.Variant j -> o, j
+        Ocaml.Repr.Variant o, Json.Variant j -> o, j
       | _ -> assert false
     in
     `Inline (f p tick o j x)) a
@@ -470,13 +470,13 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
 
   | Sum _ -> make_sum_writer p x make_variant_writer
 
-  | Record (_, a, `Record o, Record _) ->
+  | Record (_, a, Record o, Record _) ->
       [
         `Annot ("fun", `Line "fun ob x ->");
         `Block (make_record_writer p a o);
       ]
 
-  | Tuple (_, a, `Tuple, Tuple) ->
+  | Tuple (_, a, Tuple, Tuple) ->
       let len = Array.length a in
       let a =
         Array.mapi (
@@ -506,7 +506,7 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
         ]
       ]
 
-  | List (loc, x, `List o, List j) ->
+  | List (loc, x, List o, List j) ->
       (match j with
          Array ->
            let write =
@@ -536,7 +536,7 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
            ]
       )
 
-  | Option (_, x, `Option, Option) ->
+  | Option (_, x, Option, Option) ->
       [
         `Line (sprintf "Atdgen_runtime.Oj_run.write_%soption ("
                  (if p.std then "std_" else ""));
@@ -544,14 +544,14 @@ let rec make_writer p (x : oj_mapping) : Indent.t list =
         `Line ")";
       ]
 
-  | Nullable (_, x, `Nullable, Nullable) ->
+  | Nullable (_, x, Nullable, Nullable) ->
       [
         `Line "Atdgen_runtime.Oj_run.write_nullable (";
         `Block (make_writer p x);
         `Line ")";
       ]
 
-  | Wrap (_, x, `Wrap o, Wrap) ->
+  | Wrap (_, x, Wrap o, Wrap) ->
       (match o with
          None -> make_writer p x
        | Some { Ocaml.ocaml_unwrap; _} ->
@@ -875,7 +875,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
     | External _
     | Tvar _ -> [ `Line (get_reader_name p x) ]
 
-    | Sum (_, a, `Sum x, Sum) ->
+    | Sum (_, a, Sum x, Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -992,7 +992,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           ]
         ]
 
-    | Record (loc, a, `Record o, Record j) ->
+    | Record (loc, a, Record o, Record j) ->
         (match o with
              Record -> ()
            | Object ->
@@ -1003,13 +1003,13 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           `Block (make_record_reader p type_annot loc a j)
         ]
 
-    | Tuple (_, a, `Tuple, Tuple) ->
+    | Tuple (_, a, Tuple, Tuple) ->
         [
           `Annot ("fun", `Line "fun p lb ->");
           `Block (make_tuple_reader p a);
         ]
 
-    | List (loc, x, `List o, List j) ->
+    | List (loc, x, List o, List j) ->
         (match j with
              Array ->
                let read =
@@ -1039,30 +1039,30 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
                ]
         )
 
-    | Option (loc, x, `Option, Option) ->
+    | Option (loc, x, Option, Option) ->
 
         let a = [|
           {
             var_loc = loc;
             var_cons = "None";
             var_arg = None;
-            var_arepr = `Variant { Ocaml.ocaml_cons = "None";
-                                   ocaml_vdoc = None };
+            var_arepr = Ocaml.Repr.Variant { Ocaml.ocaml_cons = "None";
+                                             ocaml_vdoc = None };
             var_brepr = Json.Variant { Json.json_cons = Some "None" };
           };
           {
             var_loc = loc;
             var_cons = "Some";
             var_arg = Some x;
-            var_arepr = `Variant { Ocaml.ocaml_cons = "Some";
-                                   ocaml_vdoc = None };
+            var_arepr = Ocaml.Repr.Variant { Ocaml.ocaml_cons = "Some";
+                                             ocaml_vdoc = None };
             var_brepr = Json.Variant { Json.json_cons = Some "Some" };
           };
         |]
         in
-        make_reader p (Some "_ option") (Sum (loc, a, `Sum Classic, Json.Sum))
+        make_reader p (Some "_ option") (Sum (loc, a, Sum Classic, Json.Sum))
 
-    | Nullable (_, x, `Nullable, Nullable) ->
+    | Nullable (_, x, Nullable, Nullable) ->
         [
           `Line "fun p lb ->";
           `Block [
@@ -1074,7 +1074,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           ]
         ]
 
-    | Wrap (_, x, `Wrap o, Wrap) ->
+    | Wrap (_, x, Wrap o, Wrap) ->
         (match o with
             None -> make_reader p type_annot x
           | Some { Ocaml.ocaml_wrap; _ } ->
@@ -1096,7 +1096,7 @@ and make_variant_reader ?nullary p type_annot tick std x
   : (string option * Indent.t list) =
   let o, j =
     match x.var_arepr, x.var_brepr with
-        `Variant o, Variant j -> o, j
+        Variant o, Variant j -> o, j
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -1192,7 +1192,7 @@ and make_deconstructed_reader p loc fields set_bit =
       | Checked k -> [set_bit k]
     in
     match p.deref mapping.f_value with
-    | Sum (loc, a, `Sum x, Sum) ->
+    | Sum (loc, a, Sum x, Sum) ->
       let s = string_expr_of_constr_field p v_of_field constrf in
       let tick =
         match x with
@@ -1206,7 +1206,7 @@ and make_deconstructed_reader p loc fields set_bit =
       let cases, error_expr1 = Array.fold_left (fun (cases, error_expr1) x ->
         let o, j =
           match x.var_arepr, x.var_brepr with
-            `Variant o, Json.Variant j -> o, j
+            Ocaml.Repr.Variant o, Json.Variant j -> o, j
           | _ -> assert false
         in
         let ocaml_cons = o.Ocaml.ocaml_cons in
@@ -1505,8 +1505,8 @@ and make_tuple_reader p a =
     Array.map (
       fun x ->
         match x.cel_arepr with
-            `Cell f -> x, f.Ocaml.ocaml_default
-          | _ -> assert false
+          Ocaml.Repr.Cell f -> x, f.Ocaml.ocaml_default
+        | _ -> assert false
     ) a
   in
   let min_length =

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1778,8 +1778,8 @@ let make_ocaml_json_impl
     ) defs
 
 let check_variant untypeds = function
-  | `Inherit _ -> assert false (* inherits have been inlined by now *)
-  | `Variant (loc, (cons, ann), arg) ->
+  | Inherit _ -> assert false (* inherits have been inlined by now *)
+  | Variant (loc, (cons, ann), arg) ->
       if not (Atd.Annot.get_flag ["json"] "untyped" ann)
       then untypeds
       else match arg with

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -121,12 +121,12 @@ let is_json_string deref x =
     another representation for the JSON string.
   *)
   match Mapping.unwrap deref x with
-  | `String _ -> true
+  | String _ -> true
   | _ -> false (* or maybe we just don't know *)
 
 let get_assoc_type deref loc x =
   match deref x with
-  | `Tuple (_, [| k; v |], `Tuple, `Tuple) ->
+  | Tuple (_, [| k; v |], `Tuple, `Tuple) ->
       if not (is_json_string deref k.cel_value) then
         error loc "Due to <json repr=\"object\"> keys must be strings";
       (k.cel_value, v.cel_value)
@@ -229,7 +229,7 @@ let get_fields p a =
           f_loc = synloc;
           f_name = f_name;
           f_kind = `Required;
-          f_value = `String (synloc, `String, `String);
+          f_value = String (synloc, `String, `String);
           f_arepr = `Field ocamlf;
           f_brepr = `Field jsonf;
         } in
@@ -275,11 +275,11 @@ let rec get_writer_name
     ?(name_f = fun s -> "write_" ^ s)
     p (x : oj_mapping) : string =
   match x with
-      `Unit (_, `Unit, `Unit) ->
+      Unit (_, `Unit, `Unit) ->
         "Yojson.Safe.write_null"
-    | `Bool (_, `Bool, `Bool) ->
+    | Bool (_, `Bool, `Bool) ->
         "Yojson.Safe.write_bool"
-    | `Int (_, `Int o, `Int) ->
+    | Int (_, `Int o, `Int) ->
         (match o with
              Int -> "Yojson.Safe.write_int"
            | Char ->  "Atdgen_runtime.Oj_run.write_int8"
@@ -288,7 +288,7 @@ let rec get_writer_name
            | Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
-    | `Float (_, `Float, `Float j) ->
+    | Float (_, `Float, `Float j) ->
         (match j with
             `Float None ->
               if p.std then "Yojson.Safe.write_std_float"
@@ -302,18 +302,18 @@ let rec get_writer_name
               "Atdgen_runtime.Oj_run.write_float_as_int"
         )
 
-    | `String (_, `String, `String) ->
+    | String (_, `String, `String) ->
         "Yojson.Safe.write_string"
 
-    | `Tvar (_, s) -> "write_" ^ (Ox_emit.name_of_var s)
+    | Tvar (_, s) -> "write_" ^ (Ox_emit.name_of_var s)
 
-    | `Name (_, s, args, None, None) ->
+    | Name (_, s, args, None, None) ->
         let l = List.map (get_writer_name ~paren:true p) args in
         let s = String.concat " " (name_f s :: l) in
         if paren && l <> [] then "(" ^ s ^ ")"
         else s
 
-    | `External (_, _, args,
+    | External (_, _, args,
                  `External (_, main_module, ext_name),
                  `External) ->
         let f = main_module ^ "." ^ name_f ext_name in
@@ -326,13 +326,13 @@ let rec get_writer_name
 
 
 let get_left_writer_name p name param =
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
-  get_writer_name p (`Name (dummy_loc, name, args, None, None))
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
+  get_writer_name p (Name (dummy_loc, name, args, None, None))
 
 let get_left_to_string_name p name param =
   let name_f s = "string_of_" ^ s in
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
-  get_writer_name ~name_f p (`Name (dummy_loc, name, args, None, None))
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
+  get_writer_name ~name_f p (Name (dummy_loc, name, args, None, None))
 
 
 let rec get_reader_name
@@ -341,71 +341,71 @@ let rec get_reader_name
     p (x : oj_mapping) : string =
 
   match x with
-      `Unit (_, `Unit, `Unit) -> "Atdgen_runtime.Oj_run.read_null"
-    | `Bool (_, `Bool, `Bool) -> "Atdgen_runtime.Oj_run.read_bool"
-    | `Int (_, `Int o, `Int) ->
-        (match o with
-             Int -> "Atdgen_runtime.Oj_run.read_int"
-           | Char -> "Atdgen_runtime.Oj_run.read_int8"
-           | Int32 -> "Atdgen_runtime.Oj_run.read_int32"
-           | Int64 -> "Atdgen_runtime.Oj_run.read_int64"
-           | Float -> "Atdgen_runtime.Oj_run.read_number"
-        )
+    Unit (_, `Unit, `Unit) -> "Atdgen_runtime.Oj_run.read_null"
+  | Bool (_, `Bool, `Bool) -> "Atdgen_runtime.Oj_run.read_bool"
+  | Int (_, `Int o, `Int) ->
+      (match o with
+         Int -> "Atdgen_runtime.Oj_run.read_int"
+       | Char -> "Atdgen_runtime.Oj_run.read_int8"
+       | Int32 -> "Atdgen_runtime.Oj_run.read_int32"
+       | Int64 -> "Atdgen_runtime.Oj_run.read_int64"
+       | Float -> "Atdgen_runtime.Oj_run.read_number"
+      )
 
-    | `Float (_, `Float, `Float _) -> "Atdgen_runtime.Oj_run.read_number"
+  | Float (_, `Float, `Float _) -> "Atdgen_runtime.Oj_run.read_number"
 
-    | `String (_, `String, `String) -> "Atdgen_runtime.Oj_run.read_string"
+  | String (_, `String, `String) -> "Atdgen_runtime.Oj_run.read_string"
 
-    | `Tvar (_, s) -> "read_" ^ Ox_emit.name_of_var s
+  | Tvar (_, s) -> "read_" ^ Ox_emit.name_of_var s
 
-    | `Name (_, s, args, None, None) ->
-        let l = List.map (get_reader_name ~paren:true p) args in
-        let s = String.concat " " (name_f s :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | Name (_, s, args, None, None) ->
+      let l = List.map (get_reader_name ~paren:true p) args in
+      let s = String.concat " " (name_f s :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | `External (_, _, args,
-                 `External (_, main_module, ext_name),
-                 `External) ->
-        let f = main_module ^ "." ^ name_f ext_name in
-        let l = List.map (get_reader_name ~paren:true p) args in
-        let s = String.concat " " (f :: l) in
-        if paren && l <> [] then "(" ^ s ^ ")"
-        else s
+  | External (_, _, args,
+              `External (_, main_module, ext_name),
+              `External) ->
+      let f = main_module ^ "." ^ name_f ext_name in
+      let l = List.map (get_reader_name ~paren:true p) args in
+      let s = String.concat " " (f :: l) in
+      if paren && l <> [] then "(" ^ s ^ ")"
+      else s
 
-    | _ -> assert false
+  | _ -> assert false
 
 
 let get_left_reader_name p name param =
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
-  get_reader_name p (`Name (dummy_loc, name, args, None, None))
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
+  get_reader_name p (Name (dummy_loc, name, args, None, None))
 
 let get_left_of_string_name p name param =
   let name_f s = s ^ "_of_string" in
-  let args = List.map (fun s -> `Tvar (dummy_loc, s)) param in
-  get_reader_name ~name_f p (`Name (dummy_loc, name, args, None, None))
+  let args = List.map (fun s -> Tvar (dummy_loc, s)) param in
+  get_reader_name ~name_f p (Name (dummy_loc, name, args, None, None))
 
 let destruct_sum (x : oj_mapping) =
   match x with
-      `Sum (_, a, `Sum x, `Sum) ->
-        let tick = match x with Classic -> "" | Poly -> "`" in
-        tick, a
-    | `Unit _ -> error (loc_of_mapping x) "Cannot destruct unit"
-    | `Bool _ -> error (loc_of_mapping x) "Cannot destruct bool"
-    | `Int _ -> error (loc_of_mapping x) "Cannot destruct int"
-    | `Float _ -> error (loc_of_mapping x) "Cannot destruct float"
-    | `String _ -> error (loc_of_mapping x) "Cannot destruct string"
-    | `Name (_,name,_,_,_) ->
+    Sum (_, a, `Sum x, `Sum) ->
+      let tick = match x with Classic -> "" | Poly -> "`" in
+      tick, a
+  | Unit _ -> error (loc_of_mapping x) "Cannot destruct unit"
+  | Bool _ -> error (loc_of_mapping x) "Cannot destruct bool"
+  | Int _ -> error (loc_of_mapping x) "Cannot destruct int"
+  | Float _ -> error (loc_of_mapping x) "Cannot destruct float"
+  | String _ -> error (loc_of_mapping x) "Cannot destruct string"
+  | Name (_,name,_,_,_) ->
       error (loc_of_mapping x) ("Cannot destruct name " ^ name)
-    | `External _ -> error (loc_of_mapping x) "Cannot destruct external"
-    | `Tvar _ -> error (loc_of_mapping x) "Cannot destruct tvar"
-    | `Record _ -> error (loc_of_mapping x) "Cannot destruct record"
-    | `Tuple _ -> error (loc_of_mapping x) "Cannot destruct tuple"
-    | `List _ -> error (loc_of_mapping x) "Cannot destruct list"
-    | `Option _ -> error (loc_of_mapping x) "Cannot destruct option"
-    | `Nullable _ -> error (loc_of_mapping x) "Cannot destruct nullable"
-    | `Wrap _ -> error (loc_of_mapping x) "Cannot destruct wrap"
-    | _ -> error (loc_of_mapping x) "Cannot destruct unknown type"
+  | External _ -> error (loc_of_mapping x) "Cannot destruct external"
+  | Tvar _ -> error (loc_of_mapping x) "Cannot destruct tvar"
+  | Record _ -> error (loc_of_mapping x) "Cannot destruct record"
+  | Tuple _ -> error (loc_of_mapping x) "Cannot destruct tuple"
+  | List _ -> error (loc_of_mapping x) "Cannot destruct list"
+  | Option _ -> error (loc_of_mapping x) "Cannot destruct option"
+  | Nullable _ -> error (loc_of_mapping x) "Cannot destruct nullable"
+  | Wrap _ -> error (loc_of_mapping x) "Cannot destruct wrap"
+  | _ -> error (loc_of_mapping x) "Cannot destruct unknown type"
 
 let make_sum_writer p sum f =
   let tick, a = destruct_sum (p.deref sum) in
@@ -438,134 +438,134 @@ let string_expr_of_constr_field p v_of_field field =
   let v = v_of_field field in
   let f_value = unwrap p field in
   match f_value with
-    `String _ -> [ `Line v ]
+    String _ -> [ `Line v ]
   | _ ->
-    ( `Line "(" )::
+      ( `Line "(" )::
       (make_sum_writer p f_value (fun _ tick o j x ->
-        let ocaml_cons = o.Ocaml.ocaml_cons in
-        let json_cons = j.Json.json_cons in
-        match json_cons with
-        | None -> [
-            `Line (sprintf "| %s%s (cons,_) -> cons" tick ocaml_cons);
-          ]
-        | Some json_cons -> match x.var_arg with
-          | None -> [
-              `Line (sprintf "| %s%s -> %S" tick ocaml_cons json_cons);
-            ]
-          | Some _ -> [
-              `Line (sprintf "| %s%s _ -> %S" tick ocaml_cons json_cons);
-            ]
+         let ocaml_cons = o.Ocaml.ocaml_cons in
+         let json_cons = j.Json.json_cons in
+         match json_cons with
+         | None -> [
+             `Line (sprintf "| %s%s (cons,_) -> cons" tick ocaml_cons);
+           ]
+         | Some json_cons -> match x.var_arg with
+           | None -> [
+               `Line (sprintf "| %s%s -> %S" tick ocaml_cons json_cons);
+             ]
+           | Some _ -> [
+               `Line (sprintf "| %s%s _ -> %S" tick ocaml_cons json_cons);
+             ]
        ))@[ `Line (sprintf ") () %s" v)]
 
 let rec make_writer p (x : oj_mapping) : Indent.t list =
   match x with
-      `Unit _
-    | `Bool _
-    | `Int _
-    | `Float _
-    | `String _
-    | `Name _
-    | `External _
-    | `Tvar _ -> [ `Line (get_writer_name p x) ]
+    Unit _
+  | Bool _
+  | Int _
+  | Float _
+  | String _
+  | Name _
+  | External _
+  | Tvar _ -> [ `Line (get_writer_name p x) ]
 
-    | `Sum _ -> make_sum_writer p x make_variant_writer
+  | Sum _ -> make_sum_writer p x make_variant_writer
 
-    | `Record (_, a, `Record o, `Record _) ->
-        [
-          `Annot ("fun", `Line "fun ob x ->");
-          `Block (make_record_writer p a o);
+  | Record (_, a, `Record o, `Record _) ->
+      [
+        `Annot ("fun", `Line "fun ob x ->");
+        `Block (make_record_writer p a o);
+      ]
+
+  | Tuple (_, a, `Tuple, `Tuple) ->
+      let len = Array.length a in
+      let a =
+        Array.mapi (
+          fun i x ->
+            `Inline [
+              `Line (sprintf "(let %s = x in" (Ox_emit.nth "x" i len));
+              `Line "(";
+              `Block (make_writer p x.cel_value);
+              `Line ") ob x";
+              `Line ");"
+            ]
+        ) a
+      in
+      let l =
+        insert (`Line "Bi_outbuf.add_char ob ',';") (Array.to_list a)
+      in
+      let op, cl =
+        if p.std then '[', ']'
+        else '(', ')'
+      in
+      [
+        `Annot ("fun", `Line "fun ob x ->");
+        `Block [
+          `Line (sprintf "Bi_outbuf.add_char ob %C;" op);
+          `Inline l;
+          `Line (sprintf "Bi_outbuf.add_char ob %C;" cl);
         ]
+      ]
 
-    | `Tuple (_, a, `Tuple, `Tuple) ->
-        let len = Array.length a in
-        let a =
-          Array.mapi (
-            fun i x ->
-              `Inline [
-                `Line (sprintf "(let %s = x in" (Ox_emit.nth "x" i len));
-                `Line "(";
-                `Block (make_writer p x.cel_value);
-                `Line ") ob x";
-                `Line ");"
-              ]
-          ) a
-        in
-        let l =
-          insert (`Line "Bi_outbuf.add_char ob ',';") (Array.to_list a)
-        in
-        let op, cl =
-          if p.std then '[', ']'
-          else '(', ')'
-        in
-        [
-          `Annot ("fun", `Line "fun ob x ->");
-          `Block [
-            `Line (sprintf "Bi_outbuf.add_char ob %C;" op);
-            `Inline l;
-            `Line (sprintf "Bi_outbuf.add_char ob %C;" cl);
-          ]
-        ]
+  | List (loc, x, `List o, `List j) ->
+      (match j with
+         `Array ->
+           let write =
+             match o with
+               List -> "Atdgen_runtime.Oj_run.write_list ("
+             | Array -> "Atdgen_runtime.Oj_run.write_array ("
+           in
+           [
+             `Line write;
+             `Block (make_writer p x);
+             `Line ")";
+           ]
 
-    | `List (loc, x, `List o, `List j) ->
-        (match j with
-             `Array ->
-               let write =
-                 match o with
-                     List -> "Atdgen_runtime.Oj_run.write_list ("
-                   | Array -> "Atdgen_runtime.Oj_run.write_array ("
-               in
-               [
-                 `Line write;
-                 `Block (make_writer p x);
-                 `Line ")";
-               ]
+       | `Object ->
+           let k, v = get_assoc_type p.deref loc x in
+           let write =
+             match o with
+               List -> "Atdgen_runtime.Oj_run.write_assoc_list ("
+             | Array -> "Atdgen_runtime.Oj_run.write_assoc_array ("
+           in
+           [
+             `Line write;
+             `Block (make_writer p k);
+             `Line ") (";
+             `Block (make_writer p v);
+             `Line ")";
+           ]
+      )
 
-           | `Object ->
-               let k, v = get_assoc_type p.deref loc x in
-               let write =
-                 match o with
-                     List -> "Atdgen_runtime.Oj_run.write_assoc_list ("
-                   | Array -> "Atdgen_runtime.Oj_run.write_assoc_array ("
-               in
-               [
-                 `Line write;
-                 `Block (make_writer p k);
-                 `Line ") (";
-                 `Block (make_writer p v);
-                 `Line ")";
-               ]
-        )
+  | Option (_, x, `Option, `Option) ->
+      [
+        `Line (sprintf "Atdgen_runtime.Oj_run.write_%soption ("
+                 (if p.std then "std_" else ""));
+        `Block (make_writer p x);
+        `Line ")";
+      ]
 
-    | `Option (_, x, `Option, `Option) ->
-        [
-          `Line (sprintf "Atdgen_runtime.Oj_run.write_%soption ("
-                   (if p.std then "std_" else ""));
-          `Block (make_writer p x);
-          `Line ")";
-        ]
+  | Nullable (_, x, `Nullable, `Nullable) ->
+      [
+        `Line "Atdgen_runtime.Oj_run.write_nullable (";
+        `Block (make_writer p x);
+        `Line ")";
+      ]
 
-    | `Nullable (_, x, `Nullable, `Nullable) ->
-        [
-          `Line "Atdgen_runtime.Oj_run.write_nullable (";
-          `Block (make_writer p x);
-          `Line ")";
-        ]
+  | Wrap (_, x, `Wrap o, `Wrap) ->
+      (match o with
+         None -> make_writer p x
+       | Some { Ocaml.ocaml_unwrap; _} ->
+           [
+             `Line "fun ob x -> (";
+             `Block [
+               `Line (sprintf "let x = ( %s ) x in (" ocaml_unwrap);
+               `Block (make_writer p x);
+               `Line ") ob x)";
+             ]
+           ]
+      )
 
-    | `Wrap (_, x, `Wrap o, `Wrap) ->
-        (match o with
-            None -> make_writer p x
-          | Some { Ocaml.ocaml_unwrap; _} ->
-              [
-                `Line "fun ob x -> (";
-                `Block [
-                  `Line (sprintf "let x = ( %s ) x in (" ocaml_unwrap);
-                  `Block (make_writer p x);
-                  `Line ") ob x)";
-                ]
-              ]
-        )
-
-    | _ -> assert false
+  | _ -> assert false
 
 
 
@@ -866,16 +866,16 @@ let study_record p fields =
 
 let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
   match x with
-      `Unit _
-    | `Bool _
-    | `Int _
-    | `Float _
-    | `String _
-    | `Name _
-    | `External _
-    | `Tvar _ -> [ `Line (get_reader_name p x) ]
+      Unit _
+    | Bool _
+    | Int _
+    | Float _
+    | String _
+    | Name _
+    | External _
+    | Tvar _ -> [ `Line (get_reader_name p x) ]
 
-    | `Sum (_, a, `Sum x, `Sum) ->
+    | Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
               Classic -> ""
@@ -992,7 +992,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           ]
         ]
 
-    | `Record (loc, a, `Record o, `Record j) ->
+    | Record (loc, a, `Record o, `Record j) ->
         (match o with
              `Record -> ()
            | `Object ->
@@ -1003,13 +1003,13 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           `Block (make_record_reader p type_annot loc a j)
         ]
 
-    | `Tuple (_, a, `Tuple, `Tuple) ->
+    | Tuple (_, a, `Tuple, `Tuple) ->
         [
           `Annot ("fun", `Line "fun p lb ->");
           `Block (make_tuple_reader p a);
         ]
 
-    | `List (loc, x, `List o, `List j) ->
+    | List (loc, x, `List o, `List j) ->
         (match j with
              `Array ->
                let read =
@@ -1039,7 +1039,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
                ]
         )
 
-    | `Option (loc, x, `Option, `Option) ->
+    | Option (loc, x, `Option, `Option) ->
 
         let a = [|
           {
@@ -1060,9 +1060,9 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           };
         |]
         in
-        make_reader p (Some "_ option") (`Sum (loc, a, `Sum Classic, `Sum))
+        make_reader p (Some "_ option") (Sum (loc, a, `Sum Classic, `Sum))
 
-    | `Nullable (_, x, `Nullable, `Nullable) ->
+    | Nullable (_, x, `Nullable, `Nullable) ->
         [
           `Line "fun p lb ->";
           `Block [
@@ -1074,7 +1074,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           ]
         ]
 
-    | `Wrap (_, x, `Wrap o, `Wrap) ->
+    | Wrap (_, x, `Wrap o, `Wrap) ->
         (match o with
             None -> make_reader p type_annot x
           | Some { Ocaml.ocaml_wrap; _ } ->
@@ -1192,7 +1192,7 @@ and make_deconstructed_reader p loc fields set_bit =
       | Checked k -> [set_bit k]
     in
     match p.deref mapping.f_value with
-    | `Sum (loc, a, `Sum x, `Sum) ->
+    | Sum (loc, a, `Sum x, `Sum) ->
       let s = string_expr_of_constr_field p v_of_field constrf in
       let tick =
         match x with

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1908,7 +1908,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ocaml.ocaml_of_atd ~pp_convs ~target:`Json ~type_aliases (head, m1) in
+    Ocaml.ocaml_of_atd ~pp_convs ~target:Json ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -388,7 +388,7 @@ let get_left_of_string_name p name param =
 let destruct_sum (x : oj_mapping) =
   match x with
       `Sum (_, a, `Sum x, `Sum) ->
-        let tick = match x with `Classic -> "" | `Poly -> "`" in
+        let tick = match x with Classic -> "" | Poly -> "`" in
         tick, a
     | `Unit _ -> error (loc_of_mapping x) "Cannot destruct unit"
     | `Bool _ -> error (loc_of_mapping x) "Cannot destruct bool"
@@ -878,8 +878,8 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
     | `Sum (_, a, `Sum x, `Sum) ->
         let tick =
           match x with
-              `Classic -> ""
-            | `Poly -> "`"
+              Classic -> ""
+            | Poly -> "`"
         in
 
         let invalid_variant_tag =
@@ -1060,7 +1060,7 @@ let rec make_reader p type_annot (x : oj_mapping) : Indent.t list =
           };
         |]
         in
-        make_reader p (Some "_ option") (`Sum (loc, a, `Sum `Classic, `Sum))
+        make_reader p (Some "_ option") (`Sum (loc, a, `Sum Classic, `Sum))
 
     | `Nullable (_, x, `Nullable, `Nullable) ->
         [
@@ -1196,8 +1196,8 @@ and make_deconstructed_reader p loc fields set_bit =
       let s = string_expr_of_constr_field p v_of_field constrf in
       let tick =
         match x with
-          `Classic -> ""
-        | `Poly -> "`"
+          Classic -> ""
+        | Poly -> "`"
       in
 
       let invalid_variant_tag =

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1783,10 +1783,10 @@ let check_variant untypeds = function
       if not (Atd.Annot.get_flag ["json"] "untyped" ann)
       then untypeds
       else match arg with
-        | Some (`Tuple (_,[(_, `Name (_, (_, "string", _), _), _);
-                           (_, `Option (_,
-                                        `Name (_, (_, "json", _), _), _), _)],
-                        _)) -> cons::untypeds
+        | Some (Tuple (_,[(_, Name (_, (_, "string", _), _), _);
+                          (_, Option (_,
+                                      Name (_, (_, "json", _), _), _), _)],
+                       _)) -> cons::untypeds
         | Some typ ->
             let msg = sprintf "constructor is untyped but argument is %s\n%s"
                 (Atd.Print.string_of_type_expr typ)
@@ -1806,7 +1806,7 @@ let error_too_many_untypeds name untypeds =
 
 let check_atd (_head, body) =
   List.iter (function
-    | (Atd.Ast.Type (loc, (name, _, _), `Sum (_, conss, _))) ->
+    | (Atd.Ast.Type (loc, (name, _, _), Sum (_, conss, _))) ->
         begin match List.fold_left check_variant [] conss with
           | [] | [_] -> ()
           | untypeds ->

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -11,13 +11,13 @@ type oj_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 let rec mapping_of_expr (x : type_expr) : oj_mapping =
   match x with
     `Sum (loc, l, an) ->
-      let ocaml_t = `Sum (Ocaml.get_ocaml_sum an) in
+      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
       let json_t = Json.Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, json_t)
 
   | `Record (loc, l, an) ->
-      let ocaml_t = `Record (Ocaml.get_ocaml_record an) in
+      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
       let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
       let json_t = Json.Record (Json.get_json_record an) in
       Record (loc,
@@ -26,23 +26,23 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
               ocaml_t, json_t)
 
   | `Tuple (loc, l, _) ->
-      let ocaml_t = `Tuple in
+      let ocaml_t = Ocaml.Repr.Tuple in
       let json_t = Json.Tuple in
       Tuple (loc, Array.of_list (List.map mapping_of_cell l),
              ocaml_t, json_t)
 
   | `List (loc, x, an) ->
-      let ocaml_t = `List (Ocaml.get_ocaml_list an) in
+      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
       let json_t = Json.List (Json.get_json_list an) in
       List (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Option (loc, x, _) ->
-      let ocaml_t = `Option in
+      let ocaml_t = Ocaml.Repr.Option in
       let json_t = Json.Option in
       Option (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Nullable (loc, x, _) ->
-      let ocaml_t = `Nullable in
+      let ocaml_t = Ocaml.Repr.Nullable in
       let json_t = Json.Nullable in
       Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
@@ -50,24 +50,24 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
       error loc "Sharing is not supported by the JSON interface"
 
   | `Wrap (loc, x, an) ->
-      let ocaml_t = `Wrap (Ocaml.get_ocaml_wrap loc an) in
+      let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc an) in
       let json_t = Json.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Name (loc, (_, s, l), an) ->
       (match s with
          "unit" ->
-           Unit (loc, `Unit, Unit)
+           Unit (loc, Unit, Unit)
        | "bool" ->
-           Bool (loc, `Bool, Bool)
+           Bool (loc, Bool, Bool)
        | "int" ->
            let o = Ocaml.get_ocaml_int an in
-           Int (loc, `Int o, Int)
+           Int (loc, Int o, Int)
        | "float" ->
            let j = Json.get_json_float an in
-           Float (loc, `Float, Float j)
+           Float (loc, Float, Float j)
        | "string" ->
-           String (loc, `String, String)
+           String (loc, String, String)
        | s ->
            Name (loc, s, List.map mapping_of_expr l, None, None)
       )
@@ -78,7 +78,7 @@ and mapping_of_cell (loc, x, an) =
   let default = Ocaml.get_ocaml_default an in
   let doc = Doc.get_doc loc an in
   let ocaml_t =
-    `Cell {
+    Ocaml.Repr.Cell {
       Ocaml.ocaml_default = default;
       ocaml_fname = "";
       ocaml_mutable = false;
@@ -99,7 +99,7 @@ and mapping_of_variant = function
       let ocaml_cons = Ocaml.get_ocaml_cons s an in
       let doc = Doc.get_doc loc an in
       let ocaml_t =
-        `Variant {
+        Ocaml.Repr.Variant {
           Ocaml.ocaml_cons = ocaml_cons;
           ocaml_vdoc = doc;
         }
@@ -149,7 +149,7 @@ and mapping_of_field ocaml_field_prefix = function
         f_kind = fk;
         f_value = fvalue;
 
-        f_arepr = `Field {
+        f_arepr = Ocaml.Repr.Field {
           Ocaml.ocaml_default = ocaml_default;
           ocaml_fname = ocaml_fname;
           ocaml_mutable = ocaml_mutable;
@@ -178,7 +178,7 @@ let def_of_atd (loc, (name, param, an), x) =
              let args = List.map (fun s -> Tvar (loc, s)) param in
              Some (External
                      (loc, name, args,
-                      `External (types_module, main_module, ext_name),
+                      Ocaml.Repr.External (types_module, main_module, ext_name),
                       Json.External))
         )
     | None -> Some (mapping_of_expr x)
@@ -188,7 +188,8 @@ let def_of_atd (loc, (name, param, an), x) =
     def_name = name;
     def_param = param;
     def_value = o;
-    def_arepr = `Def { Ocaml.ocaml_predef = ocaml_predef;
+    def_arepr =
+      Ocaml.Repr.Def { Ocaml.ocaml_predef = ocaml_predef;
                        ocaml_ddoc = doc };
     def_brepr = Def;
   }

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -14,69 +14,69 @@ type oj_mapping =
 
 let rec mapping_of_expr (x : type_expr) : oj_mapping =
   match x with
-      `Sum (loc, l, an) ->
-        let ocaml_t = `Sum (Ocaml.get_ocaml_sum an) in
-        let json_t = `Sum in
-        `Sum (loc, Array.of_list (List.map mapping_of_variant l),
+    `Sum (loc, l, an) ->
+      let ocaml_t = `Sum (Ocaml.get_ocaml_sum an) in
+      let json_t = `Sum in
+      Sum (loc, Array.of_list (List.map mapping_of_variant l),
+           ocaml_t, json_t)
+
+  | `Record (loc, l, an) ->
+      let ocaml_t = `Record (Ocaml.get_ocaml_record an) in
+      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
+      let json_t = `Record (Json.get_json_record an) in
+      Record (loc,
+              Array.of_list
+                (List.map (mapping_of_field ocaml_field_prefix) l),
               ocaml_t, json_t)
 
-    | `Record (loc, l, an) ->
-        let ocaml_t = `Record (Ocaml.get_ocaml_record an) in
-        let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
-        let json_t = `Record (Json.get_json_record an) in
-        `Record (loc,
-                 Array.of_list
-                   (List.map (mapping_of_field ocaml_field_prefix) l),
-                 ocaml_t, json_t)
+  | `Tuple (loc, l, _) ->
+      let ocaml_t = `Tuple in
+      let json_t = `Tuple in
+      Tuple (loc, Array.of_list (List.map mapping_of_cell l),
+             ocaml_t, json_t)
 
-    | `Tuple (loc, l, _) ->
-        let ocaml_t = `Tuple in
-        let json_t = `Tuple in
-        `Tuple (loc, Array.of_list (List.map mapping_of_cell l),
-                ocaml_t, json_t)
+  | `List (loc, x, an) ->
+      let ocaml_t = `List (Ocaml.get_ocaml_list an) in
+      let json_t = `List (Json.get_json_list an) in
+      List (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `List (loc, x, an) ->
-        let ocaml_t = `List (Ocaml.get_ocaml_list an) in
-        let json_t = `List (Json.get_json_list an) in
-        `List (loc, mapping_of_expr x, ocaml_t, json_t)
+  | `Option (loc, x, _) ->
+      let ocaml_t = `Option in
+      let json_t = `Option in
+      Option (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Option (loc, x, _) ->
-        let ocaml_t = `Option in
-        let json_t = `Option in
-        `Option (loc, mapping_of_expr x, ocaml_t, json_t)
+  | `Nullable (loc, x, _) ->
+      let ocaml_t = `Nullable in
+      let json_t = `Nullable in
+      Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Nullable (loc, x, _) ->
-        let ocaml_t = `Nullable in
-        let json_t = `Nullable in
-        `Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
+  | `Shared (loc, _, _) ->
+      error loc "Sharing is not supported by the JSON interface"
 
-    | `Shared (loc, _, _) ->
-        error loc "Sharing is not supported by the JSON interface"
+  | `Wrap (loc, x, an) ->
+      let ocaml_t = `Wrap (Ocaml.get_ocaml_wrap loc an) in
+      let json_t = `Wrap in
+      Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
-    | `Wrap (loc, x, an) ->
-        let ocaml_t = `Wrap (Ocaml.get_ocaml_wrap loc an) in
-        let json_t = `Wrap in
-        `Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
-
-    | `Name (loc, (_, s, l), an) ->
-        (match s with
-             "unit" ->
-               `Unit (loc, `Unit, `Unit)
-           | "bool" ->
-               `Bool (loc, `Bool, `Bool)
-           | "int" ->
-               let o = Ocaml.get_ocaml_int an in
-               `Int (loc, `Int o, `Int)
-           | "float" ->
-               let j = Json.get_json_float an in
-               `Float (loc, `Float, `Float j)
-           | "string" ->
-               `String (loc, `String, `String)
-           | s ->
-               `Name (loc, s, List.map mapping_of_expr l, None, None)
-        )
-    | `Tvar (loc, s) ->
-        `Tvar (loc, s)
+  | `Name (loc, (_, s, l), an) ->
+      (match s with
+         "unit" ->
+           Unit (loc, `Unit, `Unit)
+       | "bool" ->
+           Bool (loc, `Bool, `Bool)
+       | "int" ->
+           let o = Ocaml.get_ocaml_int an in
+           Int (loc, `Int o, `Int)
+       | "float" ->
+           let j = Json.get_json_float an in
+           Float (loc, `Float, `Float j)
+       | "string" ->
+           String (loc, `String, `String)
+       | s ->
+           Name (loc, s, List.map mapping_of_expr l, None, None)
+      )
+  | `Tvar (loc, s) ->
+      Tvar (loc, s)
 
 and mapping_of_cell (loc, x, an) =
   let default = Ocaml.get_ocaml_default an in
@@ -175,17 +175,17 @@ let def_of_atd (loc, (name, param, an), x) =
   let doc = Doc.get_doc loc an in
   let o =
     match as_abstract x with
-        Some (_, _) ->
-          (match Ocaml.get_ocaml_module_and_t Json name an with
-               None -> None
-             | Some (types_module, main_module, ext_name) ->
-                 let args = List.map (fun s -> `Tvar (loc, s)) param in
-                 Some (`External
-                         (loc, name, args,
-                          `External (types_module, main_module, ext_name),
-                          `External))
-          )
-      | None -> Some (mapping_of_expr x)
+      Some (_, _) ->
+        (match Ocaml.get_ocaml_module_and_t Json name an with
+           None -> None
+         | Some (types_module, main_module, ext_name) ->
+             let args = List.map (fun s -> Tvar (loc, s)) param in
+             Some (External
+                     (loc, name, args,
+                      `External (types_module, main_module, ext_name),
+                      `External))
+        )
+    | None -> Some (mapping_of_expr x)
   in
   {
     def_loc = loc;

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -129,15 +129,15 @@ and mapping_of_field ocaml_field_prefix = function
     `Field (loc, (s, fk, an), x) ->
       let fvalue = mapping_of_expr x in
       let ocaml_default, json_unwrapped =
-       match fk, Ocaml.get_ocaml_default an with
-           `Required, None -> None, false
-         | `Optional, None -> Some "None", true
-         | (`Required | `Optional), Some _ ->
-             error loc "Superfluous default OCaml value"
-         | `With_default, Some s -> Some s, false
-         | `With_default, None ->
-             (* will try to determine implicit default value later *)
-             None, false
+        match fk, Ocaml.get_ocaml_default an with
+          Required, None -> None, false
+        | Optional, None -> Some "None", true
+        | (Required | Optional), Some _ ->
+            error loc "Superfluous default OCaml value"
+        | With_default, Some s -> Some s, false
+        | With_default, None ->
+            (* will try to determine implicit default value later *)
+            None, false
       in
       let ocaml_fname = Ocaml.get_ocaml_fname (ocaml_field_prefix ^ s) an in
       let ocaml_mutable = Ocaml.get_ocaml_mutable an in

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -195,7 +195,7 @@ let def_of_atd (loc, (name, param, an), x) =
   }
 
 let defs_of_atd_module l =
-  List.map (function `Type def -> def_of_atd def) l
+  List.map (function Atd.Ast.Type def -> def_of_atd def) l
 
 let defs_of_atd_modules l =
   List.map (fun (is_rec, l) -> (is_rec, defs_of_atd_module l)) l

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -166,33 +166,9 @@ and mapping_of_field ocaml_field_prefix = function
   | `Inherit _ -> assert false
 
 
-let def_of_atd (loc, (name, param, an), x) =
-  let ocaml_predef = Ocaml.get_ocaml_predef Json an in
-  let doc = Doc.get_doc loc an in
-  let o =
-    match as_abstract x with
-      Some (_, _) ->
-        (match Ocaml.get_ocaml_module_and_t Json name an with
-           None -> None
-         | Some (types_module, main_module, ext_name) ->
-             let args = List.map (fun s -> Tvar (loc, s)) param in
-             Some (External
-                     (loc, name, args,
-                      Ocaml.Repr.External (types_module, main_module, ext_name),
-                      Json.External))
-        )
-    | None -> Some (mapping_of_expr x)
-  in
-  {
-    def_loc = loc;
-    def_name = name;
-    def_param = param;
-    def_value = o;
-    def_arepr =
-      Ocaml.Repr.Def { Ocaml.ocaml_predef = ocaml_predef;
-                       ocaml_ddoc = doc };
-    def_brepr = Def;
-  }
+let def_of_atd atd =
+  Ox_emit.def_of_atd atd ~target:Json ~external_:Json.External
+    ~mapping_of_expr ~def:Json.Def
 
 let defs_of_atd_module l =
   List.map (function Atd.Ast.Type def -> def_of_atd def) l

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -95,7 +95,7 @@ and mapping_of_cell (loc, x, an) =
 
 
 and mapping_of_variant = function
-    `Variant (loc, (s, an), o) ->
+    Variant (loc, (s, an), o) ->
       let ocaml_cons = Ocaml.get_ocaml_cons s an in
       let doc = Doc.get_doc loc an in
       let ocaml_t =
@@ -113,8 +113,8 @@ and mapping_of_variant = function
       in
       let arg =
         match o with
-            None -> None
-          | Some x -> Some (mapping_of_expr x) in
+          None -> None
+        | Some x -> Some (mapping_of_expr x) in
       {
         var_loc = loc;
         var_cons = s;
@@ -123,7 +123,7 @@ and mapping_of_variant = function
         var_brepr = json_t
       }
 
-  | `Inherit _ -> assert false
+  | Inherit _ -> assert false
 
 and mapping_of_field ocaml_field_prefix = function
     `Field (loc, (s, fk, an), x) ->

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -171,12 +171,12 @@ and mapping_of_field ocaml_field_prefix = function
 
 
 let def_of_atd (loc, (name, param, an), x) =
-  let ocaml_predef = Ocaml.get_ocaml_predef `Json an in
+  let ocaml_predef = Ocaml.get_ocaml_predef Json an in
   let doc = Doc.get_doc loc an in
   let o =
     match as_abstract x with
         Some (_, _) ->
-          (match Ocaml.get_ocaml_module_and_t `Json name an with
+          (match Ocaml.get_ocaml_module_and_t Json name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->
                  let args = List.map (fun s -> `Tvar (loc, s)) param in

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -2,11 +2,7 @@ open Atd.Ast
 open Error
 open Mapping
 
-type o = Ocaml.atd_ocaml_repr
-type j = Json.json_repr
-
-type oj_mapping =
-    (Ocaml.atd_ocaml_repr, Json.json_repr) Mapping.mapping
+type oj_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 
 (*
   Translation of the types into the ocaml/json mapping.

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -10,13 +10,13 @@ type oj_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 
 let rec mapping_of_expr (x : type_expr) : oj_mapping =
   match x with
-    `Sum (loc, l, an) ->
+    Sum (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
       let json_t = Json.Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, json_t)
 
-  | `Record (loc, l, an) ->
+  | Record (loc, l, an) ->
       let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
       let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
       let json_t = Json.Record (Json.get_json_record an) in
@@ -25,36 +25,36 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
                 (List.map (mapping_of_field ocaml_field_prefix) l),
               ocaml_t, json_t)
 
-  | `Tuple (loc, l, _) ->
+  | Tuple (loc, l, _) ->
       let ocaml_t = Ocaml.Repr.Tuple in
       let json_t = Json.Tuple in
       Tuple (loc, Array.of_list (List.map mapping_of_cell l),
              ocaml_t, json_t)
 
-  | `List (loc, x, an) ->
+  | List (loc, x, an) ->
       let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
       let json_t = Json.List (Json.get_json_list an) in
       List (loc, mapping_of_expr x, ocaml_t, json_t)
 
-  | `Option (loc, x, _) ->
+  | Option (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Option in
       let json_t = Json.Option in
       Option (loc, mapping_of_expr x, ocaml_t, json_t)
 
-  | `Nullable (loc, x, _) ->
+  | Nullable (loc, x, _) ->
       let ocaml_t = Ocaml.Repr.Nullable in
       let json_t = Json.Nullable in
       Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
-  | `Shared (loc, _, _) ->
+  | Shared (loc, _, _) ->
       error loc "Sharing is not supported by the JSON interface"
 
-  | `Wrap (loc, x, an) ->
+  | Wrap (loc, x, an) ->
       let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc an) in
       let json_t = Json.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
-  | `Name (loc, (_, s, l), an) ->
+  | Name (loc, (_, s, l), an) ->
       (match s with
          "unit" ->
            Unit (loc, Unit, Unit)
@@ -71,7 +71,7 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
        | s ->
            Name (loc, s, List.map mapping_of_expr l, None, None)
       )
-  | `Tvar (loc, s) ->
+  | Tvar (loc, s) ->
       Tvar (loc, s)
 
 and mapping_of_cell (loc, x, an) =

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -16,14 +16,14 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
   match x with
     `Sum (loc, l, an) ->
       let ocaml_t = `Sum (Ocaml.get_ocaml_sum an) in
-      let json_t = `Sum in
+      let json_t = Json.Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, json_t)
 
   | `Record (loc, l, an) ->
       let ocaml_t = `Record (Ocaml.get_ocaml_record an) in
       let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
-      let json_t = `Record (Json.get_json_record an) in
+      let json_t = Json.Record (Json.get_json_record an) in
       Record (loc,
               Array.of_list
                 (List.map (mapping_of_field ocaml_field_prefix) l),
@@ -31,23 +31,23 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
 
   | `Tuple (loc, l, _) ->
       let ocaml_t = `Tuple in
-      let json_t = `Tuple in
+      let json_t = Json.Tuple in
       Tuple (loc, Array.of_list (List.map mapping_of_cell l),
              ocaml_t, json_t)
 
   | `List (loc, x, an) ->
       let ocaml_t = `List (Ocaml.get_ocaml_list an) in
-      let json_t = `List (Json.get_json_list an) in
+      let json_t = Json.List (Json.get_json_list an) in
       List (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Option (loc, x, _) ->
       let ocaml_t = `Option in
-      let json_t = `Option in
+      let json_t = Json.Option in
       Option (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Nullable (loc, x, _) ->
       let ocaml_t = `Nullable in
-      let json_t = `Nullable in
+      let json_t = Json.Nullable in
       Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Shared (loc, _, _) ->
@@ -55,23 +55,23 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
 
   | `Wrap (loc, x, an) ->
       let ocaml_t = `Wrap (Ocaml.get_ocaml_wrap loc an) in
-      let json_t = `Wrap in
+      let json_t = Json.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | `Name (loc, (_, s, l), an) ->
       (match s with
          "unit" ->
-           Unit (loc, `Unit, `Unit)
+           Unit (loc, `Unit, Unit)
        | "bool" ->
-           Bool (loc, `Bool, `Bool)
+           Bool (loc, `Bool, Bool)
        | "int" ->
            let o = Ocaml.get_ocaml_int an in
-           Int (loc, `Int o, `Int)
+           Int (loc, `Int o, Int)
        | "float" ->
            let j = Json.get_json_float an in
-           Float (loc, `Float, `Float j)
+           Float (loc, `Float, Float j)
        | "string" ->
-           String (loc, `String, `String)
+           String (loc, `String, String)
        | s ->
            Name (loc, s, List.map mapping_of_expr l, None, None)
       )
@@ -89,7 +89,7 @@ and mapping_of_cell (loc, x, an) =
       ocaml_fdoc = doc;
     }
   in
-  let json_t = `Cell in
+  let json_t = Json.Cell in
   {
     cel_loc = loc;
     cel_value = mapping_of_expr x;
@@ -110,10 +110,10 @@ and mapping_of_variant = function
       in
       let json_t =
         if Json.get_json_untyped an
-        then `Variant { Json.json_cons = None; }
+        then Json.Variant { Json.json_cons = None; }
         else
           let json_cons = Json.get_json_cons s an in
-          `Variant { Json.json_cons = Some json_cons; }
+          Json.Variant { Json.json_cons = Some json_cons; }
       in
       let arg =
         match o with
@@ -160,7 +160,7 @@ and mapping_of_field ocaml_field_prefix = function
           ocaml_fdoc = doc;
         };
 
-        f_brepr = `Field {
+        f_brepr = Json.Field {
           Json.json_fname;
           json_tag_field;
           json_unwrapped;
@@ -183,7 +183,7 @@ let def_of_atd (loc, (name, param, an), x) =
              Some (External
                      (loc, name, args,
                       `External (types_module, main_module, ext_name),
-                      `External))
+                      Json.External))
         )
     | None -> Some (mapping_of_expr x)
   in
@@ -194,7 +194,7 @@ let def_of_atd (loc, (name, param, an), x) =
     def_value = o;
     def_arepr = `Def { Ocaml.ocaml_predef = ocaml_predef;
                        ocaml_ddoc = doc };
-    def_brepr = `Def;
+    def_brepr = Def;
   }
 
 let defs_of_atd_module l =

--- a/atdgen/src/oj_mapping.mli
+++ b/atdgen/src/oj_mapping.mli
@@ -6,9 +6,5 @@ type oj_mapping =
     (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 
 val defs_of_atd_modules
-  : ('a *
-     [< `Type of
-          Atd.Ast.loc * (string * string list * Atd.Annot.t) * Atd.Ast.type_expr ]
-       list
-    ) list
+  : ('a * Atd.Ast.module_body) list
   -> ('a * (Ocaml.Repr.t, Json.json_repr) Mapping.def list) list

--- a/atdgen/src/oj_mapping.mli
+++ b/atdgen/src/oj_mapping.mli
@@ -2,11 +2,8 @@
 
     Please don't rely on them in any way.*)
 
-type o = Ocaml.atd_ocaml_repr
-type j = Json.json_repr
-
 type oj_mapping =
-    (Ocaml.atd_ocaml_repr, Json.json_repr) Mapping.mapping
+    (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 
 val defs_of_atd_modules
   : ('a *
@@ -14,4 +11,4 @@ val defs_of_atd_modules
           Atd.Ast.loc * (string * string list * Atd.Annot.t) * Atd.Ast.type_expr ]
        list
     ) list
-  -> ('a * (Ocaml.atd_ocaml_repr, Json.json_repr) Mapping.def list) list
+  -> ('a * (Ocaml.Repr.t, Json.json_repr) Mapping.def list) list

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -323,8 +323,8 @@ and make_variant_validator tick x :
 and make_record_validator a record_kind =
   let dot =
     match record_kind with
-        `Record -> "."
-      | `Object -> "#"
+        Record -> "."
+      | Object -> "#"
   in
   let fields = get_fields a in
   assert (fields <> []);

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -267,8 +267,8 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
         else
           let validate =
             match o with
-                `List -> "Atdgen_runtime.Ov_run.validate_list ("
-              | `Array -> "Atdgen_runtime.Ov_run.validate_array ("
+                List -> "Atdgen_runtime.Ov_run.validate_list ("
+              | Array -> "Atdgen_runtime.Ov_run.validate_array ("
           in
           prepend_validator_f v [
             `Line validate;

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -47,15 +47,15 @@ let get_fields a =
     List.map (
       fun x ->
         match x.f_arepr with
-            `Field o -> (x, o.Ocaml.ocaml_fname)
-          | _ -> assert false
+          Ocaml.Repr.Field o -> (x, o.Ocaml.ocaml_fname)
+        | _ -> assert false
     )
       (Array.to_list a)
   in
   List.filter (
     function
-        { f_brepr = (None, shallow) ; _ }, _ -> not shallow
-      | _ -> assert false
+      { f_brepr = (None, shallow) ; _ }, _ -> not shallow
+    | _ -> assert false
   ) all
 
 let rec forall : Indent.t list -> Indent.t list = function
@@ -141,11 +141,11 @@ let rec get_validator_name
     (x : ov_mapping) : string =
 
   match x with
-    Unit (_, `Unit, v)
-  | Bool (_, `Bool, v)
-  | Int (_, `Int _, v)
-  | Float (_, `Float, v)
-  | String (_, `String, v) ->
+    Unit (_, Unit, v)
+  | Bool (_, Bool, v)
+  | Int (_, Int _, v)
+  | Float (_, Float, v)
+  | String (_, String, v) ->
       (match v with
          (None, true) -> return_true_paren
        | (Some s, true) -> s
@@ -168,7 +168,7 @@ let rec get_validator_name
       )
 
   | External (_, _, args,
-              `External (_, main_module, ext_name),
+              External (_, main_module, ext_name),
               v) ->
       (match v with
          (o, false) ->
@@ -200,7 +200,7 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
   | External _
   | Tvar _ -> [ `Line (get_validator_name x) ]
 
-  | Sum (_, a, `Sum x, (v, shallow)) ->
+  | Sum (_, a, Sum x, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -226,7 +226,7 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
           `Block (prepend_validator v body);
         ]
 
-  | Record (_, a, `Record o, (v, shallow)) ->
+  | Record (_, a, Record o, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -235,7 +235,7 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
           `Block (prepend_validator v (make_record_validator a o));
         ]
 
-  | Tuple (_, a, `Tuple, (v, shallow)) ->
+  | Tuple (_, a, Tuple, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -261,7 +261,7 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
           `Block (prepend_validator v l);
         ]
 
-  | List (_, x, `List o, (v, shallow)) ->
+  | List (_, x, List o, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -276,8 +276,8 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
           `Line ")";
         ]
 
-  | Option (_, x, `Option, (v, shallow))
-  | Nullable (_, x, `Nullable, (v, shallow)) ->
+  | Option (_, x, Option, (v, shallow))
+  | Nullable (_, x, Nullable, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -287,7 +287,7 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
           `Line ")";
         ]
 
-  | Wrap (_, x, `Wrap _, (v, shallow)) ->
+  | Wrap (_, x, Wrap _, (v, shallow)) ->
       if shallow then
         opt_validator v
       else
@@ -301,7 +301,7 @@ and make_variant_validator tick x :
     Indent.t list =
   let o =
     match x.var_arepr, x.var_brepr with
-        `Variant o, (None, _) -> o
+        Variant o, (None, _) -> o
       | _ -> assert false
   in
   let ocaml_cons = o.Ocaml.ocaml_cons in

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -206,8 +206,8 @@ let rec make_validator (x : ov_mapping) : Indent.t list =
         else
           let tick =
             match x with
-                `Classic -> ""
-              | `Poly -> "`"
+                Classic -> ""
+              | Poly -> "`"
           in
           let body : Indent.t list =
             [

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -475,7 +475,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ocaml.ocaml_of_atd ~pp_convs ~target:`Validate ~type_aliases (head, m1) in
+    Ocaml.ocaml_of_atd ~pp_convs ~target:Validate ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -271,14 +271,14 @@ and mapping_of_field is_shallow ocaml_field_prefix = function
       let fvalue = mapping_of_expr is_shallow x in
       let ocaml_default =
         match fk, Ocaml.get_ocaml_default an with
-            `Required, None -> None
-          | `Optional, None -> Some "None"
-          | (`Required | `Optional), Some _ ->
-              error loc "Superfluous default OCaml value"
-          | `With_default, Some s -> Some s
-          | `With_default, None ->
-              (* will try to determine implicit default value later *)
-              None
+          Required, None -> None
+        | Optional, None -> Some "None"
+        | (Required | Optional), Some _ ->
+            error loc "Superfluous default OCaml value"
+        | With_default, Some s -> Some s
+        | With_default, None ->
+            (* will try to determine implicit default value later *)
+            None
       in
       let ocaml_fname = Ocaml.get_ocaml_fname (ocaml_field_prefix ^ s) an in
       let ocaml_mutable = Ocaml.get_ocaml_mutable an in

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -3,7 +3,7 @@ open Error
 open Mapping
 
 type ov_mapping =
-    (Ocaml.atd_ocaml_repr, Validate.validate_repr) Mapping.mapping
+    (Ocaml.Repr.t, Validate.validate_repr) Mapping.mapping
 
 (*
   Determine whether a type expression does not need validation.

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -152,13 +152,13 @@ let rec mapping_of_expr
   match x0 with
       `Sum (loc, l, an) ->
         let ocaml_t = `Sum (Ocaml.get_ocaml_sum an) in
-        `Sum (loc, Array.of_list (List.map (mapping_of_variant is_shallow) l),
+        Sum (loc, Array.of_list (List.map (mapping_of_variant is_shallow) l),
               ocaml_t, v2 an x0)
 
     | `Record (loc, l, an) ->
         let ocaml_t = `Record (Ocaml.get_ocaml_record an) in
         let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
-        `Record (loc,
+        Record (loc,
                  Array.of_list
                    (List.map
                       (mapping_of_field is_shallow ocaml_field_prefix) l),
@@ -166,20 +166,20 @@ let rec mapping_of_expr
 
     | `Tuple (loc, l, an) ->
         let ocaml_t = `Tuple in
-        `Tuple (loc, Array.of_list (List.map (mapping_of_cell is_shallow) l),
+        Tuple (loc, Array.of_list (List.map (mapping_of_cell is_shallow) l),
                 ocaml_t, v2 an x0)
 
     | `List (loc, x, an) ->
         let ocaml_t = `List (Ocaml.get_ocaml_list an) in
-        `List (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
+        List (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
 
     | `Option (loc, x, an) ->
         let ocaml_t = `Option in
-        `Option (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
+        Option (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
 
     | `Nullable (loc, x, an) ->
         let ocaml_t = `Nullable in
-        `Nullable (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
+        Nullable (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
 
     | `Shared (_, _, _) ->
         failwith "Sharing is not supported"
@@ -192,32 +192,32 @@ let rec mapping_of_expr
               None -> v2 an x0
             | Some _ -> v an, true
         in
-        `Wrap (loc, mapping_of_expr is_shallow x, ocaml_t, validator)
+        Wrap (loc, mapping_of_expr is_shallow x, ocaml_t, validator)
 
     | `Name (loc, (_, s, l), an) ->
         (match s with
-             "unit" ->
-               `Unit (loc, `Unit, (v an, true))
-           | "bool" ->
-               `Bool (loc, `Bool, (v an, true))
-           | "int" ->
-               let o = Ocaml.get_ocaml_int an in
-               `Int (loc, `Int o, (v an, true))
-           | "float" ->
-               `Float (loc, `Float, (v an, true))
-           | "string" ->
-               `String (loc, `String, (v an, true))
-           | s ->
-               let validator =
-                 match v2 an x0 with
-                     None, true -> None
-                   | x -> Some x
-               in
-               `Name (loc, s, List.map (mapping_of_expr is_shallow) l,
-                      None, validator)
+           "unit" ->
+             Unit (loc, `Unit, (v an, true))
+         | "bool" ->
+             Bool (loc, `Bool, (v an, true))
+         | "int" ->
+             let o = Ocaml.get_ocaml_int an in
+             Int (loc, `Int o, (v an, true))
+         | "float" ->
+             Float (loc, `Float, (v an, true))
+         | "string" ->
+             String (loc, `String, (v an, true))
+         | s ->
+             let validator =
+               match v2 an x0 with
+                 None, true -> None
+               | x -> Some x
+             in
+             Name (loc, s, List.map (mapping_of_expr is_shallow) l,
+                   None, validator)
         )
     | `Tvar (loc, s) ->
-        `Tvar (loc, s)
+        Tvar (loc, s)
 
 and mapping_of_cell is_shallow (loc, x, an) =
   let default = Ocaml.get_ocaml_default an in
@@ -310,8 +310,8 @@ let def_of_atd is_shallow (loc, (name, param, an), x) =
           (match Ocaml.get_ocaml_module_and_t Validate name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->
-                 let args = List.map (fun s -> `Tvar (loc, s)) param in
-                 Some (`External
+                 let args = List.map (fun s -> Tvar (loc, s)) param in
+                 Some (External
                          (loc, name, args,
                           `External (types_module, main_module, ext_name),
                           (Validate.get_validator an2, false))

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -239,7 +239,7 @@ and mapping_of_cell is_shallow (loc, x, an) =
 
 
 and mapping_of_variant is_shallow = function
-    `Variant (loc, (s, an), o) ->
+    Variant (loc, (s, an), o) ->
       let ocaml_cons = Ocaml.get_ocaml_cons s an in
       let doc = Doc.get_doc loc an in
       let ocaml_t =
@@ -250,11 +250,11 @@ and mapping_of_variant is_shallow = function
       in
       let arg, validate_t =
         match o with
-            None ->
-              None, (None, true)
-          | Some x ->
-              (Some (mapping_of_expr is_shallow x),
-               (None, noval x && is_shallow x))
+          None ->
+            None, (None, true)
+        | Some x ->
+            (Some (mapping_of_expr is_shallow x),
+             (None, noval x && is_shallow x))
       in
       {
         var_loc = loc;
@@ -264,7 +264,7 @@ and mapping_of_variant is_shallow = function
         var_brepr = validate_t;
       }
 
-  | `Inherit _ -> assert false
+  | Inherit _ -> assert false
 
 and mapping_of_field is_shallow ocaml_field_prefix = function
     `Field (loc, (s, fk, an), x) ->

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -332,7 +332,7 @@ let def_of_atd is_shallow (loc, (name, param, an), x) =
 
 let fill_def_tbl defs l =
   List.iter (
-    function `Type (_, (name, _, _), x) -> Hashtbl.add defs name x
+    function Atd.Ast.Type (_, (name, _, _), x) -> Hashtbl.add defs name x
   ) l
 
 let init_def_tbl () =
@@ -344,7 +344,7 @@ let make_def_tbl2 l =
   defs
 
 let defs_of_atd_module_gen is_shallow l =
-  List.map (function `Type def -> def_of_atd is_shallow def) l
+  List.map (function Atd.Ast.Type def -> def_of_atd is_shallow def) l
 
 let defs_of_atd_modules l =
   let defs = make_def_tbl2 l in

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -302,12 +302,12 @@ and mapping_of_field is_shallow ocaml_field_prefix = function
 
 
 let def_of_atd is_shallow (loc, (name, param, an), x) =
-  let ocaml_predef = Ocaml.get_ocaml_predef `Validate an in
+  let ocaml_predef = Ocaml.get_ocaml_predef Validate an in
   let doc = Doc.get_doc loc an in
   let o =
     match as_abstract x with
         Some (_, an2) ->
-          (match Ocaml.get_ocaml_module_and_t `Validate name an with
+          (match Ocaml.get_ocaml_module_and_t Validate name an with
                None -> None
              | Some (types_module, main_module, ext_name) ->
                  let args = List.map (fun s -> `Tvar (loc, s)) param in

--- a/atdgen/src/ov_mapping.mli
+++ b/atdgen/src/ov_mapping.mli
@@ -5,13 +5,6 @@
 type ov_mapping =
     (Ocaml.Repr.t, Validate.validate_repr) Mapping.mapping
 
-val defs_of_atd_modules :
-  ('a *
-   [< `Type of
-        Atd.Ast.loc * (string * string list * Atd.Annot.t) * Atd.Ast.type_expr &
-        'b * (string * 'c * 'd) * Atd.Ast.type_expr ]
-     list)
-    list ->
-  ('a *
-   (Ocaml.Repr.t, Validate.validate_repr) Mapping.def list)
-    list
+val defs_of_atd_modules
+  : ('a * Atd.Ast.module_body) list
+  -> ('a * (Ocaml.Repr.t, Validate.validate_repr) Mapping.def list) list

--- a/atdgen/src/ov_mapping.mli
+++ b/atdgen/src/ov_mapping.mli
@@ -3,7 +3,7 @@
     Please don't rely on them in any way.*)
 
 type ov_mapping =
-    (Ocaml.atd_ocaml_repr, Validate.validate_repr) Mapping.mapping
+    (Ocaml.Repr.t, Validate.validate_repr) Mapping.mapping
 
 val defs_of_atd_modules :
   ('a *
@@ -13,5 +13,5 @@ val defs_of_atd_modules :
      list)
     list ->
   ('a *
-   (Ocaml.atd_ocaml_repr, Validate.validate_repr) Mapping.def list)
+   (Ocaml.Repr.t, Validate.validate_repr) Mapping.def list)
     list

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -42,8 +42,8 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
       (match o with
          `Sum x ->
            (match x with
-              `Poly -> (fn, l :: pvn, cvn)
-            | `Classic ->
+              Poly -> (fn, l :: pvn, cvn)
+            | Classic ->
                 if is_root then (fn, pvn, l :: cvn)
                 else
                   error loc
@@ -202,7 +202,7 @@ let get_type_constraint ~original_types def =
 let needs_type_annot (x : _ expr) =
   match x with
   | `Record (_, _, `Record `Record, _)
-  | `Sum (_, _, `Sum `Classic, _) -> true
+  | `Sum (_, _, `Sum Classic, _) -> true
   | _ -> false
 
 let insert_annot type_annot =

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -201,7 +201,7 @@ let get_type_constraint ~original_types def =
    constructor/field name disambiguation *)
 let needs_type_annot (x : _ expr) =
   match x with
-  | Record (_, _, `Record `Record, _)
+  | Record (_, _, `Record Record, _)
   | Sum (_, _, `Sum Classic, _) -> true
   | _ -> false
 
@@ -254,7 +254,7 @@ let is_exportable def =
 
 let make_record_creator deref x =
   match x.def_value with
-    Some (Record (_, a, `Record `Record, _)) ->
+    Some (Record (_, a, `Record Ocaml.Record, _)) ->
       let s = x.def_name in
       let full_name = get_full_type_name x in
       let l =

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -40,7 +40,7 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
         Array.fold_left (extract_names_from_variant root_loc) ([], acc) va
       in
       (match o with
-         `Sum x ->
+         Sum x ->
            (match x with
               Poly -> (fn, l :: pvn, cvn)
             | Classic ->
@@ -82,7 +82,7 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
 and extract_names_from_variant root_loc (l, acc) x =
   let l =
     match x.var_arepr with
-      `Variant v -> (root_loc, x.var_loc, v.Ocaml.ocaml_cons) :: l
+      Variant v -> (root_loc, x.var_loc, v.Ocaml.ocaml_cons) :: l
     | _ -> assert false
   in
   match x.var_arg with
@@ -93,7 +93,7 @@ and extract_names_from_variant root_loc (l, acc) x =
 and extract_names_from_field root_loc (l, acc) x =
   let l =
     match x.f_arepr with
-      `Field f -> (root_loc, x.f_loc, f.Ocaml.ocaml_fname) :: l
+      Field f -> (root_loc, x.f_loc, f.Ocaml.ocaml_fname) :: l
     | _ -> assert false
   in
   (l, extract_names_from_expr root_loc acc x.f_value)
@@ -201,8 +201,8 @@ let get_type_constraint ~original_types def =
    constructor/field name disambiguation *)
 let needs_type_annot (x : _ expr) =
   match x with
-  | Record (_, _, `Record Record, _)
-  | Sum (_, _, `Sum Classic, _) -> true
+  | Record (_, _, Record Record, _)
+  | Sum (_, _, Sum Classic, _) -> true
   | _ -> false
 
 let insert_annot type_annot =
@@ -254,7 +254,7 @@ let is_exportable def =
 
 let make_record_creator deref x =
   match x.def_value with
-    Some (Record (_, a, `Record Ocaml.Record, _)) ->
+    Some (Record (_, a, Ocaml.Repr.Record Ocaml.Record, _)) ->
       let s = x.def_name in
       let full_name = get_full_type_name x in
       let l =

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -9,8 +9,8 @@ open Atd.Import
 open Error
 open Mapping
 
-type 'a expr = (Ocaml.atd_ocaml_repr, 'a) Mapping.mapping
-type 'a def = (Ocaml.atd_ocaml_repr, 'a) Mapping.def
+type 'a expr = (Ocaml.Repr.t, 'a) Mapping.mapping
+type 'a def = (Ocaml.Repr.t, 'a) Mapping.def
 type 'a grouped_defs = (bool * 'a def list) list
 
 type name = (loc * loc * string)

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -30,12 +30,12 @@ type target =
 
 let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
   match x with
-    `Unit _
-  | `Bool _
-  | `Int _
-  | `Float  _
-  | `String _ -> acc
-  | `Sum (loc, va, o, _) ->
+    Unit _
+  | Bool _
+  | Int _
+  | Float  _
+  | String _ -> acc
+  | Sum (loc, va, o, _) ->
       let l, (fn, pvn, cvn) =
         Array.fold_left (extract_names_from_variant root_loc) ([], acc) va
       in
@@ -53,7 +53,7 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
        | _ -> assert false
       )
 
-  | `Record (loc, fa, _, _) ->
+  | Record (loc, fa, _, _) ->
       if is_root then
         let l, (fn, pvn, cvn) =
           Array.fold_left (extract_names_from_field root_loc) ([], acc) fa
@@ -62,22 +62,22 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
       else
         error loc "Anonymous record types are not allowed by OCaml."
 
-  | `Tuple (_, ca, _, _) ->
+  | Tuple (_, ca, _, _) ->
       Array.fold_left (extract_names_from_cell root_loc) acc ca
 
-  | `List (_, x, _, _)
-  | `Option (_, x, _, _)
-  | `Nullable (_, x, _, _)
-  | `Wrap (_, x, _, _) ->
+  | List (_, x, _, _)
+  | Option (_, x, _, _)
+  | Nullable (_, x, _, _)
+  | Wrap (_, x, _, _) ->
       extract_names_from_expr root_loc acc x
 
-  | `Name (_, _, l, _, _) ->
+  | Name (_, _, l, _, _) ->
       List.fold_left (extract_names_from_expr root_loc) acc l
 
-  | `External (_, _, l, _, _) ->
+  | External (_, _, l, _, _) ->
       List.fold_left (extract_names_from_expr root_loc) acc l
 
-  | `Tvar _ -> acc
+  | Tvar _ -> acc
 
 and extract_names_from_variant root_loc (l, acc) x =
   let l =
@@ -201,8 +201,8 @@ let get_type_constraint ~original_types def =
    constructor/field name disambiguation *)
 let needs_type_annot (x : _ expr) =
   match x with
-  | `Record (_, _, `Record `Record, _)
-  | `Sum (_, _, `Sum Classic, _) -> true
+  | Record (_, _, `Record `Record, _)
+  | Sum (_, _, `Sum Classic, _) -> true
   | _ -> false
 
 let insert_annot type_annot =
@@ -254,7 +254,7 @@ let is_exportable def =
 
 let make_record_creator deref x =
   match x.def_value with
-    Some (`Record (_, a, `Record `Record, _)) ->
+    Some (Record (_, a, `Record `Record, _)) ->
       let s = x.def_name in
       let full_name = get_full_type_name x in
       let l =

--- a/atdgen/src/ox_emit.mli
+++ b/atdgen/src/ox_emit.mli
@@ -44,3 +44,13 @@ val map : (bool -> 'a -> 'b) -> 'a list -> 'b list
 val get_let : is_rec:bool -> is_first:bool -> Mapping.loc_id * Mapping.loc_id
 
 val write_opens : Buffer.t -> Mapping.loc_id list -> unit
+
+val def_of_atd
+  : Atd.Ast.loc
+    * (Mapping.loc_id * Mapping.loc_id list * Atd.Annot.t)
+    * Atd.Ast.type_expr
+  -> target:Ocaml.target
+  -> def:'a
+  -> external_:'a
+  -> mapping_of_expr:(Atd.Ast.type_expr -> (Ocaml.Repr.t, 'a) Mapping.mapping)
+  -> (Ocaml.Repr.t, 'a) Mapping.def

--- a/atdgen/src/ox_emit.mli
+++ b/atdgen/src/ox_emit.mli
@@ -1,5 +1,5 @@
-type 'a expr = (Ocaml.atd_ocaml_repr, 'a) Mapping.mapping
-type 'a def = (Ocaml.atd_ocaml_repr, 'a) Mapping.def
+type 'a expr = (Ocaml.Repr.t, 'a) Mapping.mapping
+type 'a def = (Ocaml.Repr.t, 'a) Mapping.def
 type 'a grouped_defs = (bool * 'a def list) list
 
 type target =
@@ -11,9 +11,9 @@ val get_full_type_name : (_, _) Mapping.def -> string
 val is_exportable : (_, _) Mapping.def -> bool
 
 val make_record_creator
-  : ((Ocaml.atd_ocaml_repr, 'a) Mapping.mapping
-     -> (Ocaml.atd_ocaml_repr, 'b) Mapping.mapping)
-  -> (Ocaml.atd_ocaml_repr, 'a) Mapping.def
+  : ((Ocaml.Repr.t, 'a) Mapping.mapping
+     -> (Ocaml.Repr.t, 'b) Mapping.mapping)
+  -> (Ocaml.Repr.t, 'a) Mapping.def
   -> string * string
 
 val opt_annot : string option -> string -> string

--- a/atdgen/src/xb_emit.ml
+++ b/atdgen/src/xb_emit.ml
@@ -20,39 +20,39 @@ type names = {
 
 let rec extract_names_from_expr acc (x : 'a expr) =
   match x with
-      `Unit _
-    | `Bool _
-    | `Int _
-    | `Float  _
-    | `String _ -> acc
-    | `Sum (_, va, _, _) ->
-        let l, (fn, vn) =
-          Array.fold_left extract_names_from_variant ([], acc) va
-        in
-        (fn, List.rev l :: vn)
+    Unit _
+  | Bool _
+  | Int _
+  | Float  _
+  | String _ -> acc
+  | Sum (_, va, _, _) ->
+      let l, (fn, vn) =
+        Array.fold_left extract_names_from_variant ([], acc) va
+      in
+      (fn, List.rev l :: vn)
 
-    | `Record (_, fa, _, _) ->
-        let l, (fn, vn) =
-          Array.fold_left extract_names_from_field ([], acc) fa
-        in
-        (List.rev l :: fn, vn)
+  | Record (_, fa, _, _) ->
+      let l, (fn, vn) =
+        Array.fold_left extract_names_from_field ([], acc) fa
+      in
+      (List.rev l :: fn, vn)
 
-    | `Tuple (_, ca, _, _) ->
-        Array.fold_left extract_names_from_cell acc ca
+  | Tuple (_, ca, _, _) ->
+      Array.fold_left extract_names_from_cell acc ca
 
-    | `List (_, x, _, _)
-    | `Option (_, x, _, _)
-    | `Nullable (_, x, _, _)
-    | `Wrap (_, x, _, _) ->
-        extract_names_from_expr acc x
+  | List (_, x, _, _)
+  | Option (_, x, _, _)
+  | Nullable (_, x, _, _)
+  | Wrap (_, x, _, _) ->
+      extract_names_from_expr acc x
 
-    | `Name (_, _, l, _, _) ->
-        List.fold_left extract_names_from_expr acc l
+  | Name (_, _, l, _, _) ->
+      List.fold_left extract_names_from_expr acc l
 
-    | `External (_, _, l, _, _) ->
-        List.fold_left extract_names_from_expr acc l
+  | External (_, _, l, _, _) ->
+      List.fold_left extract_names_from_expr acc l
 
-    | `Tvar _ -> acc
+  | Tvar _ -> acc
 
 and extract_names_from_variant (l, acc) x =
   let l = (x.var_loc, x.var_cons) :: l in

--- a/atdgen/test/jbuild
+++ b/atdgen/test/jbuild
@@ -58,7 +58,7 @@
   (action
    (run
     ${bin:atdgen} -json -extend Test -j-custom-fields
-    "fun loc s -> Printf.printf \"Warning: skipping field %s (def: %s)\" s loc"
+    "fun loc s -> Printf.eprintf \"Warning: skipping field %s (def: %s)\n\" s loc"
     ${<}
     -o testj))))
 

--- a/atdgen/test/test.atd
+++ b/atdgen/test/test.atd
@@ -23,7 +23,7 @@ j  *  j
       ">
 
 type r = {
-  a : int <ocaml validator="fun _ _ -> print_endline \"field a\"; None">;
+  a : int <ocaml validator="fun _ _ -> None">;
   b <ocaml mutable> : bool;
   c : p;
 }
@@ -112,7 +112,6 @@ type extended = {
   ~b5 <ocaml name="b5x" default="0.5"> : float;
 } <ocaml validator="\
     fun path x ->
-      print_endline \"Validating record of type 'extended'\";
       if x.b0x >= 0 then None
       else Some (Atdgen_runtime.Util.Validation.error path)">
 

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -555,11 +555,13 @@ and read_r = (
                   2
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -611,11 +613,13 @@ and read_r = (
                     2
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 25, characters 9-123" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 25, characters 9-96" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -842,7 +846,8 @@ and read_poly read__x read__y = (
                     0
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
                 )
               | 's' -> (
@@ -850,15 +855,18 @@ and read_poly read__x read__y = (
                     1
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -898,7 +906,8 @@ and read_poly read__x read__y = (
                       0
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                     )
                   )
                 | 's' -> (
@@ -906,15 +915,18 @@ and read_poly read__x read__y = (
                       1
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                     )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 144, characters 21-71" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 143, characters 21-71" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -1409,7 +1421,8 @@ let read_val1 = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 119, characters 12-161" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 118, characters 12-161" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -1439,7 +1452,8 @@ let read_val1 = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 119, characters 12-161" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 118, characters 12-161" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -1654,11 +1668,13 @@ let read_val2 = (
                   1
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -1703,11 +1719,13 @@ let read_val2 = (
                     1
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 122, characters 12-57" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 121, characters 12-57" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -2718,11 +2736,13 @@ let read_mixed_record = (
                         9
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                       )
                 )
                 else (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
               )
             | 7 -> (
@@ -2744,15 +2764,18 @@ let read_mixed_record = (
                         14
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                       )
                 )
                 else (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
               )
             | _ -> (
-                (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
               )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3009,11 +3032,13 @@ let read_mixed_record = (
                           9
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                         )
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                   )
                 )
               | 7 -> (
@@ -3035,15 +3060,18 @@ let read_mixed_record = (
                           14
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                         )
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 60, characters 20-703" (String.sub s pos len); -1
                 )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3509,11 +3537,13 @@ let read_test = (
                   4
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3591,11 +3621,13 @@ let read_test = (
                     4
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 90, characters 12-152" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3779,7 +3811,8 @@ let read__30 = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 205, characters 18-33" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 204, characters 18-33" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3809,7 +3842,8 @@ let read__30 = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 205, characters 18-33" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 204, characters 18-33" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -3889,7 +3923,8 @@ let read_some_record = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 191, characters 19-95" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 190, characters 19-95" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -3919,7 +3954,8 @@ let read_some_record = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 191, characters 19-95" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 190, characters 19-95" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4010,7 +4046,8 @@ let read_precision = (
                     2
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                   )
                 )
               | 's' -> (
@@ -4020,7 +4057,8 @@ let read_precision = (
                           1
                         )
                         else (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                       )
                     | 'q' -> (
@@ -4028,19 +4066,23 @@ let read_precision = (
                           0
                         )
                         else (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                       )
                     | _ -> (
-                        (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                        (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                       )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4087,7 +4129,8 @@ let read_precision = (
                       2
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                     )
                   )
                 | 's' -> (
@@ -4097,7 +4140,8 @@ let read_precision = (
                             1
                           )
                           else (
-                            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                           )
                         )
                       | 'q' -> (
@@ -4105,19 +4149,23 @@ let read_precision = (
                             0
                           )
                           else (
-                            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                           )
                         )
                       | _ -> (
-                          (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                          (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                         )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 198, characters 17-140" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 197, characters 17-140" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4721,7 +4769,8 @@ let read_generic read__a = (
             0
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 204, characters 18-35" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 203, characters 18-35" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4751,7 +4800,8 @@ let read_generic read__a = (
               0
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 204, characters 18-35" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 203, characters 18-35" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -4832,7 +4882,8 @@ let read_floats = (
                     0
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
                 )
               | '6' -> (
@@ -4840,15 +4891,18 @@ let read_floats = (
                     1
                   )
                   else (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -4888,7 +4942,8 @@ let read_floats = (
                       0
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                     )
                   )
                 | '6' -> (
@@ -4896,15 +4951,18 @@ let read_floats = (
                       1
                     )
                     else (
-                      (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                     )
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 55, characters 14-71" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -5207,11 +5265,13 @@ let read_extended = (
                   5
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -5297,11 +5357,13 @@ let read_extended = (
                     5
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 103, characters 16-570" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 103, characters 16-508" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in
@@ -5549,11 +5611,13 @@ let read_base = (
                   1
                 )
               | _ -> (
-                  (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
                 )
           )
           else (
-            (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
           )
       in
       let i = Yojson.Safe.map_ident p f lb in
@@ -5595,11 +5659,13 @@ let read_base = (
                     1
                   )
                 | _ -> (
-                    (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
                   )
             )
             else (
-              (fun loc s -> Printf.printf "Warning: skipping field %s (def: %s)" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 98, characters 12-40" (String.sub s pos len); -1
             )
         in
         let i = Yojson.Safe.map_ident p f lb in

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -188,7 +188,7 @@ and validate_r : _ -> r -> _ = (
   fun path x ->
     match
       (
-        fun _ _ -> print_endline "field a"; None
+        fun _ _ -> None
       ) (`Field "a" :: path) x.a
     with
       | Some _ as err -> err
@@ -428,7 +428,6 @@ let validate_extended_tuple = (
 let validate_extended : _ -> extended -> _ = (
   fun path x ->
     match ( fun path x ->
-      print_endline "Validating record of type 'extended'";
       if x.b0x >= 0 then None
       else Some (Atdgen_runtime.Util.Validation.error path) ) path x with
       | Some _ as err -> err

--- a/atdj/src/atdj_main.ml
+++ b/atdj/src/atdj_main.ml
@@ -70,7 +70,7 @@ let main () =
     env with
     module_items =
       List.map
-        (function (`Type (_, (name, _, _), atd_ty)) -> (name, atd_ty))
+        (function (Atd.Ast.Type (_, (name, _, _), atd_ty)) -> (name, atd_ty))
         atd_module
   } in
 

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -330,7 +330,7 @@ and trans_sum my_name env (`Sum (_, vars, _)) =
   let class_name = Atdj_names.to_class_name my_name in
 
   let cases = List.map (function
-    | `Variant (_, (atd_name, an), opt_ty) ->
+    | Atd.Ast.Variant (_, (atd_name, an), opt_ty) ->
         let json_name = get_json_variant_name atd_name an in
         let func_name, enum_name, field_name =
           get_java_variant_names atd_name an in
@@ -342,7 +342,7 @@ and trans_sum my_name env (`Sum (_, vars, _)) =
               Some (ty, java_ty)
         in
         (json_name, func_name, enum_name, field_name, opt_java_ty)
-    | `Inherit _ -> assert false
+    | Inherit _ -> assert false
   ) vars
   in
 

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -310,10 +310,10 @@ let rec trans_module env items = List.fold_left trans_outer env items
 
 and trans_outer env (Atd.Ast.Type (_, (name, _, _), atd_ty)) =
   match unwrap atd_ty with
-  | Sum _ as s ->
-      trans_sum name env s
-  | Record _ as r ->
-      trans_record name env r
+  | Sum (loc, v, a) ->
+      trans_sum name env (loc, v, a)
+  | Record (loc, v, a) ->
+      trans_record name env (loc, v, a)
   | Name (_, (_, _name, _), _) ->
       (* Don't translate primitive types at the top-level *)
       env
@@ -326,7 +326,7 @@ and trans_outer env (Atd.Ast.Type (_, (name, _, _), atd_ty)) =
  * we generate a class Ty implemented in Ty.java and an enum TyEnum defined
  * in a separate file TyTag.java.
 *)
-and trans_sum my_name env (Sum (_, vars, _)) =
+and trans_sum my_name env (_, vars, _) =
   let class_name = Atdj_names.to_class_name my_name in
 
   let cases = List.map (function
@@ -502,7 +502,7 @@ public class %s {
 (* Translate a record into a Java class.  Each record field becomes a field
  * within the class.
 *)
-and trans_record my_name env (Record (loc, fields, annots)) =
+and trans_record my_name env (loc, fields, annots) =
   (* Remove `Inherit values *)
   let fields = List.map
       (function

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -136,8 +136,9 @@ let assign_field env
   (* Check whether the field is optional *)
   let is_opt =
     match kind with
-      | `Optional | `With_default -> true
-      | `Required -> false in
+      | Atd.Ast.Optional
+      | With_default -> true
+      | Required -> false in
   let src = sprintf "jo.%s(\"%s\")" (get env atd_ty is_opt) json_field_name in
   if not is_opt then
     assign env (Some field_name) src java_ty atd_ty "    "
@@ -151,7 +152,7 @@ let assign_field env
     in
     let opt_set_default =
       match kind with
-      | `With_default ->
+      | Atd.Ast.With_default ->
           (match norm_ty ~unwrap_option:true env atd_ty with
            | `Name (_, (_, name, _), _) ->
                (match name with
@@ -223,8 +224,8 @@ let to_string_field env = function
       let else_part =
         let is_opt =
           match kind with
-            | `Optional | `With_default -> true
-            | `Required -> false in
+            | Atd.Ast.Optional | With_default -> true
+            | Required -> false in
         if is_opt then
           ""
         else

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -307,7 +307,7 @@ import org.json.*;
 
 let rec trans_module env items = List.fold_left trans_outer env items
 
-and trans_outer env (`Type (_, (name, _, _), atd_ty)) =
+and trans_outer env (Atd.Ast.Type (_, (name, _, _), atd_ty)) =
   match unwrap atd_ty with
     | `Sum _ as s ->
         trans_sum name env s

--- a/atdj/src/atdj_util.ml
+++ b/atdj/src/atdj_util.ml
@@ -7,35 +7,35 @@ open Atdj_env
    They could be useful for timestamps, though. *)
 let rec unwrap atd_ty =
   match atd_ty with
-  | `Wrap (_, x, _) -> unwrap x
+  | Atd.Ast.Wrap (_, x, _) -> unwrap x
   | x -> x
 
 let rec unwrap_option env atd_ty =
   match atd_ty with
-  | `Wrap (_, x, _) -> unwrap_option env x
-  | `Option (_, x, _) -> unwrap_option env x
+  | Atd.Ast.Wrap (_, x, _) -> unwrap_option env x
+  | Option (_, x, _) -> unwrap_option env x
   | x -> x
 
 (* Normalise an ATD type by expanding `top-level' type aliases *)
 let rec norm_ty ?(unwrap_option = false) env atd_ty =
   let atd_ty = unwrap atd_ty in
   match atd_ty with
-    | `Name (_, (_, name, _), _) ->
-        (match name with
-           | "bool" | "int" | "float" | "string" | "abstract" -> atd_ty
-           | _ ->
-               (try
-                  let x = List.assoc name env.module_items in
-                  norm_ty env x
-                with Not_found ->
-                  eprintf "Warning: unknown type %s\n%!" name;
-                  atd_ty
-               )
-        )
-    | `Option (_, atd_ty, _) when unwrap_option ->
-        norm_ty env atd_ty
-    | _ ->
-        atd_ty
+  | Atd.Ast.Name (_, (_, name, _), _) ->
+      (match name with
+       | "bool" | "int" | "float" | "string" | "abstract" -> atd_ty
+       | _ ->
+           (try
+              let x = List.assoc name env.module_items in
+              norm_ty env x
+            with Not_found ->
+              eprintf "Warning: unknown type %s\n%!" name;
+              atd_ty
+           )
+      )
+  | Option (_, atd_ty, _) when unwrap_option ->
+      norm_ty env atd_ty
+  | _ ->
+      atd_ty
 
 let not_supported loc =
   Atd.Ast.error_at loc "Construct not yet supported by atdj."

--- a/atdj/test/jbuild
+++ b/atdj/test/jbuild
@@ -49,5 +49,5 @@
    (AtdjTest.java
     json.jar
     junit-4.8.2.jar
-    (files_recursively_in com)))
+    (glob_files com/mylife/test/*.java)))
   (action (run ./run_test.sh))))

--- a/atdj/test/run_test.sh
+++ b/atdj/test/run_test.sh
@@ -4,5 +4,7 @@ CLASSPATH='.:json.jar:junit-4.8.2.jar'
 
 javac -classpath $CLASSPATH com/mylife/test/*.java
 javac -classpath $CLASSPATH AtdjTest.java
-javadoc -classpath $CLASSPATH -d doc/test -public com.mylife.test
-java  -classpath $CLASSPATH AtdjTest
+javadoc -quiet -Xdoclint:none -classpath $CLASSPATH -d doc/test \
+        -public com.mylife.test -quiet \
+    | grep -v "Creating destination directory"
+java  -classpath $CLASSPATH AtdjTest | grep -v -E '^(Time:|JUnit version)' > java.trace


### PR DESCRIPTION
As discussed in #23, polymorphic variants have limited utility in recent versions of OCaml and in fact, I was able to get rid of the vast majority of them with a very minimal amount of type annotations. There's a few polymorphic variants remaining that I will fix soon, but they require a bit more restructuring to do things cleanly (like putting types into their own modules). But the benefit is already there: using merlin now is far easier and all the inferred types are readable.

As for the tuple -> record conversion. I agree that it should probably be done more selectively. I think there's a few examples where the benefit is pretty clear, and I don't think there are issues with mixing records and tuples (things are already mixed). I'll make PR's for those in due time.