### PR TITLE
Generate ocaml/json code without Obj.magic

### DIFF
--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -203,6 +203,8 @@ let missing_tuple_fields p len req_fields =
            (if List.length missing > 1 then "s" else "")
            (String.concat ", " (List.map string_of_int missing)))
 
+let missing_field p field_name =
+  error_with_line p (sprintf "Missing record field %s" field_name)
 
 let missing_fields p bit_fields field_names =
   let acc = ref [] in

--- a/atdgen-runtime/src/oj_run.mli
+++ b/atdgen-runtime/src/oj_run.mli
@@ -36,6 +36,7 @@ val read_number : float read
 val invalid_variant_tag : Yojson.Lexer_state.t -> string -> _
 
 val missing_tuple_fields : Yojson.lexer_state -> int -> int list -> _
+val missing_field : Yojson.lexer_state -> string -> _
 val missing_fields : Yojson.lexer_state -> int array -> string array -> _
 
 val write_with_adapter :

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -141,9 +141,8 @@ let read_test2 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_test0 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_test1 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_test0 = ref (None) in
+    let field_test1 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -174,18 +173,20 @@ let read_test2 = (
         match i with
           | 0 ->
             field_test0 := (
-              (
-                read_poly_int2
-              ) p lb
+              Some (
+                (
+                  read_poly_int2
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_test1 := (
-              (
-                read__4
-              ) p lb
+              Some (
+                (
+                  read__4
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -220,18 +221,20 @@ let read_test2 = (
           match i with
             | 0 ->
               field_test0 := (
-                (
-                  read_poly_int2
-                ) p lb
+                Some (
+                  (
+                    read_poly_int2
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_test1 := (
-                (
-                  read__4
-                ) p lb
+                Some (
+                  (
+                    read__4
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -239,11 +242,10 @@ let read_test2 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "test0"; "test1" |];
         (
           {
-            test0 = !field_test0;
-            test1 = !field_test1;
+            test0 = (match !field_test0 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "test0");
+            test1 = (match !field_test1 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "test1");
           }
          : test2)
       )

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -82,8 +82,7 @@ and read_rec_type p lb = (
     fun p lb ->
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_lcurl p lb;
-      let field_more = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-      let bits0 = ref 0 in
+      let field_more = ref (None) in
       try
         Yojson.Safe.read_space p lb;
         Yojson.Safe.read_object_end lb;
@@ -105,11 +104,12 @@ and read_rec_type p lb = (
           match i with
             | 0 ->
               field_more := (
-                (
-                  read__4
-                ) p lb
+                Some (
+                  (
+                    read__4
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -135,11 +135,12 @@ and read_rec_type p lb = (
             match i with
               | 0 ->
                 field_more := (
-                  (
-                    read__4
-                  ) p lb
+                  Some (
+                    (
+                      read__4
+                    ) p lb
+                  )
                 );
-                bits0 := !bits0 lor 0x1;
               | _ -> (
                   Yojson.Safe.skip_json p lb
                 )
@@ -147,10 +148,9 @@ and read_rec_type p lb = (
         done;
         assert false;
       with Yojson.End_of_object -> (
-          if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "more" |];
           (
             {
-              more = !field_more;
+              more = (match !field_more with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "more");
             }
            : rec_type)
         )
@@ -537,9 +537,8 @@ let read_tf_record2 = (
     fun p lb ->
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_lcurl p lb;
-      let field_the_value2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-      let field_etc2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-      let bits0 = ref 0 in
+      let field_the_value2 = ref (None) in
+      let field_etc2 = ref (None) in
       try
         Yojson.Safe.read_space p lb;
         Yojson.Safe.read_object_end lb;
@@ -575,18 +574,20 @@ let read_tf_record2 = (
           match i with
             | 0 ->
               field_the_value2 := (
-                (
-                  read_tf_variant2
-                ) p lb
+                Some (
+                  (
+                    read_tf_variant2
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_etc2 := (
-                (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -626,18 +627,20 @@ let read_tf_record2 = (
             match i with
               | 0 ->
                 field_the_value2 := (
-                  (
-                    read_tf_variant2
-                  ) p lb
+                  Some (
+                    (
+                      read_tf_variant2
+                    ) p lb
+                  )
                 );
-                bits0 := !bits0 lor 0x1;
               | 1 ->
                 field_etc2 := (
-                  (
-                    Atdgen_runtime.Oj_run.read_string
-                  ) p lb
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
                 );
-                bits0 := !bits0 lor 0x2;
               | _ -> (
                   Yojson.Safe.skip_json p lb
                 )
@@ -645,11 +648,10 @@ let read_tf_record2 = (
         done;
         assert false;
       with Yojson.End_of_object -> (
-          if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "the_value2"; "etc2" |];
           (
             {
-              the_value2 = !field_the_value2;
-              etc2 = !field_etc2;
+              the_value2 = (match !field_the_value2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "the_value2");
+              etc2 = (match !field_etc2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "etc2");
             }
            : tf_record2)
         )
@@ -692,9 +694,8 @@ let read_tf_record = (
     fun p lb ->
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_lcurl p lb;
-      let field_the_value = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-      let field_etc = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-      let bits0 = ref 0 in
+      let field_the_value = ref (None) in
+      let field_etc = ref (None) in
       try
         Yojson.Safe.read_space p lb;
         Yojson.Safe.read_object_end lb;
@@ -730,18 +731,20 @@ let read_tf_record = (
           match i with
             | 0 ->
               field_the_value := (
-                (
-                  read_tf_variant
-                ) p lb
+                Some (
+                  (
+                    read_tf_variant
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_etc := (
-                (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -781,18 +784,20 @@ let read_tf_record = (
             match i with
               | 0 ->
                 field_the_value := (
-                  (
-                    read_tf_variant
-                  ) p lb
+                  Some (
+                    (
+                      read_tf_variant
+                    ) p lb
+                  )
                 );
-                bits0 := !bits0 lor 0x1;
               | 1 ->
                 field_etc := (
-                  (
-                    Atdgen_runtime.Oj_run.read_string
-                  ) p lb
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
                 );
-                bits0 := !bits0 lor 0x2;
               | _ -> (
                   Yojson.Safe.skip_json p lb
                 )
@@ -800,11 +805,10 @@ let read_tf_record = (
         done;
         assert false;
       with Yojson.End_of_object -> (
-          if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "the_value"; "etc" |];
           (
             {
-              the_value = !field_the_value;
-              etc = !field_etc;
+              the_value = (match !field_the_value with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "the_value");
+              etc = (match !field_etc with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "etc");
             }
            : tf_record)
         )
@@ -865,10 +869,9 @@ let read_t = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_foo = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_bar = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_baz = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_foo = ref (None) in
+    let field_bar = ref (None) in
+    let field_baz = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -918,25 +921,28 @@ let read_t = (
         match i with
           | 0 ->
             field_foo := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_bar := (
-              (
-                read_json
-              ) p lb
+              Some (
+                (
+                  read_json
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_baz := (
-              (
-                read_dyn
-              ) p lb
+              Some (
+                (
+                  read_dyn
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -990,25 +996,28 @@ let read_t = (
           match i with
             | 0 ->
               field_foo := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_bar := (
-                (
-                  read_json
-                ) p lb
+                Some (
+                  (
+                    read_json
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_baz := (
-                (
-                  read_dyn
-                ) p lb
+                Some (
+                  (
+                    read_dyn
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -1016,12 +1025,11 @@ let read_t = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "foo"; "bar"; "baz" |];
         (
           {
-            foo = !field_foo;
-            bar = !field_bar;
-            baz = !field_baz;
+            foo = (match !field_foo with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "foo");
+            bar = (match !field_bar with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "bar");
+            baz = (match !field_baz with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "baz");
           }
          : t)
       )
@@ -1470,8 +1478,7 @@ let read_b = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_thing = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_thing = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1493,11 +1500,12 @@ let read_b = (
         match i with
           | 0 ->
             field_thing := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -1523,11 +1531,12 @@ let read_b = (
           match i with
             | 0 ->
               field_thing := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -1535,10 +1544,9 @@ let read_b = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "thing" |];
         (
           {
-            thing = !field_thing;
+            thing = (match !field_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "thing");
           }
          : b)
       )
@@ -1577,9 +1585,8 @@ let read_a = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_thing = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_other_thing = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_thing = ref (None) in
+    let field_other_thing = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1615,18 +1622,20 @@ let read_a = (
         match i with
           | 0 ->
             field_thing := (
-              (
-                Atdgen_runtime.Oj_run.read_string
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_other_thing := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -1666,18 +1675,20 @@ let read_a = (
           match i with
             | 0 ->
               field_thing := (
-                (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_other_thing := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -1685,11 +1696,10 @@ let read_a = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "thing"; "other_thing" |];
         (
           {
-            thing = !field_thing;
-            other_thing = !field_other_thing;
+            thing = (match !field_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "thing");
+            other_thing = (match !field_other_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "other_thing");
           }
          : a)
       )

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -368,10 +368,9 @@ and read_r = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_a = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_c = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_a = ref (None) in
+    let field_b = ref (None) in
+    let field_c = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -407,25 +406,28 @@ and read_r = (
         match i with
           | 0 ->
             field_a := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_c := (
-              (
-                read_p
-              ) p lb
+              Some (
+                (
+                  read_p
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -465,25 +467,28 @@ and read_r = (
           match i with
             | 0 ->
               field_a := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_c := (
-                (
-                  read_p
-                ) p lb
+                Some (
+                  (
+                    read_p
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -491,12 +496,11 @@ and read_r = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "a"; "b"; "c" |];
         (
           {
-            a = !field_a;
-            b = !field_b;
-            c = !field_c;
+            a = (match !field_a with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "a");
+            b = (match !field_b with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b");
+            c = (match !field_c with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "c");
           }
          : r)
       )
@@ -592,9 +596,8 @@ and read_poly read__x read__y = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_fst = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_snd = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_fst = ref (None) in
+    let field_snd = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -639,18 +642,20 @@ and read_poly read__x read__y = (
         match i with
           | 0 ->
             field_fst := (
-              (
-                read__19 read__x
-              ) p lb
+              Some (
+                (
+                  read__19 read__x
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_snd := (
-              (
-                read__20 read__x read__y
-              ) p lb
+              Some (
+                (
+                  read__20 read__x read__y
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -699,18 +704,20 @@ and read_poly read__x read__y = (
           match i with
             | 0 ->
               field_fst := (
-                (
-                  read__19 read__x
-                ) p lb
+                Some (
+                  (
+                    read__19 read__x
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_snd := (
-                (
-                  read__20 read__x read__y
-                ) p lb
+                Some (
+                  (
+                    read__20 read__x read__y
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -718,11 +725,10 @@ and read_poly read__x read__y = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "fst"; "snd" |];
         (
           {
-            fst = !field_fst;
-            snd = !field_snd;
+            fst = (match !field_fst with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "fst");
+            snd = (match !field_snd with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "snd");
           }
          : ('x, 'y) poly)
       )
@@ -1012,8 +1018,7 @@ let read_val1 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_val1_x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_val1_x = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1036,11 +1041,12 @@ let read_val1 = (
         match i with
           | 0 ->
             field_val1_x := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -1067,11 +1073,12 @@ let read_val1 = (
           match i with
             | 0 ->
               field_val1_x := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -1079,10 +1086,9 @@ let read_val1 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "val1_x" |];
         (
           {
-            val1_x = !field_val1_x;
+            val1_x = (match !field_val1_x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "val1_x");
           }
          : val1)
       )
@@ -1180,9 +1186,8 @@ let read_val2 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_val2_x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_val2_x = ref (None) in
     let field_val2_y = ref (None) in
-    let bits0 = ref 0 in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1215,11 +1220,12 @@ let read_val2 = (
         match i with
           | 0 ->
             field_val2_x := (
-              (
-                read_val1
-              ) p lb
+              Some (
+                (
+                  read_val1
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_val2_y := (
@@ -1266,11 +1272,12 @@ let read_val2 = (
           match i with
             | 0 ->
               field_val2_x := (
-                (
-                  read_val1
-                ) p lb
+                Some (
+                  (
+                    read_val1
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_val2_y := (
@@ -1288,10 +1295,9 @@ let read_val2 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "val2_x" |];
         (
           {
-            val2_x = !field_val2_x;
+            val2_x = (match !field_val2_x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "val2_x");
             val2_y = !field_val2_y;
           }
          : val2)
@@ -1919,20 +1925,19 @@ let read_mixed_record = (
     Yojson.Safe.read_lcurl p lb;
     let field_field0 = ref (None) in
     let field_field1 = ref (None) in
-    let field_field2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field3 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field4 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_field2 = ref (None) in
+    let field_field3 = ref (None) in
+    let field_field4 = ref (None) in
     let field_field5 = ref (None) in
     let field_field6 = ref (None) in
-    let field_field7 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field8 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field9 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field10 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_field7 = ref (None) in
+    let field_field8 = ref (None) in
+    let field_field9 = ref (None) in
+    let field_field10 = ref (None) in
     let field_field11 = ref (false) in
-    let field_field12 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field13 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field14 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_field12 = ref (None) in
+    let field_field13 = ref (None) in
+    let field_field14 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -2044,25 +2049,28 @@ let read_mixed_record = (
             )
           | 2 ->
             field_field2 := (
-              (
-                read__6
-              ) p lb
+              Some (
+                (
+                  read__6
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 3 ->
             field_field3 := (
-              (
-                Atdgen_runtime.Oj_run.read_int64
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int64
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 4 ->
             field_field4 := (
-              (
-                read__7
-              ) p lb
+              Some (
+                (
+                  read__7
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_field5 := (
@@ -2085,117 +2093,121 @@ let read_mixed_record = (
             )
           | 7 ->
             field_field7 := (
-              (
-                read_test_variant
-              ) p lb
+              Some (
+                (
+                  read_test_variant
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x8;
           | 8 ->
             field_field8 := (
-              (
-                read__9
-              ) p lb
+              Some (
+                (
+                  read__9
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x10;
           | 9 ->
             field_field9 := (
-              (
-                fun p lb ->
-                  Yojson.Safe.read_space p lb;
-                  let std_tuple = Yojson.Safe.start_any_tuple p lb in
-                  let len = ref 0 in
-                  let end_of_tuple = ref false in
-                  (try
-                    let x0 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x1 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x2 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int8
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x3 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x4 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int32
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x5 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int64
-                        ) p lb
-                      in
-                      incr len;
-                      (try
+              Some (
+                (
+                  fun p lb ->
+                    Yojson.Safe.read_space p lb;
+                    let std_tuple = Yojson.Safe.start_any_tuple p lb in
+                    let len = ref 0 in
+                    let end_of_tuple = ref false in
+                    (try
+                      let x0 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
                         Yojson.Safe.read_space p lb;
                         Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      with Yojson.End_of_tuple -> end_of_tuple := true);
-                      x
-                    in
-                    if not !end_of_tuple then (
-                      try
-                        while true do
-                          Yojson.Safe.skip_json p lb;
+                        x
+                      in
+                      let x1 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x2 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int8
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x3 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x4 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int32
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x5 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int64
+                          ) p lb
+                        in
+                        incr len;
+                        (try
                           Yojson.Safe.read_space p lb;
                           Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        done
-                      with Yojson.End_of_tuple -> ()
-                    );
-                    (x0, x1, x2, x3, x4, x5)
-                  with Yojson.End_of_tuple ->
-                    Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
-              ) p lb
+                        with Yojson.End_of_tuple -> end_of_tuple := true);
+                        x
+                      in
+                      if not !end_of_tuple then (
+                        try
+                          while true do
+                            Yojson.Safe.skip_json p lb;
+                            Yojson.Safe.read_space p lb;
+                            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          done
+                        with Yojson.End_of_tuple -> ()
+                      );
+                      (x0, x1, x2, x3, x4, x5)
+                    with Yojson.End_of_tuple ->
+                      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x20;
           | 10 ->
             field_field10 := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x40;
           | 11 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_field11 := (
@@ -2206,25 +2218,28 @@ let read_mixed_record = (
             )
           | 12 ->
             field_field12 := (
-              (
-                read__10
-              ) p lb
+              Some (
+                (
+                  read__10
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x80;
           | 13 ->
             field_field13 := (
-              (
-                read__11
-              ) p lb
+              Some (
+                (
+                  read__11
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x100;
           | 14 ->
             field_field14 := (
-              (
-                read_date
-              ) p lb
+              Some (
+                (
+                  read_date
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x200;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -2340,25 +2355,28 @@ let read_mixed_record = (
               )
             | 2 ->
               field_field2 := (
-                (
-                  read__6
-                ) p lb
+                Some (
+                  (
+                    read__6
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 3 ->
               field_field3 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int64
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int64
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 4 ->
               field_field4 := (
-                (
-                  read__7
-                ) p lb
+                Some (
+                  (
+                    read__7
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_field5 := (
@@ -2381,117 +2399,121 @@ let read_mixed_record = (
               )
             | 7 ->
               field_field7 := (
-                (
-                  read_test_variant
-                ) p lb
+                Some (
+                  (
+                    read_test_variant
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x8;
             | 8 ->
               field_field8 := (
-                (
-                  read__9
-                ) p lb
+                Some (
+                  (
+                    read__9
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x10;
             | 9 ->
               field_field9 := (
-                (
-                  fun p lb ->
-                    Yojson.Safe.read_space p lb;
-                    let std_tuple = Yojson.Safe.start_any_tuple p lb in
-                    let len = ref 0 in
-                    let end_of_tuple = ref false in
-                    (try
-                      let x0 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x1 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x2 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int8
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x3 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x4 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int32
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x5 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int64
-                          ) p lb
-                        in
-                        incr len;
-                        (try
+                Some (
+                  (
+                    fun p lb ->
+                      Yojson.Safe.read_space p lb;
+                      let std_tuple = Yojson.Safe.start_any_tuple p lb in
+                      let len = ref 0 in
+                      let end_of_tuple = ref false in
+                      (try
+                        let x0 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
                           Yojson.Safe.read_space p lb;
                           Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        with Yojson.End_of_tuple -> end_of_tuple := true);
-                        x
-                      in
-                      if not !end_of_tuple then (
-                        try
-                          while true do
-                            Yojson.Safe.skip_json p lb;
+                          x
+                        in
+                        let x1 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x2 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int8
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x3 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x4 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int32
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x5 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int64
+                            ) p lb
+                          in
+                          incr len;
+                          (try
                             Yojson.Safe.read_space p lb;
                             Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                          done
-                        with Yojson.End_of_tuple -> ()
-                      );
-                      (x0, x1, x2, x3, x4, x5)
-                    with Yojson.End_of_tuple ->
-                      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
-                ) p lb
+                          with Yojson.End_of_tuple -> end_of_tuple := true);
+                          x
+                        in
+                        if not !end_of_tuple then (
+                          try
+                            while true do
+                              Yojson.Safe.skip_json p lb;
+                              Yojson.Safe.read_space p lb;
+                              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                            done
+                          with Yojson.End_of_tuple -> ()
+                        );
+                        (x0, x1, x2, x3, x4, x5)
+                      with Yojson.End_of_tuple ->
+                        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x20;
             | 10 ->
               field_field10 := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x40;
             | 11 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_field11 := (
@@ -2502,25 +2524,28 @@ let read_mixed_record = (
               )
             | 12 ->
               field_field12 := (
-                (
-                  read__10
-                ) p lb
+                Some (
+                  (
+                    read__10
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x80;
             | 13 ->
               field_field13 := (
-                (
-                  read__11
-                ) p lb
+                Some (
+                  (
+                    read__11
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x100;
             | 14 ->
               field_field14 := (
-                (
-                  read_date
-                ) p lb
+                Some (
+                  (
+                    read_date
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x200;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -2528,24 +2553,23 @@ let read_mixed_record = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3ff then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "field2"; "field3"; "field4"; "field7"; "field8"; "field9"; "field10"; "field12"; "field13"; "field14" |];
         (
           {
             field0 = !field_field0;
             field1 = !field_field1;
-            field2 = !field_field2;
-            field3 = !field_field3;
-            field4 = !field_field4;
+            field2 = (match !field_field2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field2");
+            field3 = (match !field_field3 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field3");
+            field4 = (match !field_field4 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field4");
             field5 = !field_field5;
             field6 = !field_field6;
-            field7 = !field_field7;
-            field8 = !field_field8;
-            field9 = !field_field9;
-            field10 = !field_field10;
+            field7 = (match !field_field7 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field7");
+            field8 = (match !field_field8 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field8");
+            field9 = (match !field_field9 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field9");
+            field10 = (match !field_field10 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field10");
             field11 = !field_field11;
-            field12 = !field_field12;
-            field13 = !field_field13;
-            field14 = !field_field14;
+            field12 = (match !field_field12 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field12");
+            field13 = (match !field_field13 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field13");
+            field14 = (match !field_field14 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field14");
           }
          : mixed_record)
       )
@@ -2747,10 +2771,9 @@ let read_test = (
     Yojson.Safe.read_lcurl p lb;
     let field_x0 = ref (None) in
     let field_x1 = ref (None) in
-    let field_x2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_x3 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_x4 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x2 = ref (None) in
+    let field_x3 = ref (None) in
+    let field_x4 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -2812,25 +2835,28 @@ let read_test = (
             )
           | 2 ->
             field_x2 := (
-              (
-                read_mixed
-              ) p lb
+              Some (
+                (
+                  read_mixed
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 3 ->
             field_x3 := (
-              (
-                read__15
-              ) p lb
+              Some (
+                (
+                  read__15
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 4 ->
             field_x4 := (
-              (
-                Atdgen_runtime.Oj_run.read_int64
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int64
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -2896,25 +2922,28 @@ let read_test = (
               )
             | 2 ->
               field_x2 := (
-                (
-                  read_mixed
-                ) p lb
+                Some (
+                  (
+                    read_mixed
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 3 ->
               field_x3 := (
-                (
-                  read__15
-                ) p lb
+                Some (
+                  (
+                    read__15
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 4 ->
               field_x4 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int64
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int64
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -2922,14 +2951,13 @@ let read_test = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x2"; "x3"; "x4" |];
         (
           {
             x0 = !field_x0;
             x1 = !field_x1;
-            x2 = !field_x2;
-            x3 = !field_x3;
-            x4 = !field_x4;
+            x2 = (match !field_x2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x2");
+            x3 = (match !field_x3 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x3");
+            x4 = (match !field_x4 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x4");
           }
          : test)
       )
@@ -3037,8 +3065,7 @@ let read__30 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_x294623 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x294623 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3061,11 +3088,12 @@ let read__30 = (
         match i with
           | 0 ->
             field_x294623 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3092,11 +3120,12 @@ let read__30 = (
           match i with
             | 0 ->
               field_x294623 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3104,10 +3133,9 @@ let read__30 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x294623" |];
         (
           {
-            x294623 = !field_x294623;
+            x294623 = (match !field_x294623 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x294623");
           }
          : _ generic)
       )
@@ -3149,8 +3177,7 @@ let read_some_record = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_some_field = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_some_field = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3173,11 +3200,12 @@ let read_some_record = (
         match i with
           | 0 ->
             field_some_field := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3204,11 +3232,12 @@ let read_some_record = (
           match i with
             | 0 ->
               field_some_field := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3216,10 +3245,9 @@ let read_some_record = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "some_field" |];
         (
           {
-            some_field = !field_some_field;
+            some_field = (match !field_some_field with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "some_field");
           }
          : some_record)
       )
@@ -3267,10 +3295,9 @@ let read_precision = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_sqrt2_5 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_small_2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_large_2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_sqrt2_5 = ref (None) in
+    let field_small_2 = ref (None) in
+    let field_large_2 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3331,25 +3358,28 @@ let read_precision = (
         match i with
           | 0 ->
             field_sqrt2_5 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_small_2 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_large_2 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3414,25 +3444,28 @@ let read_precision = (
           match i with
             | 0 ->
               field_sqrt2_5 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_small_2 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_large_2 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3440,12 +3473,11 @@ let read_precision = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "sqrt2_5"; "small_2"; "large_2" |];
         (
           {
-            sqrt2_5 = !field_sqrt2_5;
-            small_2 = !field_small_2;
-            large_2 = !field_large_2;
+            sqrt2_5 = (match !field_sqrt2_5 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "sqrt2_5");
+            small_2 = (match !field_small_2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "small_2");
+            large_2 = (match !field_large_2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "large_2");
           }
          : precision)
       )
@@ -3849,8 +3881,7 @@ let read_generic read__a = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_x294623 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x294623 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3873,11 +3904,12 @@ let read_generic read__a = (
         match i with
           | 0 ->
             field_x294623 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3904,11 +3936,12 @@ let read_generic read__a = (
           match i with
             | 0 ->
               field_x294623 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3916,10 +3949,9 @@ let read_generic read__a = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x294623" |];
         (
           {
-            x294623 = !field_x294623;
+            x294623 = (match !field_x294623 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x294623");
           }
          : 'a generic)
       )
@@ -3958,9 +3990,8 @@ let read_floats = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_f32 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_f64 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_f32 = ref (None) in
+    let field_f64 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -4005,18 +4036,20 @@ let read_floats = (
         match i with
           | 0 ->
             field_f32 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_f64 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -4065,18 +4098,20 @@ let read_floats = (
           match i with
             | 0 ->
               field_f32 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_f64 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -4084,11 +4119,10 @@ let read_floats = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "f32"; "f64" |];
         (
           {
-            f32 = !field_f32;
-            f64 = !field_f64;
+            f32 = (match !field_f32 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f32");
+            f64 = (match !field_f64 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f64");
           }
          : floats)
       )
@@ -4323,13 +4357,12 @@ let read_extended = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_b0x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b1x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b2x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_b0x = ref (None) in
+    let field_b1x = ref (None) in
+    let field_b2x = ref (None) in
     let field_b3x = ref (None) in
-    let field_b4x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_b4x = ref (None) in
     let field_b5x = ref (0.5) in
-    let bits0 = ref 0 in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -4374,25 +4407,28 @@ let read_extended = (
         match i with
           | 0 ->
             field_b0x := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b1x := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_b2x := (
-              (
-                Atdgen_runtime.Oj_run.read_string
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | 3 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_b3x := (
@@ -4405,11 +4441,12 @@ let read_extended = (
             )
           | 4 ->
             field_b4x := (
-              (
-                read__6
-              ) p lb
+              Some (
+                (
+                  read__6
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x8;
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_b5x := (
@@ -4466,25 +4503,28 @@ let read_extended = (
           match i with
             | 0 ->
               field_b0x := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b1x := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_b2x := (
-                (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | 3 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_b3x := (
@@ -4497,11 +4537,12 @@ let read_extended = (
               )
             | 4 ->
               field_b4x := (
-                (
-                  read__6
-                ) p lb
+                Some (
+                  (
+                    read__6
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x8;
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_b5x := (
@@ -4517,14 +4558,13 @@ let read_extended = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0xf then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "b0"; "b1"; "b2"; "b4" |];
         (
           {
-            b0x = !field_b0x;
-            b1x = !field_b1x;
-            b2x = !field_b2x;
+            b0x = (match !field_b0x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b0x");
+            b1x = (match !field_b1x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b1x");
+            b2x = (match !field_b2x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b2x");
             b3x = !field_b3x;
-            b4x = !field_b4x;
+            b4x = (match !field_b4x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b4x");
             b5x = !field_b5x;
           }
          : extended)
@@ -4685,9 +4725,8 @@ let read_base = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_b0 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b1 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_b0 = ref (None) in
+    let field_b1 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -4720,18 +4759,20 @@ let read_base = (
         match i with
           | 0 ->
             field_b0 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b1 := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -4768,18 +4809,20 @@ let read_base = (
           match i with
             | 0 ->
               field_b0 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b1 := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -4787,11 +4830,10 @@ let read_base = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "b0"; "b1" |];
         (
           {
-            b0 = !field_b0;
-            b1 = !field_b1;
+            b0 = (match !field_b0 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b0");
+            b1 = (match !field_b1 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b1");
           }
          : base)
       )

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -368,10 +368,9 @@ and read_r = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_a = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_c = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_a = ref (None) in
+    let field_b = ref (None) in
+    let field_c = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -405,25 +404,28 @@ and read_r = (
         match i with
           | 0 ->
             field_a := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_c := (
-              (
-                read_p
-              ) p lb
+              Some (
+                (
+                  read_p
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -461,25 +463,28 @@ and read_r = (
           match i with
             | 0 ->
               field_a := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_c := (
-                (
-                  read_p
-                ) p lb
+                Some (
+                  (
+                    read_p
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -487,12 +492,11 @@ and read_r = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "a"; "b"; "c" |];
         (
           {
-            a = !field_a;
-            b = !field_b;
-            c = !field_c;
+            a = (match !field_a with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "a");
+            b = (match !field_b with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b");
+            c = (match !field_c with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "c");
           }
          : r)
       )
@@ -588,9 +592,8 @@ and read_poly read__x read__y = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_fst = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_snd = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_fst = ref (None) in
+    let field_snd = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -631,18 +634,20 @@ and read_poly read__x read__y = (
         match i with
           | 0 ->
             field_fst := (
-              (
-                read__19 read__x
-              ) p lb
+              Some (
+                (
+                  read__19 read__x
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_snd := (
-              (
-                read__20 read__x read__y
-              ) p lb
+              Some (
+                (
+                  read__20 read__x read__y
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -687,18 +692,20 @@ and read_poly read__x read__y = (
           match i with
             | 0 ->
               field_fst := (
-                (
-                  read__19 read__x
-                ) p lb
+                Some (
+                  (
+                    read__19 read__x
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_snd := (
-                (
-                  read__20 read__x read__y
-                ) p lb
+                Some (
+                  (
+                    read__20 read__x read__y
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -706,11 +713,10 @@ and read_poly read__x read__y = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "fst"; "snd" |];
         (
           {
-            fst = !field_fst;
-            snd = !field_snd;
+            fst = (match !field_fst with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "fst");
+            snd = (match !field_snd with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "snd");
           }
          : ('x, 'y) poly)
       )
@@ -1000,8 +1006,7 @@ let read_val1 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_val1_x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_val1_x = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1023,11 +1028,12 @@ let read_val1 = (
         match i with
           | 0 ->
             field_val1_x := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -1053,11 +1059,12 @@ let read_val1 = (
           match i with
             | 0 ->
               field_val1_x := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -1065,10 +1072,9 @@ let read_val1 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "val1_x" |];
         (
           {
-            val1_x = !field_val1_x;
+            val1_x = (match !field_val1_x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "val1_x");
           }
          : val1)
       )
@@ -1166,9 +1172,8 @@ let read_val2 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_val2_x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_val2_x = ref (None) in
     let field_val2_y = ref (None) in
-    let bits0 = ref 0 in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -1199,11 +1204,12 @@ let read_val2 = (
         match i with
           | 0 ->
             field_val2_x := (
-              (
-                read_val1
-              ) p lb
+              Some (
+                (
+                  read_val1
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_val2_y := (
@@ -1248,11 +1254,12 @@ let read_val2 = (
           match i with
             | 0 ->
               field_val2_x := (
-                (
-                  read_val1
-                ) p lb
+                Some (
+                  (
+                    read_val1
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_val2_y := (
@@ -1270,10 +1277,9 @@ let read_val2 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "val2_x" |];
         (
           {
-            val2_x = !field_val2_x;
+            val2_x = (match !field_val2_x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "val2_x");
             val2_y = !field_val2_y;
           }
          : val2)
@@ -1901,20 +1907,19 @@ let read_mixed_record = (
     Yojson.Safe.read_lcurl p lb;
     let field_field0 = ref (None) in
     let field_field1 = ref (None) in
-    let field_field2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field3 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field4 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_field2 = ref (None) in
+    let field_field3 = ref (None) in
+    let field_field4 = ref (None) in
     let field_field5 = ref (None) in
     let field_field6 = ref (None) in
-    let field_field7 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field8 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field9 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field10 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_field7 = ref (None) in
+    let field_field8 = ref (None) in
+    let field_field9 = ref (None) in
+    let field_field10 = ref (None) in
     let field_field11 = ref (false) in
-    let field_field12 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field13 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_field14 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_field12 = ref (None) in
+    let field_field13 = ref (None) in
+    let field_field14 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -2021,25 +2026,28 @@ let read_mixed_record = (
             )
           | 2 ->
             field_field2 := (
-              (
-                read__6
-              ) p lb
+              Some (
+                (
+                  read__6
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 3 ->
             field_field3 := (
-              (
-                Atdgen_runtime.Oj_run.read_int64
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int64
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 4 ->
             field_field4 := (
-              (
-                read__7
-              ) p lb
+              Some (
+                (
+                  read__7
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_field5 := (
@@ -2062,117 +2070,121 @@ let read_mixed_record = (
             )
           | 7 ->
             field_field7 := (
-              (
-                read_test_variant
-              ) p lb
+              Some (
+                (
+                  read_test_variant
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x8;
           | 8 ->
             field_field8 := (
-              (
-                read__9
-              ) p lb
+              Some (
+                (
+                  read__9
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x10;
           | 9 ->
             field_field9 := (
-              (
-                fun p lb ->
-                  Yojson.Safe.read_space p lb;
-                  let std_tuple = Yojson.Safe.start_any_tuple p lb in
-                  let len = ref 0 in
-                  let end_of_tuple = ref false in
-                  (try
-                    let x0 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x1 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x2 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int8
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x3 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x4 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int32
-                        ) p lb
-                      in
-                      incr len;
-                      Yojson.Safe.read_space p lb;
-                      Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      x
-                    in
-                    let x5 =
-                      let x =
-                        (
-                          Atdgen_runtime.Oj_run.read_int64
-                        ) p lb
-                      in
-                      incr len;
-                      (try
+              Some (
+                (
+                  fun p lb ->
+                    Yojson.Safe.read_space p lb;
+                    let std_tuple = Yojson.Safe.start_any_tuple p lb in
+                    let len = ref 0 in
+                    let end_of_tuple = ref false in
+                    (try
+                      let x0 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
                         Yojson.Safe.read_space p lb;
                         Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                      with Yojson.End_of_tuple -> end_of_tuple := true);
-                      x
-                    in
-                    if not !end_of_tuple then (
-                      try
-                        while true do
-                          Yojson.Safe.skip_json p lb;
+                        x
+                      in
+                      let x1 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x2 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int8
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x3 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x4 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int32
+                          ) p lb
+                        in
+                        incr len;
+                        Yojson.Safe.read_space p lb;
+                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                        x
+                      in
+                      let x5 =
+                        let x =
+                          (
+                            Atdgen_runtime.Oj_run.read_int64
+                          ) p lb
+                        in
+                        incr len;
+                        (try
                           Yojson.Safe.read_space p lb;
                           Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        done
-                      with Yojson.End_of_tuple -> ()
-                    );
-                    (x0, x1, x2, x3, x4, x5)
-                  with Yojson.End_of_tuple ->
-                    Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
-              ) p lb
+                        with Yojson.End_of_tuple -> end_of_tuple := true);
+                        x
+                      in
+                      if not !end_of_tuple then (
+                        try
+                          while true do
+                            Yojson.Safe.skip_json p lb;
+                            Yojson.Safe.read_space p lb;
+                            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          done
+                        with Yojson.End_of_tuple -> ()
+                      );
+                      (x0, x1, x2, x3, x4, x5)
+                    with Yojson.End_of_tuple ->
+                      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x20;
           | 10 ->
             field_field10 := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x40;
           | 11 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_field11 := (
@@ -2183,25 +2195,28 @@ let read_mixed_record = (
             )
           | 12 ->
             field_field12 := (
-              (
-                read__10
-              ) p lb
+              Some (
+                (
+                  read__10
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x80;
           | 13 ->
             field_field13 := (
-              (
-                read__11
-              ) p lb
+              Some (
+                (
+                  read__11
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x100;
           | 14 ->
             field_field14 := (
-              (
-                read_date
-              ) p lb
+              Some (
+                (
+                  read_date
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x200;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -2312,25 +2327,28 @@ let read_mixed_record = (
               )
             | 2 ->
               field_field2 := (
-                (
-                  read__6
-                ) p lb
+                Some (
+                  (
+                    read__6
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 3 ->
               field_field3 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int64
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int64
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 4 ->
               field_field4 := (
-                (
-                  read__7
-                ) p lb
+                Some (
+                  (
+                    read__7
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_field5 := (
@@ -2353,117 +2371,121 @@ let read_mixed_record = (
               )
             | 7 ->
               field_field7 := (
-                (
-                  read_test_variant
-                ) p lb
+                Some (
+                  (
+                    read_test_variant
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x8;
             | 8 ->
               field_field8 := (
-                (
-                  read__9
-                ) p lb
+                Some (
+                  (
+                    read__9
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x10;
             | 9 ->
               field_field9 := (
-                (
-                  fun p lb ->
-                    Yojson.Safe.read_space p lb;
-                    let std_tuple = Yojson.Safe.start_any_tuple p lb in
-                    let len = ref 0 in
-                    let end_of_tuple = ref false in
-                    (try
-                      let x0 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x1 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x2 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int8
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x3 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x4 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int32
-                          ) p lb
-                        in
-                        incr len;
-                        Yojson.Safe.read_space p lb;
-                        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        x
-                      in
-                      let x5 =
-                        let x =
-                          (
-                            Atdgen_runtime.Oj_run.read_int64
-                          ) p lb
-                        in
-                        incr len;
-                        (try
+                Some (
+                  (
+                    fun p lb ->
+                      Yojson.Safe.read_space p lb;
+                      let std_tuple = Yojson.Safe.start_any_tuple p lb in
+                      let len = ref 0 in
+                      let end_of_tuple = ref false in
+                      (try
+                        let x0 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
                           Yojson.Safe.read_space p lb;
                           Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                        with Yojson.End_of_tuple -> end_of_tuple := true);
-                        x
-                      in
-                      if not !end_of_tuple then (
-                        try
-                          while true do
-                            Yojson.Safe.skip_json p lb;
+                          x
+                        in
+                        let x1 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x2 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int8
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x3 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x4 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int32
+                            ) p lb
+                          in
+                          incr len;
+                          Yojson.Safe.read_space p lb;
+                          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                          x
+                        in
+                        let x5 =
+                          let x =
+                            (
+                              Atdgen_runtime.Oj_run.read_int64
+                            ) p lb
+                          in
+                          incr len;
+                          (try
                             Yojson.Safe.read_space p lb;
                             Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-                          done
-                        with Yojson.End_of_tuple -> ()
-                      );
-                      (x0, x1, x2, x3, x4, x5)
-                    with Yojson.End_of_tuple ->
-                      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
-                ) p lb
+                          with Yojson.End_of_tuple -> end_of_tuple := true);
+                          x
+                        in
+                        if not !end_of_tuple then (
+                          try
+                            while true do
+                              Yojson.Safe.skip_json p lb;
+                              Yojson.Safe.read_space p lb;
+                              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+                            done
+                          with Yojson.End_of_tuple -> ()
+                        );
+                        (x0, x1, x2, x3, x4, x5)
+                      with Yojson.End_of_tuple ->
+                        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2; 3; 4; 5 ]);
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x20;
             | 10 ->
               field_field10 := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x40;
             | 11 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_field11 := (
@@ -2474,25 +2496,28 @@ let read_mixed_record = (
               )
             | 12 ->
               field_field12 := (
-                (
-                  read__10
-                ) p lb
+                Some (
+                  (
+                    read__10
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x80;
             | 13 ->
               field_field13 := (
-                (
-                  read__11
-                ) p lb
+                Some (
+                  (
+                    read__11
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x100;
             | 14 ->
               field_field14 := (
-                (
-                  read_date
-                ) p lb
+                Some (
+                  (
+                    read_date
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x200;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -2500,24 +2525,23 @@ let read_mixed_record = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3ff then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "field2"; "field3"; "field4"; "field7"; "field8"; "field9"; "field10"; "field12"; "field13"; "field14" |];
         (
           {
             field0 = !field_field0;
             field1 = !field_field1;
-            field2 = !field_field2;
-            field3 = !field_field3;
-            field4 = !field_field4;
+            field2 = (match !field_field2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field2");
+            field3 = (match !field_field3 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field3");
+            field4 = (match !field_field4 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field4");
             field5 = !field_field5;
             field6 = !field_field6;
-            field7 = !field_field7;
-            field8 = !field_field8;
-            field9 = !field_field9;
-            field10 = !field_field10;
+            field7 = (match !field_field7 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field7");
+            field8 = (match !field_field8 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field8");
+            field9 = (match !field_field9 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field9");
+            field10 = (match !field_field10 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field10");
             field11 = !field_field11;
-            field12 = !field_field12;
-            field13 = !field_field13;
-            field14 = !field_field14;
+            field12 = (match !field_field12 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field12");
+            field13 = (match !field_field13 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field13");
+            field14 = (match !field_field14 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "field14");
           }
          : mixed_record)
       )
@@ -2719,10 +2743,9 @@ let read_test = (
     Yojson.Safe.read_lcurl p lb;
     let field_x0 = ref (None) in
     let field_x1 = ref (None) in
-    let field_x2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_x3 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_x4 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x2 = ref (None) in
+    let field_x3 = ref (None) in
+    let field_x4 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -2782,25 +2805,28 @@ let read_test = (
             )
           | 2 ->
             field_x2 := (
-              (
-                read_mixed
-              ) p lb
+              Some (
+                (
+                  read_mixed
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 3 ->
             field_x3 := (
-              (
-                read__15
-              ) p lb
+              Some (
+                (
+                  read__15
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 4 ->
             field_x4 := (
-              (
-                Atdgen_runtime.Oj_run.read_int64
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int64
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -2864,25 +2890,28 @@ let read_test = (
               )
             | 2 ->
               field_x2 := (
-                (
-                  read_mixed
-                ) p lb
+                Some (
+                  (
+                    read_mixed
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 3 ->
               field_x3 := (
-                (
-                  read__15
-                ) p lb
+                Some (
+                  (
+                    read__15
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 4 ->
               field_x4 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int64
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int64
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -2890,14 +2919,13 @@ let read_test = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x2"; "x3"; "x4" |];
         (
           {
             x0 = !field_x0;
             x1 = !field_x1;
-            x2 = !field_x2;
-            x3 = !field_x3;
-            x4 = !field_x4;
+            x2 = (match !field_x2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x2");
+            x3 = (match !field_x3 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x3");
+            x4 = (match !field_x4 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x4");
           }
          : test)
       )
@@ -3005,8 +3033,7 @@ let read__30 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_x294623 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x294623 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3028,11 +3055,12 @@ let read__30 = (
         match i with
           | 0 ->
             field_x294623 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3058,11 +3086,12 @@ let read__30 = (
           match i with
             | 0 ->
               field_x294623 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3070,10 +3099,9 @@ let read__30 = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x294623" |];
         (
           {
-            x294623 = !field_x294623;
+            x294623 = (match !field_x294623 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x294623");
           }
          : _ generic)
       )
@@ -3115,8 +3143,7 @@ let read_some_record = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_some_field = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_some_field = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3138,11 +3165,12 @@ let read_some_record = (
         match i with
           | 0 ->
             field_some_field := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3168,11 +3196,12 @@ let read_some_record = (
           match i with
             | 0 ->
               field_some_field := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3180,10 +3209,9 @@ let read_some_record = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "some_field" |];
         (
           {
-            some_field = !field_some_field;
+            some_field = (match !field_some_field with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "some_field");
           }
          : some_record)
       )
@@ -3231,10 +3259,9 @@ let read_precision = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_sqrt2_5 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_small_2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_large_2 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_sqrt2_5 = ref (None) in
+    let field_small_2 = ref (None) in
+    let field_large_2 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3289,25 +3316,28 @@ let read_precision = (
         match i with
           | 0 ->
             field_sqrt2_5 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_small_2 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_large_2 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3366,25 +3396,28 @@ let read_precision = (
           match i with
             | 0 ->
               field_sqrt2_5 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_small_2 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_large_2 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3392,12 +3425,11 @@ let read_precision = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x7 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "sqrt2_5"; "small_2"; "large_2" |];
         (
           {
-            sqrt2_5 = !field_sqrt2_5;
-            small_2 = !field_small_2;
-            large_2 = !field_large_2;
+            sqrt2_5 = (match !field_sqrt2_5 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "sqrt2_5");
+            small_2 = (match !field_small_2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "small_2");
+            large_2 = (match !field_large_2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "large_2");
           }
          : precision)
       )
@@ -3801,8 +3833,7 @@ let read_generic read__a = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_x294623 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_x294623 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3824,11 +3855,12 @@ let read_generic read__a = (
         match i with
           | 0 ->
             field_x294623 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -3854,11 +3886,12 @@ let read_generic read__a = (
           match i with
             | 0 ->
               field_x294623 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -3866,10 +3899,9 @@ let read_generic read__a = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x1 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "x294623" |];
         (
           {
-            x294623 = !field_x294623;
+            x294623 = (match !field_x294623 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "x294623");
           }
          : 'a generic)
       )
@@ -3908,9 +3940,8 @@ let read_floats = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_f32 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_f64 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_f32 = ref (None) in
+    let field_f64 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -3951,18 +3982,20 @@ let read_floats = (
         match i with
           | 0 ->
             field_f32 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_f64 := (
-              (
-                Atdgen_runtime.Oj_run.read_number
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -4007,18 +4040,20 @@ let read_floats = (
           match i with
             | 0 ->
               field_f32 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_f64 := (
-                (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -4026,11 +4061,10 @@ let read_floats = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "f32"; "f64" |];
         (
           {
-            f32 = !field_f32;
-            f64 = !field_f64;
+            f32 = (match !field_f32 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f32");
+            f64 = (match !field_f64 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f64");
           }
          : floats)
       )
@@ -4265,13 +4299,12 @@ let read_extended = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_b0x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b1x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b2x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_b0x = ref (None) in
+    let field_b1x = ref (None) in
+    let field_b2x = ref (None) in
     let field_b3x = ref (None) in
-    let field_b4x = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_b4x = ref (None) in
     let field_b5x = ref (0.5) in
-    let bits0 = ref 0 in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -4314,25 +4347,28 @@ let read_extended = (
         match i with
           | 0 ->
             field_b0x := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b1x := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | 2 ->
             field_b2x := (
-              (
-                Atdgen_runtime.Oj_run.read_string
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x4;
           | 3 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_b3x := (
@@ -4345,11 +4381,12 @@ let read_extended = (
             )
           | 4 ->
             field_b4x := (
-              (
-                read__6
-              ) p lb
+              Some (
+                (
+                  read__6
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x8;
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
               field_b5x := (
@@ -4404,25 +4441,28 @@ let read_extended = (
           match i with
             | 0 ->
               field_b0x := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b1x := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | 2 ->
               field_b2x := (
-                (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x4;
             | 3 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_b3x := (
@@ -4435,11 +4475,12 @@ let read_extended = (
               )
             | 4 ->
               field_b4x := (
-                (
-                  read__6
-                ) p lb
+                Some (
+                  (
+                    read__6
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x8;
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
                 field_b5x := (
@@ -4455,14 +4496,13 @@ let read_extended = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0xf then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "b0"; "b1"; "b2"; "b4" |];
         (
           {
-            b0x = !field_b0x;
-            b1x = !field_b1x;
-            b2x = !field_b2x;
+            b0x = (match !field_b0x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b0x");
+            b1x = (match !field_b1x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b1x");
+            b2x = (match !field_b2x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b2x");
             b3x = !field_b3x;
-            b4x = !field_b4x;
+            b4x = (match !field_b4x with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b4x");
             b5x = !field_b5x;
           }
          : extended)
@@ -4623,9 +4663,8 @@ let read_base = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_b0 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let field_b1 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
-    let bits0 = ref 0 in
+    let field_b0 = ref (None) in
+    let field_b1 = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -4656,18 +4695,20 @@ let read_base = (
         match i with
           | 0 ->
             field_b0 := (
-              (
-                Atdgen_runtime.Oj_run.read_int
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x1;
           | 1 ->
             field_b1 := (
-              (
-                Atdgen_runtime.Oj_run.read_bool
-              ) p lb
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
             );
-            bits0 := !bits0 lor 0x2;
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -4702,18 +4743,20 @@ let read_base = (
           match i with
             | 0 ->
               field_b0 := (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x1;
             | 1 ->
               field_b1 := (
-                (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
               );
-              bits0 := !bits0 lor 0x2;
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -4721,11 +4764,10 @@ let read_base = (
       done;
       assert false;
     with Yojson.End_of_object -> (
-        if !bits0 <> 0x3 then Atdgen_runtime.Oj_run.missing_fields p [| !bits0 |] [| "b0"; "b1" |];
         (
           {
-            b0 = !field_b0;
-            b1 = !field_b1;
+            b0 = (match !field_b0 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b0");
+            b1 = (match !field_b1 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "b1");
           }
          : base)
       )


### PR DESCRIPTION
With this, reading json objects no longer relies on `Obj.magic` (#92 ). Json support is now done entirely without the use `Obj`, which will give a peace of mind to users and maintainers alike.

The biniou/ocaml backend still uses Obj.magic in the same place (reading one record) in addition to initializing and reading its special "table" construct which is a list of records optimized for compactness. I'm reluctant to touch this right now due to the lack of benchmarks and lack of time on my end, and given that the primary goal of biniou was to have the flexibility of json with increased performance.
