### PR TITLE
Update data validation tutorial section and example code

### DIFF
--- a/doc/tutorial-data/validate/resume.ml
+++ b/doc/tutorial-data/validate/resume.ml
@@ -1,12 +1,10 @@
 let check_experience x =
-  (match Resume_v.validate_work_experience [] x with
-      None ->
-        Printf.printf "VALID:\n"
-    | Some error ->
-        Printf.printf "INVALID: %s\n"
-          (Atdgen_runtime.Util.Validation.string_of_error error)
-  );
-  Printf.printf "%s\n"
+  let is_valid = match Resume_v.validate_work_experience [] x with
+    | None -> false
+    | _ -> true
+  in
+  Printf.printf "%s:\n%s\n"
+    (if is_valid then "VALID" else "INVALID")
     (Yojson.Safe.prettify (Resume_j.string_of_work_experience x))
 
 let () =

--- a/doc/tutorial-data/validate/resume_util.ml
+++ b/doc/tutorial-data/validate/resume_util.ml
@@ -10,11 +10,11 @@ let ascii_printable c =
 *)
 let validate_some_text s =
   s <> "" &&
-  try
-    String.iter (fun c -> if not (ascii_printable c) then raise Exit) s;
-    true
-  with Exit ->
-    false
+    try
+      String.iter (fun c -> if not (ascii_printable c) then raise Exit) s;
+      true
+    with Exit ->
+      false
 
 (*
   Check that the combination of year, month and day exists in the
@@ -28,12 +28,12 @@ let validate_date x =
   (let dmax =
     match m with
         2 ->
-        if y mod 4 = 0 && not (y mod 100 = 0) || y mod 400 = 0 then 29
-        else 28
+          if y mod 4 = 0 && not (y mod 100 = 0) || y mod 400 = 0 then 29
+          else 28
       | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> 31
       | _ -> 30
-   in
-   d <= dmax)
+  in
+  d <= dmax)
 
 (* Compare dates chronologically *)
 let compare_date a b =
@@ -47,6 +47,6 @@ let compare_date a b =
 (* Check that the end_date, when defined, is not earlier than the start_date *)
 let validate_job x =
   match x.end_date with
-    None -> None
-  | Some end_date ->
-      compare_date x.start_date end_date <= 0
+      None -> true
+    | Some end_date ->
+        compare_date x.start_date end_date <= 0


### PR DESCRIPTION
Closes  #134 

The whitespace changes to doc/tutorial-data/validate/resume_util.ml are just from bringing the example code up to date with the code in the tutorial text.