### PR TITLE
Remove incorrect lambda annotation

### DIFF
--- a/atdgen-codec-runtime/src/decode.mli
+++ b/atdgen-codec-runtime/src/decode.mli
@@ -1,4 +1,4 @@
-type 'a t
+type 'a t = Json.t -> 'a
 
 val make : (Json.t -> 'a) -> 'a t
 

--- a/atdgen-codec-runtime/src/encode.mli
+++ b/atdgen-codec-runtime/src/encode.mli
@@ -1,4 +1,4 @@
-type 'a t
+type 'a t = 'a -> Json.t
 
 val make : ('a -> Json.t) -> 'a t
 

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -1208,7 +1208,7 @@ let make_ocaml_biniou_writer ~original_types deref is_rec let1 let2 def =
   let write = get_left_writer_name ~tagged:true name param in
   let to_string = get_left_to_string_name name param in
   let write_untagged_expr = make_writer deref ~tagged:false x in
-  let eta_expand = is_rec && not (Ox_emit.is_function write_untagged_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda write_untagged_expr) in
   let needs_annot = Ox_emit.needs_type_annot x in
   let extra_param, extra_args =
     match eta_expand, needs_annot with
@@ -1260,8 +1260,8 @@ let make_ocaml_biniou_reader ~original_types ~ocaml_version
   let get_reader_expr =
     make_reader deref ~tagged:false ~ocaml_version ?type_annot x in
   let read_expr = make_reader deref ~tagged:true ~ocaml_version ?type_annot x in
-  let eta_expand1 = is_rec && not (Ox_emit.is_function get_reader_expr) in
-  let eta_expand2 = is_rec && not (Ox_emit.is_function read_expr) in
+  let eta_expand1 = is_rec && not (Ox_emit.is_lambda get_reader_expr) in
+  let eta_expand2 = is_rec && not (Ox_emit.is_lambda read_expr) in
   let extra_param1, extra_args1 =
     if eta_expand1 then " tag", " tag"
     else "", ""

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -129,7 +129,7 @@ let rec make_reader ?type_annot p (x : Oj_mapping.t) : Indent.t list =
   | Tvar _ -> [ Indent.Line (get_reader_name p x) ]
   | Record (loc, a, Record o, Record j) ->
       Ocaml.obj_unimplemented loc o;
-      [ Annot ("fun", Line (sprintf "%s (fun json ->" decoder_make))
+      [ Line (sprintf "%s (fun json ->" decoder_make)
       ; Block (make_record_reader ?type_annot p loc a j)
       ; Line ")"
       ]
@@ -408,9 +408,8 @@ let rec make_writer ?type_annot p (x : Oj_mapping.t) : Indent.t list =
             ]
         | Object ->
             let _k, v = Ox_emit.get_assoc_type p.deref loc x in
-            [ Annot
-                ("fun", Line (sprintf "%s (fun (t : %s) ->"
-                               encoder_make (type_annot_str type_annot)))
+            [ Line (sprintf "%s (fun (t : %s) ->"
+                      encoder_make (type_annot_str type_annot))
             ; Block
                 [ Line (sprintf "%s |>"
                            (match o with
@@ -439,9 +438,8 @@ let rec make_writer ?type_annot p (x : Oj_mapping.t) : Indent.t list =
             ]
        )
   | Record (_, a, Record o, Record _) ->
-      [ Annot
-          ("fun", Line (sprintf "%s (fun (t : %s) ->"
-                          encoder_make (type_annot_str type_annot)))
+      [ Line (sprintf "%s (fun (t : %s) ->"
+                encoder_make (type_annot_str type_annot))
       ; Block (make_record_writer p a o)
       ; Line ")"
       ]

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -313,7 +313,7 @@ let make_ocaml_bs_reader p ~original_types is_rec let1 _let2
     )
   in
   let reader_expr = make_reader ?type_annot p x in
-  let eta_expand = is_rec && not (Ox_emit.is_function reader_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda reader_expr) in
   let extra_param, extra_args =
     if eta_expand then " js", " js"
     else "", ""
@@ -563,7 +563,7 @@ let make_ocaml_bs_writer p ~original_types is_rec let1 _let2
   let param = def.def_param in
   let write = get_left_writer_name p name param in
   let writer_expr = make_writer ?type_annot p x in
-  let eta_expand = is_rec && not (Ox_emit.is_function writer_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda writer_expr) in
   let extra_param, extra_args =
     if eta_expand then " js", " js"
     else "", ""

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1164,7 +1164,7 @@ let make_ocaml_json_writer p ~original_types is_rec let1 let2 def =
   let write = get_left_writer_name p name param in
   let to_string = get_left_to_string_name p name param in
   let writer_expr = make_writer p x in
-  let eta_expand = is_rec && not (Ox_emit.is_function writer_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda writer_expr) in
   let needs_annot = Ox_emit.needs_type_annot x in
   let extra_param, extra_args, type_annot =
     match eta_expand, needs_annot with
@@ -1199,7 +1199,7 @@ let make_ocaml_json_reader p ~original_types is_rec let1 let2 def =
     | false -> None
   in
   let reader_expr = make_reader p type_annot x in
-  let eta_expand = is_rec && not (Ox_emit.is_function reader_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda reader_expr) in
   let extra_param, extra_args =
     if eta_expand then " p lb", " p lb"
     else "", ""

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -341,7 +341,7 @@ let make_ocaml_validator ~original_types is_rec let1 def =
   let param = def.def_param in
   let validate = get_left_validator_name name param in
   let validator_expr = make_validator x in
-  let eta_expand = is_rec && not (Ox_emit.is_function validator_expr) in
+  let eta_expand = is_rec && not (Ox_emit.is_lambda validator_expr) in
   let needs_annot = Ox_emit.needs_type_annot x in
   let extra_param, extra_args, type_annot =
     match eta_expand, needs_annot with

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -282,16 +282,18 @@ let create_%s %s
 
   | _ -> "", ""
 
-let rec is_function (l : Indent.t list) =
+let rec is_lambda (l : Indent.t list) =
   match l with
     [] -> false
   | x :: _ ->
       match x with
         Line _ -> false
-      | Block l -> is_function l
-      | Inline l -> is_function l
+      | Block l -> is_lambda l
+      | Inline l -> is_lambda l
       | Annot ("fun", _) -> true
-      | Annot (_, x) -> is_function [x]
+      | Annot (_, x) -> is_lambda [x]
+
+let is_function = is_lambda
 
 let name_of_var s = "_" ^ s
 

--- a/atdgen/src/ox_emit.mli
+++ b/atdgen/src/ox_emit.mli
@@ -29,7 +29,13 @@ val get_type_constraint
   -> ('a, 'b) Mapping.def
   -> string
 
+(** Determine whether the start of the given block of code was annotated
+    with the "fun" tag, indicating that it represents a lambda (anonymous
+    function). *)
+val is_lambda : Indent.t list -> bool
+
 val is_function : Indent.t list -> bool
+[@@deprecated "Please use 'is_lambda' instead of 'is_function'."]
 
 val needs_type_annot : _ expr -> bool
 

--- a/atdgen/test/bucklescript/bucklespec.atd
+++ b/atdgen/test/bucklescript/bucklespec.atd
@@ -66,3 +66,15 @@ type record_json_name =
   }
 
 type single_tuple = [ Single_tuple of (int) ]
+
+type recurse = {
+  recurse_items: recurse list;
+}
+
+type mutual_recurse1 = {
+  mutual_recurse2: mutual_recurse2;
+}
+
+type mutual_recurse2 = {
+  mutual_recurse1: mutual_recurse1;
+}

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.ml
@@ -1,6 +1,16 @@
 (* Auto-generated from "bucklespec.atd" *)
               [@@@ocaml.warning "-27-32-35-39"]
 
+type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
+
+type mutual_recurse1 = Bucklespec_t.mutual_recurse1 = {
+  mutual_recurse2: mutual_recurse2
+}
+
+and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
+  mutual_recurse1: mutual_recurse1
+}
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -38,6 +48,103 @@ type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
 
+let rec write_mutual_recurse1 js = (
+  Atdgen_codec_runtime.Encode.make (fun (t : mutual_recurse1) ->
+    (
+    Atdgen_codec_runtime.Encode.obj
+      [
+          Atdgen_codec_runtime.Encode.field
+            (
+            write_mutual_recurse2
+            )
+          ~name:"mutual_recurse2"
+          t.mutual_recurse2
+      ]
+    )
+  )
+) js
+and write_mutual_recurse2 js = (
+  Atdgen_codec_runtime.Encode.make (fun (t : mutual_recurse2) ->
+    (
+    Atdgen_codec_runtime.Encode.obj
+      [
+          Atdgen_codec_runtime.Encode.field
+            (
+            write_mutual_recurse1
+            )
+          ~name:"mutual_recurse1"
+          t.mutual_recurse1
+      ]
+    )
+  )
+) js
+let rec read_mutual_recurse1 js = (
+  Atdgen_codec_runtime.Decode.make (fun json ->
+    (
+      ({
+          mutual_recurse2 =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              read_mutual_recurse2
+              |> Atdgen_codec_runtime.Decode.field "mutual_recurse2"
+            ) json;
+      } : mutual_recurse1)
+    )
+  )
+) js
+and read_mutual_recurse2 js = (
+  Atdgen_codec_runtime.Decode.make (fun json ->
+    (
+      ({
+          mutual_recurse1 =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              read_mutual_recurse1
+              |> Atdgen_codec_runtime.Decode.field "mutual_recurse1"
+            ) json;
+      } : mutual_recurse2)
+    )
+  )
+) js
+let rec write__5 js = (
+  Atdgen_codec_runtime.Encode.list (
+    write_recurse
+  )
+) js
+and write_recurse js = (
+  Atdgen_codec_runtime.Encode.make (fun (t : recurse) ->
+    (
+    Atdgen_codec_runtime.Encode.obj
+      [
+          Atdgen_codec_runtime.Encode.field
+            (
+            write__5
+            )
+          ~name:"recurse_items"
+          t.recurse_items
+      ]
+    )
+  )
+) js
+let rec read__5 js = (
+  Atdgen_codec_runtime.Decode.list (
+    read_recurse
+  )
+) js
+and read_recurse js = (
+  Atdgen_codec_runtime.Decode.make (fun json ->
+    (
+      ({
+          recurse_items =
+            Atdgen_codec_runtime.Decode.decode
+            (
+              read__5
+              |> Atdgen_codec_runtime.Decode.field "recurse_items"
+            ) json;
+      } : recurse)
+    )
+  )
+) js
 let write_valid = (
   Atdgen_codec_runtime.Encode.bool
 )

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.mli
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.mli
@@ -1,6 +1,16 @@
 (* Auto-generated from "bucklespec.atd" *)
               [@@@ocaml.warning "-27-32-35-39"]
 
+type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
+
+type mutual_recurse1 = Bucklespec_t.mutual_recurse1 = {
+  mutual_recurse2: mutual_recurse2
+}
+
+and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
+  mutual_recurse1: mutual_recurse1
+}
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -37,6 +47,18 @@ type label = Bucklespec_t.label
 type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
