### PR TITLE
Include name of validation function in error message from `valid`

### DIFF
--- a/atdgen/src/validate.ml
+++ b/atdgen/src/validate.ml
@@ -24,10 +24,13 @@ type validate_repr = (string option * bool)
 
 let make_full_validator s =
   sprintf "\
-    fun path x -> \
-      if ( %s ) x then None \
-      else Some (Atdgen_runtime.Util.Validation.error path)"
-    s
+  fun path x ->
+    let msg = \"Failed check by %s\" in
+    if (%s) x then
+      None
+    else
+      Some (Atdgen_runtime.Util.Validation.error ~msg path)"
+    (String.escaped s) s
 
 let get_validator an =
   let full =

--- a/atdgen/test/test.atd
+++ b/atdgen/test/test.atd
@@ -208,3 +208,5 @@ type validate_me =
     <ocaml valid="fun s -> true">
       list
         <ocaml valid="fun l -> true">
+
+type validated_string_check = string <ocaml valid="fun s -> s = \"abc\"">

--- a/atdgen/test/test.expected.ml
+++ b/atdgen/test/test.expected.ml
@@ -18,6 +18,8 @@ type p = [ `A | `B of r | `C ]
 
 and r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = string
+
 type validate_me = string list
 
 type val1 = { val1_x: int }
@@ -716,6 +718,25 @@ and read__1 = (
 )
 and _1_of_string ?pos s =
   read__1 (Bi_inbuf.from_string ?pos s)
+let validated_string_check_tag = Bi_io.string_tag
+let write_untagged_validated_string_check = (
+  Bi_io.write_untagged_string
+)
+let write_validated_string_check ob x =
+  Bi_io.write_tag ob Bi_io.string_tag;
+  write_untagged_validated_string_check ob x
+let string_of_validated_string_check ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_validated_string_check ob x;
+  Bi_outbuf.contents ob
+let get_validated_string_check_reader = (
+  Atdgen_runtime.Ob_run.get_string_reader
+)
+let read_validated_string_check = (
+  Atdgen_runtime.Ob_run.read_string
+)
+let validated_string_check_of_string ?pos s =
+  read_validated_string_check (Bi_inbuf.from_string ?pos s)
 let _31_tag = Bi_io.array_tag
 let write_untagged__31 = (
   Atdgen_runtime.Ob_run.write_untagged_list

--- a/atdgen/test/test.expected.mli
+++ b/atdgen/test/test.expected.mli
@@ -18,6 +18,8 @@ type p = [ `A | `B of r | `C ]
 
 and r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = string
+
 type validate_me = string list
 
 type val1 = { val1_x: int }
@@ -400,6 +402,43 @@ val create_r :
   c: p ->
   unit -> r
   (** Create a record of type {!r}. *)
