### PR TITLE
Fix some warnings

### DIFF
--- a/atd/src/doc.ml
+++ b/atd/src/doc.ml
@@ -18,7 +18,9 @@ let parse_text loc s =
 
 let get_doc loc an : doc option =
   Annot.get_opt_field
-    (fun s -> Some (parse_text loc s)) ["doc"] "text" an
+    ~parse:(fun s -> Some (parse_text loc s))
+    ~sections:["doc"]
+    ~field:"text" an
 
 
 (* Conversion to HTML *)

--- a/atd/src/parser.mly
+++ b/atd/src/parser.mly
@@ -117,12 +117,12 @@ type_expr:
          | "nullable", [x] -> Nullable (loc, x, a)
          | "shared", [x] ->
              let a =
-               if Annot.has_field ["share"] "id" a then
+               if Annot.has_field ~sections:["share"] ~field:"id" a then
                  (* may cause ID clashes if not used properly *)
                  a
                else
-                 Annot.set_field loc
-                   "share" "id" (Some (Annot.create_id ())) a
+                 Annot.set_field ~loc
+                   ~section:"share" ~field:"id" (Some (Annot.create_id ())) a
              in
              Shared (loc, x, a)
          | "wrap", [x] -> Wrap (loc, x, a)

--- a/atdgen/src/json.mli
+++ b/atdgen/src/json.mli
@@ -59,6 +59,7 @@ type json_repr =
   | Wrap
 
 val get_json_sum : Atd.Annot.t -> json_adapter
+[@@ocaml.warning "-32"]
 
 val get_json_list : Atd.Annot.t -> json_list
 

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -12,7 +12,7 @@ type variant_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.variant_mapping
 let check_json_sum loc json_sum_param variants =
   if json_sum_param.Json.json_open_enum then (
     let variants_with_arg =
-      List.filter (function {var_arg = Some _} -> true | _ -> false) variants
+      List.filter (function {var_arg = Some _; _} -> true | _ -> false) variants
     in
     match variants_with_arg with
     | [] ->


### PR DESCRIPTION
If a function uses labels, then we should use them in applications. get_json_sum
remains unused, so it's best to annotate it as such. Add a wildcard pattern when
some records fields are unused.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>