### PR TITLE
Generate typedefs by default + respect -nfd and -ntd cli flags

### DIFF
--- a/atdgen/src/obuckle_emit.mli
+++ b/atdgen/src/obuckle_emit.mli
@@ -1,16 +1,16 @@
 
 val make_ocaml_files
   :  opens:string list
-  -> with_typedefs:'b
-  -> with_create:'c
-  -> with_fundefs:'d
+  -> with_typedefs:bool
+  -> with_create:bool
+  -> with_fundefs:bool
   -> all_rec:bool
   -> pos_fname:string option
   -> pos_lnum:int option
   -> type_aliases:string option
-  -> force_defaults:'e
-  -> ocaml_version:'g
-  -> pp_convs:'h
+  -> force_defaults:'a
+  -> ocaml_version:'b
+  -> pp_convs:'c
   -> string option
   -> Ox_emit.target
   -> unit


### PR DESCRIPTION
This PR makes `atdgen -bs` output type declarations by default, since:
1. This is what all other generators (`-j`, `-b`, `-v`) do;
2. It is more convenient because `-open Foo_t` is not needed.

It is still possible to get the old behaviour by passing `-ntd` to atdgen (but why?).

In addition, `-nfd` is now supported, too.