+
+
+(* Writers for type validated_string_check *)
+
+val validated_string_check_tag : Bi_io.node_tag
+  (** Tag used by the writers for type {!validated_string_check}.
+      Readers may support more than just this tag. *)
+
+val write_untagged_validated_string_check :
+  Bi_outbuf.t -> validated_string_check -> unit
+  (** Output an untagged biniou value of type {!validated_string_check}. *)
+
+val write_validated_string_check :
+  Bi_outbuf.t -> validated_string_check -> unit
+  (** Output a biniou value of type {!validated_string_check}. *)
+
+val string_of_validated_string_check :
+  ?len:int -> validated_string_check -> string
+  (** Serialize a value of type {!validated_string_check} into
+      a biniou string. *)
+
+(* Readers for type validated_string_check *)
+
+val get_validated_string_check_reader :
+  Bi_io.node_tag -> (Bi_inbuf.t -> validated_string_check)
+  (** Return a function that reads an untagged
+      biniou value of type {!validated_string_check}. *)
+
+val read_validated_string_check :
+  Bi_inbuf.t -> validated_string_check
+  (** Input a tagged biniou value of type {!validated_string_check}. *)
+
+val validated_string_check_of_string :
+  ?pos:int -> string -> validated_string_check
+  (** Deserialize a biniou value of type {!validated_string_check}.
+      @param pos specifies the position where
+                 reading starts. Default: 0. *)
 
 
 (* Writers for type validate_me *)

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -947,6 +949,18 @@ let rec read__1 = (
 )
 and _1_of_string s =
   read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_validated_string_check = (
+  Yojson.Safe.write_string
+)
+let string_of_validated_string_check ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_validated_string_check ob x;
+  Bi_outbuf.contents ob
+let read_validated_string_check = (
+  Atdgen_runtime.Oj_run.read_string
+)
+let validated_string_check_of_string s =
+  read_validated_string_check (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__31 = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string

--- a/atdgen/test/testj.expected.mli
+++ b/atdgen/test/testj.expected.mli
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -278,6 +280,27 @@ val create_r :
   c: p ->
   unit -> r
   (** Create a record of type {!r}. *)
+
+
+val write_validated_string_check :
+  Bi_outbuf.t -> validated_string_check -> unit
+  (** Output a JSON value of type {!validated_string_check}. *)
+
+val string_of_validated_string_check :
+  ?len:int -> validated_string_check -> string
+  (** Serialize a value of type {!validated_string_check}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_validated_string_check :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> validated_string_check
+  (** Input JSON data of type {!validated_string_check}. *)
+
+val validated_string_check_of_string :
+  string -> validated_string_check
+  (** Deserialize JSON data of type {!validated_string_check}. *)
 
 
 val write_validate_me :

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -935,6 +937,18 @@ let rec read__1 = (
 )
 and _1_of_string s =
   read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_validated_string_check = (
+  Yojson.Safe.write_string
+)
+let string_of_validated_string_check ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_validated_string_check ob x;
+  Bi_outbuf.contents ob
+let read_validated_string_check = (
+  Atdgen_runtime.Oj_run.read_string
+)
+let validated_string_check_of_string s =
+  read_validated_string_check (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__31 = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string

--- a/atdgen/test/testjstd.expected.mli
+++ b/atdgen/test/testjstd.expected.mli
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -278,6 +280,27 @@ val create_r :
   c: p ->
   unit -> r
   (** Create a record of type {!r}. *)
+
+
+val write_validated_string_check :
+  Bi_outbuf.t -> validated_string_check -> unit
+  (** Output a JSON value of type {!validated_string_check}. *)
+
+val string_of_validated_string_check :
+  ?len:int -> validated_string_check -> string
+  (** Serialize a value of type {!validated_string_check}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_validated_string_check :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> validated_string_check
+  (** Input JSON data of type {!validated_string_check}. *)
+
+val validated_string_check_of_string :
+  string -> validated_string_check
+  (** Deserialize JSON data of type {!validated_string_check}. *)
 
 
 val write_validate_me :

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -224,13 +226,31 @@ and validate_test_variant path x = (
 let rec validate__1 path (x : _ p') = (
   fun _ _ -> None
 ) path x
+let validate_validated_string_check = (
+  fun path x ->
+    let msg = "Failed check by fun s -> s = \"abc\"" in
+    if (fun s -> s = "abc") x then
+      None
+    else
+      Some (Atdgen_runtime.Util.Validation.error ~msg path)
+)
 let validate__31 = (
   (fun path x ->
-    (match ( fun path x -> if ( fun l -> true ) x then None else Some (Atdgen_runtime.Util.Validation.error path) ) path x with
+    (match ( fun path x ->
+    let msg = "Failed check by fun l -> true" in
+    if (fun l -> true) x then
+      None
+    else
+      Some (Atdgen_runtime.Util.Validation.error ~msg path) ) path x with
       | Some _ as err -> err
       | None -> (
           Atdgen_runtime.Ov_run.validate_list (
-            fun path x -> if ( fun s -> true ) x then None else Some (Atdgen_runtime.Util.Validation.error path)
+            fun path x ->
+    let msg = "Failed check by fun s -> true" in
+    if (fun s -> true) x then
+      None
+    else
+      Some (Atdgen_runtime.Util.Validation.error ~msg path)
           )
         ) path x
     )
@@ -324,7 +344,12 @@ let validate_tup = (
   fun _ _ -> None
 )
 let validate_star_rating = (
-  fun path x -> if ( fun x -> x >= 1 && x <= 5 ) x then None else Some (Atdgen_runtime.Util.Validation.error path)
+  fun path x ->
+    let msg = "Failed check by fun x -> x >= 1 && x <= 5" in
+    if (fun x -> x >= 1 && x <= 5) x then
+      None
+    else
+      Some (Atdgen_runtime.Util.Validation.error ~msg path)
 )
 let validate__30 : _ -> _ generic -> _ = (
   fun _ _ -> None

--- a/atdgen/test/testv.expected.mli
+++ b/atdgen/test/testv.expected.mli
@@ -16,6 +16,8 @@ type p = Test.p
 
 and r = Test.r = { a: int; mutable b: bool; c: p }
 
+type validated_string_check = Test.validated_string_check
+
 type validate_me = Test.validate_me
 
 type val1 = Test.val1 = { val1_x: int }
@@ -185,6 +187,10 @@ val create_r :
 val validate_r :
   Atdgen_runtime.Util.Validation.path -> r -> Atdgen_runtime.Util.Validation.error option
   (** Validate a value of type {!r}. *)
+
+val validate_validated_string_check :
+  Atdgen_runtime.Util.Validation.path -> validated_string_check -> Atdgen_runtime.Util.Validation.error option
+  (** Validate a value of type {!validated_string_check}. *)
 
 val validate_validate_me :
   Atdgen_runtime.Util.Validation.path -> validate_me -> Atdgen_runtime.Util.Validation.error option


### PR DESCRIPTION
Aims to address part of #33 

Currently, adding validation to types with the `valid` field produces error messages with no indication of what cased the failure (beyond the path). This change ensures that all validation errors include an indication of the failing validation function. This is the default behavior and messaging I would expect as a user.

E.g., 

Given

```ocaml
(* scratch_util.ml *)

let validate_u8 i = 0 <= i && i <= 255
```

and 

```ocaml
(* scratch.adt *)

type u8 = int <ocaml valid="Scratch_util.validate_u8">

type point = {x: u8; y: u8}
```

We get validation errors like so:

```
Validation error: Failed check by Scratch_util.validate_u8; path = <root>.y
```

Some points to note:

1. This doesn't fully satisfy #33, since the reporter wanted a light-weight way of specifying a particular error message, not just recording the validation function.
2. The formatting of the generated ocaml isn't very nice. I could use pointers to any preferred style guidelines or principles to follow for fixing that up.
3. This PR should include updates to the documentation, which I'll add if the approach is judged to be agreeable.
4. Would it be more fitting to have the error message read `Validation error: validator = Scratch_util.validate_u8; path = <root>.y`?