### PR TITLE
Jbuild workspace refactor

### DIFF
--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -3,4 +3,4 @@
 (context ((switch 4.03.0)))
 (context ((switch 4.04.2)))
 (context ((switch 4.05.0)))
-(context ((switch 4.06.0)))
+(context ((switch 4.06.1)))

--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -1,6 +1,4 @@
 ;; This file is used by `make all-supported-ocaml-versions`
-(context ((switch 4.02.3)))
-(context ((switch 4.03.0)))
 (context ((switch 4.04.2)))
 (context ((switch 4.05.0)))
 (context ((switch 4.06.1)))


### PR DESCRIPTION
@mjambon this PR updates the list of workspaces to what we actually support today. We didn't really support 4.02 or 4.03 because opaque_identity wasn't supported in those version. With your #143 PR, we should be able to add back the support. I suggest that we merge this PR, and you rebase yours on top master. Just so to make the tests are passing on all the versions that we expect.