### PR TITLE
Ocaml adapters support for bucklescript

### DIFF
--- a/atdgen-codec-runtime/src/decode.ml
+++ b/atdgen-codec-runtime/src/decode.ml
@@ -117,3 +117,6 @@ let option_as_constr f =
 let nullable f = function
   | `Null -> None
   | x -> Some (f x)
+
+let adapter (normalize: Json.t -> Json.t) (reader: 'a t) json =
+  reader (normalize json)

--- a/atdgen-codec-runtime/src/decode.mli
+++ b/atdgen-codec-runtime/src/decode.mli
@@ -38,3 +38,5 @@ val enum : (string * [`Single of 'a | `Decode of 'a t]) list -> 'a t
 val option_as_constr : 'a t -> 'a option t
 
 val nullable : 'a t -> 'a option t
+
+val adapter: (Json.t -> Json.t) -> ('a t) -> ('a t)

--- a/atdgen-codec-runtime/src/encode.ml
+++ b/atdgen-codec-runtime/src/encode.ml
@@ -86,3 +86,7 @@ let nullable f = function
 let option_as_constr f = function
   | None -> `Variant ("None", None)
   | Some s -> `Variant ("Some", Some (f s))
+
+let adapter (restore: Json.t -> Json.t) (writer: 'a t) x =
+  let encoded = writer x in
+  restore encoded

--- a/atdgen-codec-runtime/src/encode.mli
+++ b/atdgen-codec-runtime/src/encode.mli
@@ -37,3 +37,5 @@ val contramap : ('b -> 'a) -> 'a t -> 'b t
 val nullable : 'a t -> 'a option t
 
 val option_as_constr : 'a t -> 'a option t
+
+val adapter: (Json.t -> Json.t) -> ('a t) -> ('a t)

--- a/atdgen-codec-runtime/src/json_adapter.ml
+++ b/atdgen-codec-runtime/src/json_adapter.ml
@@ -1,0 +1,44 @@
+(* Json adapters. See .mli. *)
+
+module type S = sig
+  val normalize : Json.t -> Json.t
+  val restore : Json.t -> Json.t
+end
+
+module Type_field = struct
+  module type Param = sig
+    val type_field_name : string
+  end
+
+  module Make (Param : Param) : S = struct
+    open Param
+
+    let normalize (x : Json.t) : Json.t =
+      match x with
+      | `Assoc fields ->
+          (match List.assoc type_field_name fields with
+           | `String type_ -> `List [ `String type_; x ]
+           | exception Not_found -> x
+           | _ -> x (* malformed *)
+          )
+      | `String _ as x -> x
+      | malformed -> malformed
+
+    let restore (x : Json.t) : Json.t =
+      match x with
+      | `List [ `String type_; `Assoc fields ] ->
+          let fields =
+            (type_field_name, `String type_) ::
+            List.filter (fun (k, _) -> k <> type_field_name) fields
+          in
+          `Assoc fields
+      | `String _ as x -> x
+      | malformed -> malformed
+  end
+
+  module Default_param : Param = struct
+    let type_field_name = "type"
+  end
+
+  include Make (Default_param)
+end

--- a/atdgen-codec-runtime/src/json_adapter.mli
+++ b/atdgen-codec-runtime/src/json_adapter.mli
@@ -1,0 +1,78 @@
+(** Json adapters and tools for the user to make their own json adapters
+    for common situations.
+
+    Json adapters are used to rewrite json node into a form compatible
+    with atdgen's conventions.
+*)
+
+(** Module signature required of any json adapter.
+    For example, an ATD annotation
+    [<json
+       adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field"]
+    refers to the OCaml module
+    [Atdgen_codec_runtime.Json_adapter.Type_field].
+*)
+
+module type S = sig
+  (** Convert a real json tree into an atd-compliant form. *)
+  val normalize : Json.t -> Json.t
+
+  (** Convert an atd-compliant json tree into a real json tree. *)
+  val restore : Json.t -> Json.t
+end
+
+(** Support for json objects that contain a field that indicates
+    the type of that object.
+    The following
+{[
+{
+  "type": "User",
+  "id": "abc123",
+  "age": 52
+}
+]}
+        gets converted into a pair
+{[
+[
+  "User",
+  {
+    "type": "User",
+    "id": "abc123",
+    "age": 52
+  }
+]
+]}
+        A corresponding ATD type definition is
+{[
+type obj = [
+  | User of user
+  | ...
+] <json adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field">
+
+type user = {
+  id: string;
+  age: int;
+
+  (* The following field definition is supported, albeit useless. *)
+  type_ <json name="type">: string;
+}
+]}
+*)
+module Type_field : sig
+  module type Param = sig
+    val type_field_name : string
+  end
+
+  (** Default parameters, using [type_field_name = "type"]. *)
+  module Default_param : Param
+
+  (** Default adapter assuming a ["type"] field. *)
+  include S
+
+  (** Functor, allowing the use of a custom parameter:
+{[
+module Kind = Type_field.Make (struct type_field_name = "kind" end)
+]}
+  *)
+  module Make (Param : Param) : S
+end

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -121,14 +121,16 @@ let read_with_adapter adapter reader =
   match adapter.Json.ocaml_adapter with
   | None -> reader
   | Some adapter_path ->
-    let normalize = Oj_mapping.json_normalizer_of_adapter_path adapter_path in
-    [
-      Line (
-        sprintf "Atdgen_codec_runtime.Decode.adapter %s (" normalize
-      );
-      Block reader;
-      Line ")";
-    ]
+      let normalize =
+        Oj_mapping.json_normalizer_of_adapter_path adapter_path
+      in
+      [
+        Line (
+          sprintf "Atdgen_codec_runtime.Decode.adapter %s (" normalize
+        );
+        Block reader;
+        Line ")";
+      ]
 
 let rec make_reader ?type_annot p (x : Oj_mapping.t) : Indent.t list =
   match x with
@@ -159,23 +161,23 @@ let rec make_reader ?type_annot p (x : Oj_mapping.t) : Indent.t list =
       ]
   | List (loc, x, List o, List j) ->
       (match j with
-          Array ->
-            [ Line (sprintf "%s ("
-                      (match o with
-                       | List -> decoder_ident "list"
-                       | Array -> decoder_ident "array"))
-            ; Block (make_reader p x)
-            ; Line ")"
-            ]
-        | Object ->
-            let _k, v = Ox_emit.get_assoc_type p.deref loc x in (* TODO key wrap *)
-            [ Line (sprintf "%s ("
-                      (match o with
-                       | List -> decoder_ident "obj_list"
-                       | Array -> decoder_ident "obj_array"))
-            ; Block (make_reader p v)
-            ; Line ")"
-            ]
+         Array ->
+           [ Line (sprintf "%s ("
+                     (match o with
+                      | List -> decoder_ident "list"
+                      | Array -> decoder_ident "array"))
+           ; Block (make_reader p x)
+           ; Line ")"
+           ]
+       | Object ->
+           let _k, v = Ox_emit.get_assoc_type p.deref loc x in (* TODO key wrap *)
+           [ Line (sprintf "%s ("
+                     (match o with
+                      | List -> decoder_ident "obj_list"
+                      | Array -> decoder_ident "obj_array"))
+           ; Block (make_reader p v)
+           ; Line ")"
+           ]
       )
   | Sum (_, a, Sum osum, Sum j) ->
       if j.json_open_enum then open_enum_not_supported ();
@@ -363,7 +365,7 @@ let rec get_writer_name
       encoder_ident (
         match j with
         | Float None -> "float"
-          (* TODO *)
+        (* TODO *)
         | Float (Some _precision) -> sprintf "float"
         | Int -> "float"
       )
@@ -415,46 +417,46 @@ let rec make_writer ?type_annot p (x : Oj_mapping.t) : Indent.t list =
       ]
   | List (loc, x, List o, List j) ->
       (match j with
-          Array ->
-            [ Line (sprintf "%s ("
-                       (match o with
-                        | List -> encoder_ident "list"
-                        | Array -> encoder_ident "array"))
-            ; Block (make_writer p x)
-            ; Line ")"
-            ]
-        | Object ->
-            let _k, v = Ox_emit.get_assoc_type p.deref loc x in
-            [ Annot
-                ("fun", Line (sprintf "%s (fun (t : %s) ->"
-                               encoder_make (type_annot_str type_annot)))
-            ; Block
-                [ Line (sprintf "%s |>"
-                           (match o with
-                            | List -> "t"
-                            | Array -> "Array.to_list t"))
-                ; Line "List.map ("
-                ; Block
-                    [ Line "fun (key, value) ->"
-                    ; Block
-                        [ Line (encoder_ident "field")
-                        ; Block
-                            [ Line "("
-                            ; Block (make_writer p v)
-                            ; Line ")"
-                            ]
-                        ; Block
-                            [ Line "~name:key" (* TODO unwrap keys? *)
-                            ; Line "value";
-                            ]
-                        ]
-                    ]
-                ; Line ") |>"
-                ; Line (encoder_ident "obj")
-                ]
-            ; Line ")"
-            ]
-       )
+         Array ->
+           [ Line (sprintf "%s ("
+                     (match o with
+                      | List -> encoder_ident "list"
+                      | Array -> encoder_ident "array"))
+           ; Block (make_writer p x)
+           ; Line ")"
+           ]
+       | Object ->
+           let _k, v = Ox_emit.get_assoc_type p.deref loc x in
+           [ Annot
+               ("fun" , Line (sprintf "%s (fun (t : %s) ->"
+                                encoder_make (type_annot_str type_annot)))
+           ; Block
+               [ Line (sprintf "%s |>"
+                         (match o with
+                          | List -> "t"
+                          | Array -> "Array.to_list t"))
+               ; Line "List.map ("
+               ; Block
+                   [ Line "fun (key, value) ->"
+                   ; Block
+                       [ Line (encoder_ident "field")
+                       ; Block
+                           [ Line "("
+                           ; Block (make_writer p v)
+                           ; Line ")"
+                           ]
+                       ; Block
+                           [ Line "~name:key" (* TODO unwrap keys? *)
+                           ; Line "value";
+                           ]
+                       ]
+                   ]
+               ; Line ") |>"
+               ; Line (encoder_ident "obj")
+               ]
+           ; Line ")"
+           ]
+      )
   | Record (_, a, Record o, Record _) ->
       [ Annot
           ("fun", Line (sprintf "%s (fun (t : %s) ->"

--- a/atdgen/test/bucklescript/bucklespec.atd
+++ b/atdgen/test/bucklescript/bucklespec.atd
@@ -66,3 +66,19 @@ type record_json_name =
   }
 
 type single_tuple = [ Single_tuple of (int) ]
+
+(*** Test json adapters ***)
+
+type adapted = [
+  | A of a
+  | B of b
+] <json adapter.ocaml="Atdgen_codec_runtime.Json_adapter.Type_field">
+
+type a = {
+  thing: string;
+  other_thing: bool;
+}
+
+type b = {
+  thing: int;
+}

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.ml
@@ -38,6 +38,12 @@ type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
 
+type b = Bucklespec_t.b = { thing: int }
+
+type a = Bucklespec_t.a = { thing: string; other_thing: bool }
+
+type adapted = Bucklespec_t.adapted
+
 let write_valid = (
   Atdgen_codec_runtime.Encode.bool
 )
@@ -589,4 +595,113 @@ let write_from_module_a = (
 )
 let read_from_module_a = (
   A_bs.read_from_module_a
+)
+let write_b = (
+  Atdgen_codec_runtime.Encode.make (fun (t : b) ->
+    (
+    Atdgen_codec_runtime.Encode.obj
+      [
+          Atdgen_codec_runtime.Encode.field
+            (
+            Atdgen_codec_runtime.Encode.int
+            )
+          ~name:"thing"
+          t.thing
+      ]
+    )
+  )
+)
+let read_b = (
+  Atdgen_codec_runtime.Decode.make (fun json ->
+    (
+      ({
+          thing =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              Atdgen_codec_runtime.Decode.int
+              |> Atdgen_codec_runtime.Decode.field "thing"
+            ) json;
+      } : b)
+    )
+  )
+)
+let write_a = (
+  Atdgen_codec_runtime.Encode.make (fun (t : a) ->
+    (
+    Atdgen_codec_runtime.Encode.obj
+      [
+          Atdgen_codec_runtime.Encode.field
+            (
+            Atdgen_codec_runtime.Encode.string
+            )
+          ~name:"thing"
+          t.thing
+        ;
+          Atdgen_codec_runtime.Encode.field
+            (
+            Atdgen_codec_runtime.Encode.bool
+            )
+          ~name:"other_thing"
+          t.other_thing
+      ]
+    )
+  )
+)
+let read_a = (
+  Atdgen_codec_runtime.Decode.make (fun json ->
+    (
+      ({
+          thing =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              Atdgen_codec_runtime.Decode.string
+              |> Atdgen_codec_runtime.Decode.field "thing"
+            ) json;
+          other_thing =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              Atdgen_codec_runtime.Decode.bool
+              |> Atdgen_codec_runtime.Decode.field "other_thing"
+            ) json;
+      } : a)
+    )
+  )
+)
+let write_adapted = (
+  Atdgen_codec_runtime.Encode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.restore (
+    Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
+      | `A x ->
+      Atdgen_codec_runtime.Encode.constr1 "A" (
+        write_a
+      ) x
+      | `B x ->
+      Atdgen_codec_runtime.Encode.constr1 "B" (
+        write_b
+      ) x
+    )
+  )
+)
+let read_adapted = (
+  Atdgen_codec_runtime.Decode.adapter Atdgen_codec_runtime.Json_adapter.Type_field.normalize (
+    Atdgen_codec_runtime.Decode.enum
+    [
+        (
+        "A"
+        ,
+          `Decode (
+          read_a
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`A x) : _))
+          )
+        )
+      ;
+        (
+        "B"
+        ,
+          `Decode (
+          read_b
+          |> Atdgen_codec_runtime.Decode.map (fun x -> ((`B x) : _))
+          )
+        )
+    ]
+  )
 )

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.mli
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.mli
@@ -38,6 +38,12 @@ type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
 
+type b = Bucklespec_t.b = { thing: int }
+
+type a = Bucklespec_t.a = { thing: string; other_thing: bool }
+
+type adapted = Bucklespec_t.adapted
+
 val read_valid :  valid Atdgen_codec_runtime.Decode.t
 
 val write_valid :  valid Atdgen_codec_runtime.Encode.t
@@ -105,4 +111,16 @@ val write_labeled :  labeled Atdgen_codec_runtime.Encode.t
 val read_from_module_a :  from_module_a Atdgen_codec_runtime.Decode.t
 
 val write_from_module_a :  from_module_a Atdgen_codec_runtime.Encode.t
+
+val read_b :  b Atdgen_codec_runtime.Decode.t
+
+val write_b :  b Atdgen_codec_runtime.Encode.t
+
+val read_a :  a Atdgen_codec_runtime.Decode.t
+
+val write_a :  a Atdgen_codec_runtime.Encode.t
+
+val read_adapted :  adapted Atdgen_codec_runtime.Decode.t
+
+val write_adapted :  adapted Atdgen_codec_runtime.Encode.t
 

--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -38,6 +38,12 @@ type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
 
+type b = Bucklespec_t.b = { thing: int }
+
+type a = Bucklespec_t.a = { thing: string; other_thing: bool }
+
+type adapted = Bucklespec_t.adapted
+
 let write_valid = (
   Yojson.Safe.write_bool
 )
@@ -1787,3 +1793,340 @@ let read_from_module_a = (
 )
 let from_module_a_of_string s =
   read_from_module_a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_b : _ -> b -> _ = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"thing\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.thing;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_b ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_b ob x;
+  Bi_outbuf.contents ob
+let read_b = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_thing = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 5 && String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 'g' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_thing := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 5 && String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 'g' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_thing := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            thing = (match !field_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "thing");
+          }
+         : b)
+      )
+)
+let b_of_string s =
+  read_b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_a : _ -> a -> _ = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"thing\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.thing;
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"other_thing\":";
+    (
+      Yojson.Safe.write_bool
+    )
+      ob x.other_thing;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_a ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_a ob x;
+  Bi_outbuf.contents ob
+let read_a = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_thing = ref (None) in
+    let field_other_thing = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          match len with
+            | 5 -> (
+                if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 'g' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 11 -> (
+                if String.unsafe_get s pos = 'o' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'h' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'n' && String.unsafe_get s (pos+10) = 'g' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_thing := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_other_thing := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            match len with
+              | 5 -> (
+                  if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 'g' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 11 -> (
+                  if String.unsafe_get s pos = 'o' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'h' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'n' && String.unsafe_get s (pos+10) = 'g' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_thing := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_other_thing := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            thing = (match !field_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "thing");
+            other_thing = (match !field_other_thing with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "other_thing");
+          }
+         : a)
+      )
+)
+let a_of_string s =
+  read_a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_adapted = (
+  Atdgen_runtime.Oj_run.write_with_adapter Atdgen_codec_runtime.Json_adapter.Type_field.restore (
+    fun ob x ->
+      match x with
+        | `A x ->
+          Bi_outbuf.add_string ob "[\"A\",";
+          (
+            write_a
+          ) ob x;
+          Bi_outbuf.add_char ob ']'
+        | `B x ->
+          Bi_outbuf.add_string ob "[\"B\",";
+          (
+            write_b
+          ) ob x;
+          Bi_outbuf.add_char ob ']'
+  )
+)
+let string_of_adapted ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_adapted ob x;
+  Bi_outbuf.contents ob
+let read_adapted = (
+  Atdgen_runtime.Oj_run.read_with_adapter Atdgen_codec_runtime.Json_adapter.Type_field.normalize (
+    fun p lb ->
+      Yojson.Safe.read_space p lb;
+      match Yojson.Safe.start_any_variant p lb with
+        | `Edgy_bracket -> (
+            match Yojson.Safe.read_ident p lb with
+              | "A" ->
+                Atdgen_runtime.Oj_run.read_until_field_value p lb;
+                let x = (
+                    read_a
+                  ) p lb
+                in
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_gt p lb;
+                `A x
+              | "B" ->
+                Atdgen_runtime.Oj_run.read_until_field_value p lb;
+                let x = (
+                    read_b
+                  ) p lb
+                in
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_gt p lb;
+                `B x
+              | x ->
+                Atdgen_runtime.Oj_run.invalid_variant_tag p x
+          )
+        | `Double_quote -> (
+            match Yojson.Safe.finish_string p lb with
+              | x ->
+                Atdgen_runtime.Oj_run.invalid_variant_tag p x
+          )
+        | `Square_bracket -> (
+            match Atdgen_runtime.Oj_run.read_string p lb with
+              | "A" ->
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_comma p lb;
+                Yojson.Safe.read_space p lb;
+                let x = (
+                    read_a
+                  ) p lb
+                in
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_rbr p lb;
+                `A x
+              | "B" ->
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_comma p lb;
+                Yojson.Safe.read_space p lb;
+                let x = (
+                    read_b
+                  ) p lb
+                in
+                Yojson.Safe.read_space p lb;
+                Yojson.Safe.read_rbr p lb;
+                `B x
+              | x ->
+                Atdgen_runtime.Oj_run.invalid_variant_tag p x
+          )
+  )
+)
+let adapted_of_string s =
+  read_adapted (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/bucklescript/bucklespec_roundtrip.ml
+++ b/atdgen/test/bucklescript/bucklespec_roundtrip.ml
@@ -120,4 +120,34 @@ let () =
         ~yojson:Bucklespec_j.single_tuple_of_string
         ~buckle:Bucklespec_bs.write_single_tuple
         ~data:(`Single_tuple (123))
+    ; test_decode ~name:"decode adapted variant a"
+        ~yojson:Bucklespec_j.string_of_adapted
+        ~buckle:Bucklespec_bs.read_adapted
+        ~data: Bucklespec_t.(
+          `A ({
+            thing = "thing";
+            other_thing = false;
+          }))
+    ; test_encode ~name:"encode adapted variant a"
+        ~yojson:Bucklespec_j.adapted_of_string
+        ~buckle:Bucklespec_bs.write_adapted
+        ~data: Bucklespec_t.(
+          `A ({
+            thing = "thing";
+            other_thing = false;
+          }))
+    ; test_decode ~name:"decode adapted variant b"
+        ~yojson:Bucklespec_j.string_of_adapted
+        ~buckle:Bucklespec_bs.read_adapted
+        ~data: Bucklespec_t.(
+          `B ({
+            thing = 1;
+          }))
+    ; test_encode ~name:"encode adapted variant b"
+        ~yojson:Bucklespec_j.adapted_of_string
+        ~buckle:Bucklespec_bs.write_adapted
+        ~data: Bucklespec_t.(
+          `B ({
+            thing = 1;
+          }))
     ]


### PR DESCRIPTION
I started working on adapters support for bucklescript and made a little progress on decoding variants. (I haven't yet committed test cases before getting some initial feedback, but I played around with it on a real project and was able to decode fairly convoluted variant type)

Is there a reason to have separate `json_sum_adapter` and `json_record_adapter` fields? When are they used at the same time?

P.S: I tried to follow common indentation/formatting, but it looks arbitrary. Do you use `ocamlformat`? 