### PR TITLE
Improve map_record_creator_field signature

### DIFF
--- a/atd/src/import.ml
+++ b/atd/src/import.ml
@@ -61,6 +61,13 @@ module List = struct
     | []
     | [_] -> t
     | x :: xs -> x :: sep @ (insert_sep xs ~sep)
+
+  let split3 l =
+    let (x, y, z) =
+      List.fold_left (fun (xs, ys, zs) (x, y, z) ->
+        (x::xs, y::ys, z::zs)
+      ) ([], [], []) l in
+    (List.rev x, List.rev y, List.rev z)
 end
 
 module Option = struct

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -848,6 +848,11 @@ let get_implicit_ocaml_default = function
   | Nullable (_, _, Nullable, _) -> Some "None"
   | _ -> None
 
+type create_fields =
+  { intf_params: string
+  ; impl_params: string
+  ; impl_fields: string
+  }
 
 let map_record_creator_field deref x =
   let o =
@@ -862,14 +867,20 @@ let map_record_creator_field deref x =
         let t = ocaml_of_expr (ocaml_of_expr_mapping x.f_value) in
         let intf = sprintf "\n  %s: %s ->" fname t in
         let impl1 = sprintf "\n  ~%s" fname in
-        intf, impl1, impl2
+        { intf_params = intf
+        ; impl_params = impl1
+        ; impl_fields = impl2
+        }
 
     | Optional ->
         let x = unwrap_option (deref x.f_value) in
         let t = ocaml_of_expr (ocaml_of_expr_mapping x) in
         let intf = sprintf "\n  ?%s: %s ->" fname t in
         let impl1 = sprintf "\n  ?%s" fname in
-        intf, impl1, impl2
+        { intf_params = intf
+        ; impl_params = impl1
+        ; impl_fields = impl2
+        }
 
     | With_default ->
         let t = ocaml_of_expr (ocaml_of_expr_mapping x.f_value) in
@@ -887,7 +898,10 @@ let map_record_creator_field deref x =
           in
           sprintf "\n  ?(%s = %s)" fname default
         in
-        intf, impl1, impl2
+        { intf_params = intf
+        ; impl_params = impl1
+        ; impl_fields = impl2
+        }
 
 let obj_unimplemented loc = function
    | Record -> ()

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -96,12 +96,17 @@ val ocaml_of_atd
   -> (Atd.Ast.loc * Atd.Ast.annot) * (bool * Atd.Ast.module_body) list
   -> string
 
+type create_fields =
+  { intf_params: string
+  ; impl_params: string
+  ; impl_fields: string
+  }
 
 val map_record_creator_field
   : ((Repr.t, 'a) Mapping.mapping
      -> (Repr.t, 'b) Mapping.mapping)
   -> (Repr.t, 'a) Mapping.field_mapping
-  -> string * string * string
+  -> create_fields
 
 val tick : atd_ocaml_sum -> string
 

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -250,10 +250,13 @@ let make_record_creator deref x =
     Some (Record (_, a, Ocaml.Repr.Record Ocaml.Record, _)) ->
       let s = x.def_name in
       let full_name = get_full_type_name x in
-      let l =
-        Array.to_list
-          (Array.map (Ocaml.map_record_creator_field deref) a) in
-      let intf_params = List.map (fun (x, _, _) -> x) l in
+      let (intf_params, impl_params, impl_fields) =
+        Array.map (Ocaml.map_record_creator_field deref) a
+        |> Array.to_list
+        |> List.map (fun { Ocaml. intf_params; impl_params; impl_fields } ->
+          (intf_params, impl_params, impl_fields))
+        |> List.split3
+      in
       let intf =
         sprintf "\
 val create_%s :%s
@@ -265,8 +268,6 @@ val create_%s :%s
           full_name
           s
       in
-      let impl_params = List.map (fun (_, x, _) -> x) l in
-      let impl_fields = List.map (fun (_, _, x) -> x) l in
       let impl =
         sprintf "\
 let create_%s %s


### PR DESCRIPTION
The tuple returned made reading the code hard since all the fields were of the
same type. A record is introduced to improve the return type. Also, List.split3
is added to make it easier to go from create_fields list to the individual
representation.