### PR TITLE
Document t field in from field

### DIFF
--- a/doc/atdgen.rst
+++ b/doc/atdgen.rst
@@ -1012,6 +1012,16 @@ Second input file ``part2.atd`` depending on the first one:
     type point <ocaml from="Part1"> = abstract
     type points = point list
 
+To use a different type name than defined in the ``Part1`` module, add a
+``t`` field declaration to the annotation which refers the original
+type name:
+
+.. code:: ocaml
+
+    type point_xy <ocaml from="Part1" t="point"> = abstract
+    type points = point_xy list
+
+
 Field ``module``
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds an example of using the `t` field in conjunction with the `from` field, which allows the user to redefine the type name as they import it from an external module.
