### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,19 @@
 # This file determines who will be assigned code reviews by Github.
 # See https://help.github.com/articles/about-codeowners/
 
+# We are looking for volunteers to help with project maintenance.
+# Please open an pull request or an issue indicating your skills and interests.
+#
+# We can use help with the following:
+# - triaging issues: answering questions of fellow users,
+#   asking for clarification on how to reproduce a bug, assigning issues
+#   to a suitable team member.
+# - documentation: adding examples based on your practical use cases.
+# - tooling: if you're familiar with a particular tool that would be useful
+#   to the project, please use your expertise and help us get set up.
+# - community: let the world know your organization depends on the project,
+#   help us get more users, weigh in on design decisions.
+
 # Fallback reviewers
 * @mjambon @rgrinberg
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# This file determines who will be assigned code reviews by Github.
+# See https://help.github.com/articles/about-codeowners/
+
+# Fallback reviewers
+* @mjambon @rgrinberg
+
+# ATD language
+/atd/ @mjambon
+/atdcat/ @mjambon
+
+# OCaml and Bucklescript support
+/atdgen-runtime/ @rgrinberg @mjambon
+/atdgen/ @rgrinberg @mjambon
+
+# Java support
+# /atdj/ YOUR_NAME_HERE
+
+# Scala support
+/atds/ @aij
+
+# Use of the dune build system
+dune* @rgrinberg


### PR DESCRIPTION
This adds a CODEOWNERS file, which documents who's in charge of what. Github uses this to assign code reviews automatically (in theory; haven't used this yet). Names I put into this file besides my own are @rgrinberg (active with Bucklescript support) and @aij (work on Scala support).

[ocaml-community](https://github.com/ocaml-community/meta) requires such file and it seems like a good idea. I would like to migrate atd to ocaml-community sooner or later. I'm hoping it would make it easier to benefit from other people's expertise and improve the responsiveness on small issues. Please check it out and let me know if there are any concerns.
