### PR TITLE
Cleanup assoc and option handling

### DIFF
--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -287,9 +287,7 @@ let expand ?(keep_poly = false) (l : type_def list)
         let t' = subst env t in
         subst_type_name loc loc2 "wrap" [t'] a
 
-    | Tvar (_, s) as x ->
-        (try List.assoc s env
-         with Not_found -> x)
+    | Tvar (_, s) as x -> Option.value (List.assoc s env) ~default:x
 
     | Name (loc, (loc2, name, args), a) ->
         let args' = List.map (subst env) args in

--- a/atd/src/import.ml
+++ b/atd/src/import.ml
@@ -68,6 +68,13 @@ module List = struct
         (x::xs, y::ys, z::zs)
       ) ([], [], []) l in
     (List.rev x, List.rev y, List.rev z)
+
+  let assoc_exn = assoc
+
+  let assoc key xs =
+    match List.assoc key xs with
+    | s -> Some s
+    | exception Not_found -> None
 end
 
 module Option = struct
@@ -78,6 +85,21 @@ module Option = struct
   let value_exn = function
     | None -> failwith "Option.value_exn"
     | Some s -> s
+
+  let value ~default = function
+    | None -> default
+    | Some s -> s
+
+  let is_some = function
+    | None -> false
+    | Some _ -> true
+
+  module O = struct
+    let (>>=) x f =
+      match x with
+      | None -> None
+      | Some x -> f x
+  end
 end
 
 let sprintf = Printf.sprintf

--- a/atd/src/inherit.ml
+++ b/atd/src/inherit.ml
@@ -87,9 +87,7 @@ let expand ?(inherit_fields = true) ?(inherit_variants = true) tbl t0 =
     | Name (loc, (_, "wrap", [t]), a) ->
         Wrap (loc, subst false param t, a)
 
-    | Tvar (_, s) ->
-        (try List.assoc s param
-         with Not_found -> t)
+    | Tvar (_, s) -> Option.value (List.assoc s param) ~default:t
 
     | Name (loc, (loc2, k, args), a) ->
         let expanded_args = List.map (subst false param) args in

--- a/atdcat/atdcat.ml
+++ b/atdcat/atdcat.ml
@@ -5,24 +5,21 @@ let html_of_doc loc s =
   Atd.Doc.html_of_doc doc
 
 let format_html_comments ((section, (_, l)) as x) =
+  let comment s =
+    let comment = "(*html " ^ s ^ "*)" in
+    Easy_format.Atom (comment, Easy_format.atom)
+  in
   match section with
-      "doc" ->
-        (try
-           match List.assoc "html" l with
-               (_, Some s) ->
-                 let comment = "(*html " ^ s ^ "*)" in
-                 Easy_format.Atom (comment, Easy_format.atom)
-             | _ -> raise Not_found
-         with Not_found ->
-           match List.assoc "text" l with
-               (loc, Some s) ->
-                 let comment = "(*html " ^ html_of_doc loc s ^ "*)" in
-                 Easy_format.Atom (comment, Easy_format.atom)
-             | _ ->
-                 Atd.Print.default_annot x
-        )
-    | _ ->
-        Atd.Print.default_annot x
+  | "doc" ->
+      begin match List.assoc "html" l with
+        | Some (_, Some s) -> comment s
+        | Some _ | None ->
+            begin match List.assoc "text" l with
+              | Some (loc, Some s) -> comment (html_of_doc loc s)
+              | Some _ | None -> Atd.Print.default_annot x
+            end
+      end
+  | _ -> Atd.Print.default_annot x
 
 let print_atd ~html_doc ast =
   let annot =

--- a/atdgen-runtime/src/json_adapter.ml
+++ b/atdgen-runtime/src/json_adapter.ml
@@ -18,11 +18,9 @@ module Type_field = struct
     let normalize (x : json) : json =
       match x with
       | `Assoc fields ->
-          (match
-             try Some (List.assoc type_field_name fields)
-             with Not_found -> None
-           with
-           | Some (`String type_) -> `List [ `String type_; x ]
+          (match List.assoc type_field_name fields with
+           | `String type_ -> `List [ `String type_; x ]
+           | exception Not_found -> x
            | _ -> x (* malformed *)
           )
       | `String type_ as x -> x

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -539,7 +539,8 @@ public class %s implements Atdj {
   let env = List.fold_left
       (fun env (`Field (_, (field_name, _, annots), _) as field) ->
          let field_name = get_java_field_name field_name annots in
-         let cmd = assign_field env field (List.assoc field_name java_tys) in
+         let cmd =
+           assign_field env field (List.assoc_exn field_name java_tys) in
          fprintf out "%s" cmd;
          env
       )
@@ -568,7 +569,7 @@ public class %s implements Atdj {
   List.iter
     (function `Field (loc, (field_name, _, annots), _) ->
        let field_name = get_java_field_name field_name annots in
-       let java_ty = List.assoc field_name java_tys in
+       let java_ty = List.assoc_exn field_name java_tys in
        output_string out (javadoc loc annots "  ");
        fprintf out "  public %s %s;\n" java_ty field_name)
     fields;

--- a/atdj/src/atdj_util.ml
+++ b/atdj/src/atdj_util.ml
@@ -24,13 +24,11 @@ let rec norm_ty ?(unwrap_option = false) env atd_ty =
       (match name with
        | "bool" | "int" | "float" | "string" | "abstract" -> atd_ty
        | _ ->
-           (try
-              let x = List.assoc name env.module_items in
-              norm_ty env x
-            with Not_found ->
-              eprintf "Warning: unknown type %s\n%!" name;
-              atd_ty
-           )
+           (match List.assoc name env.module_items with
+            | Some x -> norm_ty env x
+            | None ->
+                eprintf "Warning: unknown type %s\n%!" name;
+                atd_ty)
       )
   | Option (_, atd_ty, _) when unwrap_option ->
       norm_ty env atd_ty


### PR DESCRIPTION
I promise I'm not planning to start crusading against exceptions in favor of result and optional but this is one case where it's worth doing. `Not_found` is a real pain in the neck to debug, because so many things throw it and it doesn't tell you anything about what wasn't found. We end up converting `Not_found` to none in many cases anyway, so let's just take that as the default. The old `assoc` is still available as `assoc_exn` in the few odd cases where it's still necessary.