### PR TITLE
Remove obsolete checks for overlaps

### DIFF
--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -49,12 +49,6 @@ let parse_ocaml_version () =
   else
     None
 
-let get_default_name_overlap ocaml_version =
-  match ocaml_version with
-  | Some (major, _) when major < 4 -> false
-  | Some (4, 0) -> false
-  | _ -> true
-
 let main () =
   let pos_fname = ref None in
   let pos_lnum = ref None in
@@ -73,7 +67,6 @@ let main () =
   let constr_mismatch_handler = ref None in
   let type_aliases = ref None in
   let ocaml_version = parse_ocaml_version () in
-  let name_overlap = ref (get_default_name_overlap ocaml_version) in
   let set_opens s =
     let l = Str.split (Str.regexp " *, *\\| +") s in
     opens := List.rev_append l !opens
@@ -274,23 +267,6 @@ let main () =
     "-rec", Arg.Set all_rec,
     "
           Keep OCaml type definitions mutually recursive";
-
-    "-o-name-overlap", Arg.Set name_overlap,
-    "
-          Accept records and classic (non-polymorphic) variants with identical
-          field or constructor names in the same module. Overlapping names are
-          supported in OCaml since version 4.01.
-
-          Duplicate name checking will be skipped, and type annotations will
-          be included in the implementation to disambiguate names.
-          This is the default if atdgen was compiled for OCaml >= 4.01.0";
-
-    "-o-no-name-overlap", Arg.Clear name_overlap,
-    "
-          Disallow records and classic (non-polymorphic) variants
-          with identical field or constructor names in the same module.
-          This is the default if atdgen was compiled for OCaml < 4.01.0";
-
     "-version",
     Arg.Unit (fun () ->
                 print_endline Version.version;
@@ -432,7 +408,6 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list|-bs) example.atd" Sys.argv.(0) in
           ~type_aliases
           ~force_defaults
           ~ocaml_version
-          ~name_overlap: !name_overlap
           atd_file ocaml_prefix
 
 let () =

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -1358,7 +1358,6 @@ let make_ocaml_files
     ~pos_lnum
     ~type_aliases
     ~force_defaults:_
-    ~name_overlap
     ~ocaml_version
     ~pp_convs
     atd_file out =
@@ -1383,7 +1382,6 @@ let make_ocaml_files
   in
   let m1 = tsort m0 in
   let defs1 = defs_of_atd_modules m1 in
-  if not name_overlap then Ox_emit.check defs1;
   Xb_emit.check defs1;
   let (m1', original_types) =
     Atd.Expand.expand_module_body ~keep_poly:true m0

--- a/atdgen/src/ob_emit.mli
+++ b/atdgen/src/ob_emit.mli
@@ -9,7 +9,6 @@ val make_ocaml_files
   -> pos_lnum:int option
   -> type_aliases:string option
   -> force_defaults:_ (* not used *)
-  -> name_overlap:bool
   -> ocaml_version:(int * int) option
   -> pp_convs:Ocaml.pp_convs
   -> string option -> Ox_emit.target -> unit

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1812,7 +1812,6 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~preprocess_input
-    ~name_overlap
     ~ocaml_version
     ~pp_convs
     atd_file out =
@@ -1840,7 +1839,6 @@ let make_ocaml_files
   in
   let m1 = tsort m0 in
   let defs1 = Oj_mapping.defs_of_atd_modules m1 in
-  if not name_overlap then Ox_emit.check defs1;
   let (m1', original_types) =
     Atd.Expand.expand_module_body ~keep_poly:true m0
   in

--- a/atdgen/src/oj_emit.mli
+++ b/atdgen/src/oj_emit.mli
@@ -13,7 +13,6 @@ val make_ocaml_files
   -> type_aliases:string option
   -> force_defaults:bool
   -> preprocess_input:string option
-  -> name_overlap:bool
   -> ocaml_version:(int * int) option
   -> pp_convs:Ocaml.pp_convs
   -> string option

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -416,7 +416,6 @@ let make_ocaml_files
     ~pos_lnum
     ~type_aliases
     ~force_defaults:_
-    ~name_overlap
     ~ocaml_version:_
     ~pp_convs
     atd_file out =
@@ -442,7 +441,6 @@ let make_ocaml_files
   let m1 = tsort m0
   in
   let defs1 = Ov_mapping.defs_of_atd_modules m1 in
-  if not name_overlap then Ox_emit.check defs1;
   let (m1', original_types) =
     Atd.Expand.expand_module_body ~keep_poly:true m0
   in

--- a/atdgen/src/ov_emit.mli
+++ b/atdgen/src/ov_emit.mli
@@ -9,7 +9,6 @@ val make_ocaml_files
   -> pos_lnum:int option
   -> type_aliases:string option
   -> force_defaults:_ (* TODO unused *)
-  -> name_overlap:bool
   -> ocaml_version:_ (* TODO unused *)
   -> pp_convs:Ocaml.pp_convs
   -> string option -> Ox_emit.target -> unit


### PR DESCRIPTION
These checks are only useful for versions of OCaml taht atdgen doesn't even
build on (< 4.02).

Fix #53 