### PR TITLE
remove all opens of Error

### DIFF
--- a/atdgen/src/mapping.ml
+++ b/atdgen/src/mapping.ml
@@ -1,7 +1,5 @@
 open Printf
 
-open Error
-
 type loc = Atd.Ast.loc
 
 type loc_id = string
@@ -63,7 +61,7 @@ type ('a, 'b) def = {
 let as_abstract = function
     Atd.Ast.Name (_, (loc, "abstract", l), a) ->
       if l <> [] then
-        error loc "\"abstract\" takes no type parameters";
+        Error.error loc "\"abstract\" takes no type parameters";
       Some (loc, a)
   | _ ->
       None
@@ -149,7 +147,7 @@ let apply param x args =
 
 let rec find_name loc env visited name =
   if List.mem name visited then
-    error loc "Cyclic type definition"
+    Error.error loc "Cyclic type definition"
   else
     let param, x = Env.find name env in
     (param, deref_expr env (name :: visited) x)

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -6,7 +6,6 @@
 open Printf
 
 open Atd.Ast
-open Error
 open Mapping
 open Ob_mapping
 
@@ -183,7 +182,7 @@ let get_fields deref a =
                          Ocaml.get_implicit_ocaml_default
                            deref x.f_value in
                        if d = None then
-                         error x.f_loc "Missing default field value"
+                         Error.error x.f_loc "Missing default field value"
                        else
                          d
                    | Some _ as default -> default
@@ -241,7 +240,7 @@ let rec get_writer_name
        | Int32, `Int32 -> sprintf "Bi_io.write_%sint32" un
        | Int64, `Int64 -> sprintf "Bi_io.write_%sint64" un
        | _ ->
-           error loc "Unsupported combination of OCaml/Biniou int types"
+           Error.error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
   | Float (_, Float, Float b) ->
@@ -345,7 +344,7 @@ let rec get_reader_name
        | Int32, `Int32 -> xreader "int32"
        | Int64, `Int64 -> xreader "int64"
        | _ ->
-           error loc "Unsupported combination of OCaml/Biniou int types"
+           Error.error loc "Unsupported combination of OCaml/Biniou int types"
       )
 
   | Float (_, Float, Float b) ->
@@ -660,7 +659,7 @@ and make_table_writer deref tagged list_kind x =
     match deref x with
         Record (_, a, Record record_kind, Record) -> a, record_kind
       | _ ->
-          error (loc_of_mapping x) "Not a record type"
+          Error.error (loc_of_mapping x) "Not a record type"
   in
   let dot =
     match record_kind with
@@ -931,7 +930,7 @@ let rec make_reader
         (match o with
              Record -> ()
            | Object ->
-               error loc "Sorry, OCaml objects are not supported"
+               Error.error loc "Sorry, OCaml objects are not supported"
         );
         let body = make_record_reader deref ~ocaml_version type_annot a in
         wrap_body ~tagged Bi_io.record_tag body
@@ -1223,11 +1222,11 @@ and make_table_reader deref ~ocaml_version loc list_kind x =
           (match o with
                Record -> ()
              | Object ->
-                 error loc "Sorry, OCaml objects are not supported"
+                 Error.error loc "Sorry, OCaml objects are not supported"
           );
           get_fields deref a
       | _ ->
-          error loc "Not a list or array of records"
+          Error.error loc "Not a list or array of records"
   in
   let init_fields, init_bits, set_bit, check_bits, create_record =
     study_record ~ocaml_version fields

--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -1,5 +1,4 @@
 open Atd.Ast
-open Error
 open Mapping
 
 type ob_mapping =
@@ -129,7 +128,7 @@ and mapping_of_field ocaml_field_prefix = function
           Required, None -> None, false
         | Optional, None -> Some "None", true
         | (Required | Optional), Some _ ->
-            error loc "Superfluous default OCaml value"
+            Error.error loc "Superfluous default OCaml value"
         | With_default, Some s -> Some s, false
         | With_default, None ->
             (* will try to determine implicit default value later *)

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -1,5 +1,4 @@
 open Atd.Ast
-open Error
 open Mapping
 
 type oj_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
@@ -47,7 +46,7 @@ let rec mapping_of_expr (x : type_expr) : oj_mapping =
       Nullable (loc, mapping_of_expr x, ocaml_t, json_t)
 
   | Shared (loc, _, _) ->
-      error loc "Sharing is not supported by the JSON interface"
+      Error.error loc "Sharing is not supported by the JSON interface"
 
   | Wrap (loc, x, an) ->
       let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc an) in
@@ -133,7 +132,7 @@ and mapping_of_field ocaml_field_prefix = function
           Required, None -> None, false
         | Optional, None -> Some "None", true
         | (Required | Optional), Some _ ->
-            error loc "Superfluous default OCaml value"
+            Error.error loc "Superfluous default OCaml value"
         | With_default, Some s -> Some s, false
         | With_default, None ->
             (* will try to determine implicit default value later *)

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -1,5 +1,4 @@
 open Atd.Ast
-open Error
 open Mapping
 
 type ov_mapping =
@@ -274,7 +273,7 @@ and mapping_of_field is_shallow ocaml_field_prefix = function
           Required, None -> None
         | Optional, None -> Some "None"
         | (Required | Optional), Some _ ->
-            error loc "Superfluous default OCaml value"
+            Error.error loc "Superfluous default OCaml value"
         | With_default, Some s -> Some s
         | With_default, None ->
             (* will try to determine implicit default value later *)

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -6,7 +6,6 @@
 open Printf
 
 open Atd.Import
-open Error
 open Mapping
 
 type 'a expr = (Ocaml.Repr.t, 'a) Mapping.mapping
@@ -46,7 +45,7 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
             | Classic ->
                 if is_root then (fn, pvn, l :: cvn)
                 else
-                  error loc
+                  Error.error loc
                     "Anonymous classic variant types are not allowed \
                      by OCaml."
            )
@@ -60,7 +59,7 @@ let rec extract_names_from_expr ?(is_root = false) root_loc acc (x : 'a expr) =
         in
         (l :: fn, pvn, cvn)
       else
-        error loc "Anonymous record types are not allowed by OCaml."
+        Error.error loc "Anonymous record types are not allowed by OCaml."
 
   | Tuple (_, ca, _, _) ->
       Array.fold_left (extract_names_from_cell root_loc) acc ca
@@ -145,12 +144,12 @@ after the field name or variant name in the ATD type definition.
             field_kind s
         in
         if loc <> orig_loc then
-          error3
+          Error.error3
             root_loc msg1
             orig_loc msg2
             loc msg3
         else
-          error2
+          Error.error2
             root_loc msg1
             orig_loc msg2
 

--- a/atdgen/src/xb_emit.ml
+++ b/atdgen/src/xb_emit.ml
@@ -4,7 +4,6 @@
 *)
 
 open Printf
-open Error
 open Mapping
 
 type 'a expr = ('a, Biniou.biniou_repr) Mapping.mapping
@@ -93,7 +92,7 @@ let check_duplicate_hashes kind l =
       let h = Bi_io.hash_name s in
       try
         let loc0, s0 = Hashtbl.find tbl h in
-        error2
+        Error.error2
           loc0 (sprintf "Definition of %s %s." kind s0)
           loc (
             sprintf "\


### PR DESCRIPTION
It's quite a bit easier to grep for failwith with the fully qualified names. I'll also rename `Error.error` to something like `Error.fatal` to be a bit more descriptive.