### PR TITLE
Fix hardcoded /bin/bash

### DIFF
--- a/atdj/test/run_test.sh
+++ b/atdj/test/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CLASSPATH='.:json.jar:junit-4.8.2.jar'
 


### PR DESCRIPTION
`bash` is often not in `/bin`. Script wasn't using bash-specific features anyway.

If it did require Bash, `#!/usr/bin/env bash` would be more portable.