### PR TITLE
Fix and test ambiguous record w/json adapters

### DIFF
--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -57,7 +57,7 @@ type a = Bucklespec_t.a = { thing: string; other_thing: bool }
 type adapted = Bucklespec_t.adapted
 
 let rec write_mutual_recurse1 : _ -> mutual_recurse1 -> _ = (
-  fun ob x ->
+  fun ob (x : mutual_recurse1) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -76,7 +76,7 @@ and string_of_mutual_recurse1 ?(len = 1024) x =
   write_mutual_recurse1 ob x;
   Bi_outbuf.contents ob
 and write_mutual_recurse2 : _ -> mutual_recurse2 -> _ = (
-  fun ob x ->
+  fun ob (x : mutual_recurse2) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -262,7 +262,7 @@ and string_of__5 ?(len = 1024) x =
   write__5 ob x;
   Bi_outbuf.contents ob
 and write_recurse : _ -> recurse -> _ = (
-  fun ob x ->
+  fun ob (x : recurse) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -563,7 +563,7 @@ let read__6 = (
 let _6_of_string s =
   read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_using_object : _ -> using_object -> _ = (
-  fun ob x ->
+  fun ob (x : using_object) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1329,7 +1329,7 @@ let read_same_pair read__a = (
 let same_pair_of_string read__a s =
   read_same_pair read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_record_json_name : _ -> record_json_name -> _ = (
-  fun ob x ->
+  fun ob (x : record_json_name) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1527,7 +1527,7 @@ let read_point = (
 let point_of_string s =
   read_point (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_param_similar write__a : _ -> 'a param_similar -> _ = (
-  fun ob x ->
+  fun ob (x : 'a param_similar) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1680,7 +1680,7 @@ let read_param_similar read__a = (
 let param_similar_of_string read__a s =
   read_param_similar read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_param write__a : _ -> 'a param -> _ = (
-  fun ob x ->
+  fun ob (x : 'a param) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1833,7 +1833,7 @@ let read_param read__a = (
 let param_of_string read__a s =
   read_param read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_pair write__a write__b : _ -> ('a, 'b) pair -> _ = (
-  fun ob x ->
+  fun ob (x : ('a, 'b) pair) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -2026,7 +2026,7 @@ let read_label = (
 let label_of_string s =
   read_label (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_labeled : _ -> labeled -> _ = (
-  fun ob x ->
+  fun ob (x : labeled) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -2234,7 +2234,7 @@ let read_from_module_a = (
 let from_module_a_of_string s =
   read_from_module_a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_b : _ -> b -> _ = (
-  fun ob x ->
+  fun ob (x : b) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -2332,7 +2332,7 @@ let read_b = (
 let b_of_string s =
   read_b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_a : _ -> a -> _ = (
-  fun ob x ->
+  fun ob (x : a) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -54,6 +54,18 @@
  (action
   (run %{bin:atdgen} -json -std-json -o test2j -open Test,Test2,Testj -ntd %{deps})))
 
+(rule
+ (targets test_ambiguous_record_t.ml test_ambiguous_record_t.mli)
+ (deps    test_ambiguous_record.atd)
+ (action
+  (run %{bin:atdgen} -t %{deps})))
+
+(rule
+ (targets test_ambiguous_record_j.ml test_ambiguous_record_j.mli)
+ (deps    test_ambiguous_record.atd)
+ (action
+  (run %{bin:atdgen} -json -std-json -o test_ambiguous_record_j -open Test_ambiguous_record_t -ntd %{deps})))
+
 (alias
  (name runtest)
  (package atdgen)
@@ -124,6 +136,12 @@
  (package atdgen)
  (action (diff testv.expected.mli testv.mli)))
 
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_ambiguous_record_j.expected.ml test_ambiguous_record_j.ml)))
+
+
 (executables
  (libraries atd atdgen-runtime)
  (names test_atdgen_main)
@@ -132,6 +150,8 @@
   json_adapters
   test3j_j
   test3j_t
+  test_ambiguous_record_t
+  test_ambiguous_record_j
   testjstd
   testj
   testv

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -110,7 +110,7 @@ let read__4 = (
 let _4_of_string s =
   read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test2 : _ -> test2 -> _ = (
-  fun ob x ->
+  fun ob (x : test2) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -51,7 +51,7 @@ and string_of__4 ?(len = 1024) x =
   Bi_outbuf.contents ob
 and write_rec_type ob (x : rec_type) = (
   Atdgen_runtime.Oj_run.write_with_adapter Json_adapters.Identity.restore (
-    fun ob x ->
+    fun ob (x : rec_type) ->
       Bi_outbuf.add_char ob '{';
       let is_first = ref true in
       if !is_first then
@@ -504,7 +504,7 @@ let tf_variant_of_string s =
   read_tf_variant (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_tf_record2 : _ -> tf_record2 -> _ = (
   Atdgen_runtime.Oj_run.write_with_adapter Test_lib.Tag_field_with_catchall.restore (
-    fun ob x ->
+    fun ob (x : tf_record2) ->
       Bi_outbuf.add_char ob '{';
       let is_first = ref true in
       if !is_first then
@@ -661,7 +661,7 @@ let tf_record2_of_string s =
   read_tf_record2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_tf_record : _ -> tf_record -> _ = (
   Atdgen_runtime.Oj_run.write_with_adapter Test_lib.Tag_field_example.restore (
-    fun ob x ->
+    fun ob (x : tf_record) ->
       Bi_outbuf.add_char ob '{';
       let is_first = ref true in
       if !is_first then
@@ -829,7 +829,7 @@ let read_dyn = (
 let dyn_of_string s =
   read_dyn (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_t : _ -> t -> _ = (
-  fun ob x ->
+  fun ob (x : t) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1274,7 +1274,7 @@ let read__3 = (
 let _3_of_string s =
   read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_patch : _ -> patch -> _ = (
-  fun ob x ->
+  fun ob (x : patch) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     (match x.patch1 with None -> () | Some x ->
@@ -1456,7 +1456,7 @@ let read_patch = (
 let patch_of_string s =
   read_patch (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_b : _ -> b -> _ = (
-  fun ob x ->
+  fun ob (x : b) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1554,7 +1554,7 @@ let read_b = (
 let b_of_string s =
   read_b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_a : _ -> a -> _ = (
-  fun ob x ->
+  fun ob (x : a) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then

--- a/atdgen/test/test_ambiguous_record.atd
+++ b/atdgen/test/test_ambiguous_record.atd
@@ -1,0 +1,5 @@
+type ambiguous = {ambiguous:string;not_ambiguous1:int}
+
+type ambiguous' = {ambiguous:string;not_ambiguous2:int}
+   <json adapter.ocaml="Json_adapters.Identity">
+

--- a/atdgen/test/test_ambiguous_record_j.expected.ml
+++ b/atdgen/test/test_ambiguous_record_j.expected.ml
@@ -1,0 +1,330 @@
+(* Auto-generated from "test_ambiguous_record.atd" *)
+[@@@ocaml.warning "-27-32-35-39"]
+open Test_ambiguous_record_t
+
+let write_ambiguous' : _ -> ambiguous' -> _ = (
+  Atdgen_runtime.Oj_run.write_with_adapter Json_adapters.Identity.restore (
+    fun ob (x : ambiguous') ->
+      Bi_outbuf.add_char ob '{';
+      let is_first = ref true in
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"ambiguous\":";
+      (
+        Yojson.Safe.write_string
+      )
+        ob x.ambiguous;
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"not_ambiguous2\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x.not_ambiguous2;
+      Bi_outbuf.add_char ob '}';
+  )
+)
+let string_of_ambiguous' ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_ambiguous' ob x;
+  Bi_outbuf.contents ob
+let read_ambiguous' = (
+  Atdgen_runtime.Oj_run.read_with_adapter Json_adapters.Identity.normalize (
+    fun p lb ->
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_lcurl p lb;
+      let field_ambiguous = ref (None) in
+      let field_not_ambiguous2 = ref (None) in
+      try
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_end lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            match len with
+              | 9 -> (
+                  if String.unsafe_get s pos = 'a' && String.unsafe_get s (pos+1) = 'm' && String.unsafe_get s (pos+2) = 'b' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'g' && String.unsafe_get s (pos+5) = 'u' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 's' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 14 -> (
+                  if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'g' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'u' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = '2' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_ambiguous := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_not_ambiguous2 := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+        while true do
+          Yojson.Safe.read_space p lb;
+          Yojson.Safe.read_object_sep p lb;
+          Yojson.Safe.read_space p lb;
+          let f =
+            fun s pos len ->
+              if pos < 0 || len < 0 || pos + len > String.length s then
+                invalid_arg "out-of-bounds substring position or length";
+              match len with
+                | 9 -> (
+                    if String.unsafe_get s pos = 'a' && String.unsafe_get s (pos+1) = 'm' && String.unsafe_get s (pos+2) = 'b' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'g' && String.unsafe_get s (pos+5) = 'u' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 's' then (
+                      0
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | 14 -> (
+                    if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'g' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'u' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = '2' then (
+                      1
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | _ -> (
+                    -1
+                  )
+          in
+          let i = Yojson.Safe.map_ident p f lb in
+          Atdgen_runtime.Oj_run.read_until_field_value p lb;
+          (
+            match i with
+              | 0 ->
+                field_ambiguous := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
+                );
+              | 1 ->
+                field_not_ambiguous2 := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              | _ -> (
+                  Yojson.Safe.skip_json p lb
+                )
+          );
+        done;
+        assert false;
+      with Yojson.End_of_object -> (
+          (
+            {
+              ambiguous = (match !field_ambiguous with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "ambiguous");
+              not_ambiguous2 = (match !field_not_ambiguous2 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "not_ambiguous2");
+            }
+           : ambiguous')
+        )
+  )
+)
+let ambiguous'_of_string s =
+  read_ambiguous' (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_ambiguous : _ -> ambiguous -> _ = (
+  fun ob (x : ambiguous) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"ambiguous\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.ambiguous;
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"not_ambiguous1\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.not_ambiguous1;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_ambiguous ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_ambiguous ob x;
+  Bi_outbuf.contents ob
+let read_ambiguous = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_ambiguous = ref (None) in
+    let field_not_ambiguous1 = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          match len with
+            | 9 -> (
+                if String.unsafe_get s pos = 'a' && String.unsafe_get s (pos+1) = 'm' && String.unsafe_get s (pos+2) = 'b' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'g' && String.unsafe_get s (pos+5) = 'u' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 's' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 14 -> (
+                if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'g' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'u' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = '1' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_ambiguous := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_not_ambiguous1 := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            match len with
+              | 9 -> (
+                  if String.unsafe_get s pos = 'a' && String.unsafe_get s (pos+1) = 'm' && String.unsafe_get s (pos+2) = 'b' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'g' && String.unsafe_get s (pos+5) = 'u' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 's' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 14 -> (
+                  if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'g' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'u' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = '1' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_ambiguous := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_not_ambiguous1 := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            ambiguous = (match !field_ambiguous with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "ambiguous");
+            not_ambiguous1 = (match !field_not_ambiguous1 with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "not_ambiguous1");
+          }
+         : ambiguous)
+      )
+)
+let ambiguous_of_string s =
+  read_ambiguous (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let create_ambiguous' 
+  ~ambiguous
+  ~not_ambiguous2
+  () : ambiguous' =
+  {
+    ambiguous = ambiguous;
+    not_ambiguous2 = not_ambiguous2;
+  }
+let create_ambiguous 
+  ~ambiguous
+  ~not_ambiguous1
+  () : ambiguous =
+  {
+    ambiguous = ambiguous;
+    not_ambiguous1 = not_ambiguous1;
+  }

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -605,7 +605,7 @@ let test_json_open_enum () =
   check (x2 = x)
 
 let test_ambiguous_record () =
-  section "test <test ambiguous record with json adapters>";
+  section "test ambiguous record with json adapters";
   let json_in = {|{ambiguous:"x", not_ambiguous1:0}|} in
   let json_in' = {|{ambiguous:"x'", not_ambiguous2:1}|} in
   let x, x' =

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -604,6 +604,22 @@ let test_json_open_enum () =
   let x2 = Test3j_j.sample_open_enums_of_string json_out in
   check (x2 = x)
 
+let test_ambiguous_record () =
+  section "test <test ambiguous record with json adapters>";
+  let json_in = {|{ambiguous:"x", not_ambiguous1:0}|} in
+  let json_in' = {|{ambiguous:"x'", not_ambiguous2:1}|} in
+  let x, x' =
+    Test_ambiguous_record_j.ambiguous_of_string json_in,
+    Test_ambiguous_record_j.ambiguous'_of_string json_in' in
+  let json_out, json_out' =
+    Test_ambiguous_record_j.string_of_ambiguous x,
+    Test_ambiguous_record_j.string_of_ambiguous' x' in
+  let x2, x2' =
+    Test_ambiguous_record_j.ambiguous_of_string json_out,
+    Test_ambiguous_record_j.ambiguous'_of_string json_out' in
+  check ((x, x') = (x2, x2'))
+
+
 let all_tests = [
   test_ocaml_internals;
   test_biniou_missing_field;
@@ -637,6 +653,7 @@ let all_tests = [
   test_tag_field_emulation;
   test_tag_field_emulation_with_catchall;
   test_json_open_enum;
+  test_ambiguous_record;
 ]
 
 (* TODO: use Alcotest to run the test suite. *)
@@ -655,3 +672,8 @@ let quality_test () =
       exit 1
 
 let () = quality_test ()
+
+
+
+
+

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -274,7 +274,7 @@ and string_of_p ?(len = 1024) x =
   write_p ob x;
   Bi_outbuf.contents ob
 and write_r : _ -> r -> _ = (
-  fun ob x ->
+  fun ob (x : r) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -517,7 +517,7 @@ and string_of__20 write__a write__b ?(len = 1024) x =
   write__20 write__a write__b ob x;
   Bi_outbuf.contents ob
 and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
-  fun ob x ->
+  fun ob (x : ('x, 'y) poly) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -996,7 +996,7 @@ let read_validate_me = (
 let validate_me_of_string s =
   read_validate_me (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val1 : _ -> val1 -> _ = (
-  fun ob x ->
+  fun ob (x : val1) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1153,7 +1153,7 @@ let read__16 = (
 let _16_of_string s =
   read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val2 : _ -> val2 -> _ = (
-  fun ob x ->
+  fun ob (x : val2) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1728,7 +1728,7 @@ let read__10 = (
 let _10_of_string s =
   read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed_record : _ -> mixed_record -> _ = (
-  fun ob x ->
+  fun ob (x : mixed_record) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     (match x.field0 with None -> () | Some x ->
@@ -2707,7 +2707,7 @@ let read__15 = (
 let _15_of_string s =
   read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test : _ -> test -> _ = (
-  fun ob x ->
+  fun ob (x : test) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     (match x.x0 with None -> () | Some x ->
@@ -3043,7 +3043,7 @@ let read_star_rating = (
 let star_rating_of_string s =
   read_star_rating (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__30 : _ -> _ generic -> _ = (
-  fun ob x ->
+  fun ob (x : _ generic) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3155,7 +3155,7 @@ let read_specialized = (
 let specialized_of_string s =
   read_specialized (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_some_record : _ -> some_record -> _ = (
-  fun ob x ->
+  fun ob (x : some_record) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3255,7 +3255,7 @@ let read_some_record = (
 let some_record_of_string s =
   read_some_record (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_precision : _ -> precision -> _ = (
-  fun ob x ->
+  fun ob (x : precision) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3859,7 +3859,7 @@ let read_hello = (
 let hello_of_string s =
   read_hello (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_generic write__a : _ -> 'a generic -> _ = (
-  fun ob x ->
+  fun ob (x : 'a generic) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3959,7 +3959,7 @@ let read_generic read__a = (
 let generic_of_string read__a s =
   read_generic read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_floats : _ -> floats -> _ = (
-  fun ob x ->
+  fun ob (x : floats) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -4286,7 +4286,7 @@ let read_extended_tuple = (
 let extended_tuple_of_string s =
   read_extended_tuple (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_extended : _ -> extended -> _ = (
-  fun ob x ->
+  fun ob (x : extended) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -4694,7 +4694,7 @@ let read_base_tuple = (
 let base_tuple_of_string s =
   read_base_tuple (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_base : _ -> base -> _ = (
-  fun ob x ->
+  fun ob (x : base) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -274,7 +274,7 @@ and string_of_p ?(len = 1024) x =
   write_p ob x;
   Bi_outbuf.contents ob
 and write_r : _ -> r -> _ = (
-  fun ob x ->
+  fun ob (x : r) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -513,7 +513,7 @@ and string_of__20 write__a write__b ?(len = 1024) x =
   write__20 write__a write__b ob x;
   Bi_outbuf.contents ob
 and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
-  fun ob x ->
+  fun ob (x : ('x, 'y) poly) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -984,7 +984,7 @@ let read_validate_me = (
 let validate_me_of_string s =
   read_validate_me (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val1 : _ -> val1 -> _ = (
-  fun ob x ->
+  fun ob (x : val1) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1139,7 +1139,7 @@ let read__16 = (
 let _16_of_string s =
   read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val2 : _ -> val2 -> _ = (
-  fun ob x ->
+  fun ob (x : val2) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -1710,7 +1710,7 @@ let read__10 = (
 let _10_of_string s =
   read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed_record : _ -> mixed_record -> _ = (
-  fun ob x ->
+  fun ob (x : mixed_record) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     (match x.field0 with None -> () | Some x ->
@@ -2679,7 +2679,7 @@ let read__15 = (
 let _15_of_string s =
   read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test : _ -> test -> _ = (
-  fun ob x ->
+  fun ob (x : test) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     (match x.x0 with None -> () | Some x ->
@@ -3011,7 +3011,7 @@ let read_star_rating = (
 let star_rating_of_string s =
   read_star_rating (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__30 : _ -> _ generic -> _ = (
-  fun ob x ->
+  fun ob (x : _ generic) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3121,7 +3121,7 @@ let read_specialized = (
 let specialized_of_string s =
   read_specialized (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_some_record : _ -> some_record -> _ = (
-  fun ob x ->
+  fun ob (x : some_record) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3219,7 +3219,7 @@ let read_some_record = (
 let some_record_of_string s =
   read_some_record (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_precision : _ -> precision -> _ = (
-  fun ob x ->
+  fun ob (x : precision) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3811,7 +3811,7 @@ let read_hello = (
 let hello_of_string s =
   read_hello (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_generic write__a : _ -> 'a generic -> _ = (
-  fun ob x ->
+  fun ob (x : 'a generic) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -3909,7 +3909,7 @@ let read_generic read__a = (
 let generic_of_string read__a s =
   read_generic read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_floats : _ -> floats -> _ = (
-  fun ob x ->
+  fun ob (x : floats) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -4228,7 +4228,7 @@ let read_extended_tuple = (
 let extended_tuple_of_string s =
   read_extended_tuple (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_extended : _ -> extended -> _ = (
-  fun ob x ->
+  fun ob (x : extended) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -4632,7 +4632,7 @@ let read_base_tuple = (
 let base_tuple_of_string s =
   read_base_tuple (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_base : _ -> base -> _ = (
-  fun ob x ->
+  fun ob (x : base) ->
     Bi_outbuf.add_char ob '{';
     let is_first = ref true in
     if !is_first then


### PR DESCRIPTION
This PR incorporates #173 and adds a minimal test to verify the fix. The bug manifests with ambiguous record fields in the same atd file combined with the use of custom json adapters.

This addresses issue #172.