+
+val read_recurse :  recurse Atdgen_codec_runtime.Decode.t
+
+val write_recurse :  recurse Atdgen_codec_runtime.Encode.t
+
+val read_mutual_recurse1 :  mutual_recurse1 Atdgen_codec_runtime.Decode.t
+
+val write_mutual_recurse1 :  mutual_recurse1 Atdgen_codec_runtime.Encode.t
+
+val read_mutual_recurse2 :  mutual_recurse2 Atdgen_codec_runtime.Decode.t
+
+val write_mutual_recurse2 :  mutual_recurse2 Atdgen_codec_runtime.Encode.t
 
 val read_valid :  valid Atdgen_codec_runtime.Decode.t
 

--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -1,6 +1,16 @@
 (* Auto-generated from "bucklespec.atd" *)
 [@@@ocaml.warning "-27-32-35-39"]
 
+type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
+
+type mutual_recurse1 = Bucklespec_t.mutual_recurse1 = {
+  mutual_recurse2: mutual_recurse2
+}
+
+and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
+  mutual_recurse1: mutual_recurse1
+}
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -38,6 +48,316 @@ type labeled = Bucklespec_t.labeled = { flag: valid; lb: label; count: int }
 
 type from_module_a = A_t.from_module_a
 
+let rec write_mutual_recurse1 : _ -> mutual_recurse1 -> _ = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"mutual_recurse2\":";
+    (
+      write_mutual_recurse2
+    )
+      ob x.mutual_recurse2;
+    Bi_outbuf.add_char ob '}';
+)
+and string_of_mutual_recurse1 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_mutual_recurse1 ob x;
+  Bi_outbuf.contents ob
+and write_mutual_recurse2 : _ -> mutual_recurse2 -> _ = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"mutual_recurse1\":";
+    (
+      write_mutual_recurse1
+    )
+      ob x.mutual_recurse1;
+    Bi_outbuf.add_char ob '}';
+)
+and string_of_mutual_recurse2 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_mutual_recurse2 ob x;
+  Bi_outbuf.contents ob
+let rec read_mutual_recurse1 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_mutual_recurse2 = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 15 && String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'c' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'r' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 'e' && String.unsafe_get s (pos+14) = '2' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_mutual_recurse2 := (
+              Some (
+                (
+                  read_mutual_recurse2
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 15 && String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'c' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'r' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 'e' && String.unsafe_get s (pos+14) = '2' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_mutual_recurse2 := (
+                Some (
+                  (
+                    read_mutual_recurse2
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            mutual_recurse2 = (match !field_mutual_recurse2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "mutual_recurse2");
+          }
+         : mutual_recurse1)
+      )
+)
+and mutual_recurse1_of_string s =
+  read_mutual_recurse1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read_mutual_recurse2 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_mutual_recurse1 = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 15 && String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'c' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'r' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 'e' && String.unsafe_get s (pos+14) = '1' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_mutual_recurse1 := (
+              Some (
+                (
+                  read_mutual_recurse1
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 15 && String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'c' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'r' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 'e' && String.unsafe_get s (pos+14) = '1' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_mutual_recurse1 := (
+                Some (
+                  (
+                    read_mutual_recurse1
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            mutual_recurse1 = (match !field_mutual_recurse1 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "mutual_recurse1");
+          }
+         : mutual_recurse2)
+      )
+)
+and mutual_recurse2_of_string s =
+  read_mutual_recurse2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let rec write__5 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_recurse
+  )
+) ob x
+and string_of__5 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__5 ob x;
+  Bi_outbuf.contents ob
+and write_recurse : _ -> recurse -> _ = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"recurse_items\":";
+    (
+      write__5
+    )
+      ob x.recurse_items;
+    Bi_outbuf.add_char ob '}';
+)
+and string_of_recurse ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_recurse ob x;
+  Bi_outbuf.contents ob
+let rec read__5 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_recurse
+  )
+) p lb
+and _5_of_string s =
+  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read_recurse = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_recurse_items = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 13 && String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 's' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'm' && String.unsafe_get s (pos+12) = 's' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_recurse_items := (
+              Some (
+                (
+                  read__5
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 13 && String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 's' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'm' && String.unsafe_get s (pos+12) = 's' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_recurse_items := (
+                Some (
+                  (
+                    read__5
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            recurse_items = (match !field_recurse_items with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "recurse_items");
+          }
+         : recurse)
+      )
+)
+and recurse_of_string s =
+  read_recurse (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_valid = (
   Yojson.Safe.write_bool
 )


### PR DESCRIPTION
This removes some incorrect lambda annotations in the tree of generated code. To reduce future confusion, I renamed the function `Ox_emit.is_function` to `Ox_emit.is_lambda`. The old name is still available but deprecated.

This should solve #152.
