### PR TITLE
Support jsoo compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ test:
 
 check: test
 
+js:
+	$(DUNE) build atdgen/bin/ag_main.bc.js
+
 clean:
 	$(DUNE) clean
 

--- a/atd.opam
+++ b/atd.opam
@@ -17,4 +17,5 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "easy-format"
+  "re"
 ]

--- a/atd/src/dune
+++ b/atd/src/dune
@@ -4,4 +4,4 @@
 (library
  (name atd)
  (public_name atd)
- (libraries easy-format unix str))
+ (libraries easy-format unix re))

--- a/atdcat/atdcat.ml
+++ b/atdcat/atdcat.ml
@@ -76,7 +76,7 @@ let print ~html_doc ~out_format ast =
   f ast
 
 let split_on_comma =
-  Str.split_delim (Str.regexp ",")
+  Re.Str.split_delim (Re.Str.regexp ",")
 
 let () =
   let expand = ref false in

--- a/atdgen.opam
+++ b/atdgen.opam
@@ -19,4 +19,5 @@ depends: [
   "atdgen-runtime" {>= "2.0.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1" }
+  "re"
 ]

--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -42,10 +42,10 @@ type mode =
   | Bucklescript (* -bs (bucklescript) *)
 
 let parse_ocaml_version () =
-  let re = Str.regexp "^\\([0-9]+\\)\\.\\([0-9]+\\)" in
-  if Str.string_match re Sys.ocaml_version 0 then
-    let major = Str.matched_group 1 Sys.ocaml_version in
-    let minor = Str.matched_group 2 Sys.ocaml_version in
+  let re = Re.Str.regexp "^\\([0-9]+\\)\\.\\([0-9]+\\)" in
+  if Re.Str.string_match re Sys.ocaml_version 0 then
+    let major = Re.Str.matched_group 1 Sys.ocaml_version in
+    let minor = Re.Str.matched_group 2 Sys.ocaml_version in
     Some (int_of_string major, int_of_string minor)
   else
     None
@@ -68,20 +68,20 @@ let main () =
   let type_aliases = ref None in
   let ocaml_version = parse_ocaml_version () in
   let set_opens s =
-    let l = Str.split (Str.regexp " *, *\\| +") s in
+    let l = Re.Str.split (Re.Str.regexp " *, *\\| +") s in
     opens := List.rev_append l !opens
   in
   let pp_convs : Ocaml.pp_convs ref = ref (Ocaml.Ppx []) in
   let options = [
     "-type-conv", Arg.String (fun s ->
-      pp_convs := Camlp4 (Str.split (Str.regexp ",") s)),
+      pp_convs := Camlp4 (Re.Str.split (Re.Str.regexp ",") s)),
     "
     GEN1,GEN2,...
          Insert 'with GEN1, GEN2, ...' after OCaml type definitions for the
          type-conv preprocessor
     ";
     "-deriving-conv", Arg.String (fun s ->
-      pp_convs := Ocaml.Ppx (Str.split (Str.regexp ",") s)),
+      pp_convs := Ocaml.Ppx (Re.Str.split (Re.Str.regexp ",") s)),
     "
     GEN1,GEN2,...
          Insert 'with GEN1, GEN2, ...' after OCaml type definitions for the

--- a/atdgen/bin/dune
+++ b/atdgen/bin/dune
@@ -1,5 +1,5 @@
 (executables
- (libraries str atd atdgen_emit)
+ (libraries re atd atdgen_emit)
  (names ag_main)
  (public_names atdgen)
  (package atdgen))

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -594,7 +594,7 @@ let ocamldoc_verbatim_escape s =
   in
   escape esc s
 
-let split = Str.split (Str.regexp " ")
+let split = Re.Str.split (Re.Str.regexp " ")
 
 
 let make_ocamldoc_block = function

--- a/atdj.opam
+++ b/atdj.opam
@@ -16,4 +16,5 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {build}
   "atd" {>= "2.0.0"}
+  "re"
 ]

--- a/atdj/src/atdj_main.ml
+++ b/atdj/src/atdj_main.ml
@@ -12,8 +12,8 @@ let args_spec env = Arg.align
 let usage_msg = "Usage: " ^ Sys.argv.(0) ^ " <options> <file>\nOptions are:"
 
 let make_package_dirs package =
-  let re   = Str.regexp "\\." in
-  let dirs = Str.split re package in
+  let re   = Re.Str.regexp "\\." in
+  let dirs = Re.Str.split re package in
   List.fold_left
     (fun parent dir ->
        let full_dir = parent ^ "/" ^ dir in
@@ -54,8 +54,8 @@ let main () =
           ) else x in
 
   (* Validate package name *)
-  let re = Str.regexp "^[a-zA-Z0-9]+\\(\\.[a-zA-Z0-9]+\\)*$" in
-  if not (Str.string_match re env.package 0) then (
+  let re = Re.Str.regexp "^[a-zA-Z0-9]+\\(\\.[a-zA-Z0-9]+\\)*$" in
+  if not (Re.Str.string_match re env.package 0) then (
     prerr_endline "Invalid package name";
     Arg.usage args_spec' usage_msg;
     exit 1

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -43,8 +43,8 @@ let get env atd_ty opt =
   prefix ^ suffix
 
 let extract_from_edgy_brackets s =
-  Str.global_replace
-    (Str.regexp "^[^<]*<\\|>[^>]*$") "" s
+  Re.Str.global_replace
+    (Re.Str.regexp "^[^<]*<\\|>[^>]*$") "" s
 (*
 extract_from_edgy_brackets "ab<cd<e>>f";;
 - : string = "cd<e>"

--- a/atdj/src/atdj_util.ml
+++ b/atdj/src/atdj_util.ml
@@ -56,9 +56,9 @@ Warning:
    Insert given string ind_S at the beginning of each line from string s.
 *)
 let indent_block_s =
-  let rex = Str.regexp "^" in
+  let rex = Re.Str.regexp "^" in
   fun ins s ->
-    Str.global_replace rex ins s
+    Re.Str.global_replace rex ins s
 
 (*
    Insert n spaces at the beginning of each line from string s.

--- a/atdj/src/dune
+++ b/atdj/src/dune
@@ -2,4 +2,4 @@
  (name atdj_main)
  (public_name atdj)
  (package atdj)
- (libraries str atd))
+ (libraries re atd))


### PR DESCRIPTION
This PR replaces `str` with `re` so that atdgen binaries can be compiled using jsoo. It would offer an easy way to publish an atdgen executable to bucklescript users without depending on opam.