### PR TITLE
Check annotations in target-specific ocaml section

### DIFF
--- a/atdgen/src/ob_mapping.ml
+++ b/atdgen/src/ob_mapping.ml
@@ -12,14 +12,14 @@ type ob_mapping =
 let rec mapping_of_expr (x : type_expr) : ob_mapping =
   match x with
     Sum (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
+      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum Biniou an) in
       let biniou_t = Biniou.Sum in
       Sum (loc, Array.of_list (List.map mapping_of_variant l),
            ocaml_t, biniou_t)
 
   | Record (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
-      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
+      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record Biniou an) in
+      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix Biniou an in
       let biniou_t = Biniou.Record in
       Record (loc,
               Array.of_list
@@ -33,7 +33,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
              ocaml_t, biniou_t)
 
   | List (loc, x, an) ->
-      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
+      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list Biniou an) in
       let biniou_t = Biniou.List (Biniou.get_biniou_list an) in
       List (loc, mapping_of_expr x, ocaml_t, biniou_t)
 
@@ -51,7 +51,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
       failwith "Sharing is no longer supported"
 
   | Wrap (loc, x, a) ->
-      let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc a) in
+      let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap Biniou loc a) in
       let json_t = Biniou.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
@@ -62,7 +62,7 @@ let rec mapping_of_expr (x : type_expr) : ob_mapping =
        | "bool" ->
            Bool (loc, Bool, Biniou.Bool)
        | "int" ->
-           let o = Ocaml.get_ocaml_int an in
+           let o = Ocaml.get_ocaml_int Biniou an in
            let b = Biniou.get_biniou_int an in
            Int (loc, Int o, Biniou.Int b)
        | "float" ->
@@ -80,7 +80,7 @@ and mapping_of_cell (cel_loc, x, an) =
   { cel_loc
   ; cel_value = mapping_of_expr x
   ; cel_arepr = Ocaml.Repr.Cell
-        { Ocaml.ocaml_default = Ocaml.get_ocaml_default an
+        { Ocaml.ocaml_default = Ocaml.get_ocaml_default Biniou an
         ; ocaml_fname = ""
         ; ocaml_mutable = false
         ; ocaml_fdoc = Atd.Doc.get_doc cel_loc an
@@ -95,7 +95,7 @@ and mapping_of_variant = function
       ; var_cons
       ; var_arg = Option.map mapping_of_expr o
       ; var_arepr = Ocaml.Repr.Variant
-            { Ocaml.ocaml_cons = Ocaml.get_ocaml_cons var_cons an
+            { Ocaml.ocaml_cons = Ocaml.get_ocaml_cons Biniou var_cons an
             ; ocaml_vdoc = Atd.Doc.get_doc var_loc an
             }
       ; var_brepr = Biniou.Variant
@@ -105,7 +105,7 @@ and mapping_of_field ocaml_field_prefix = function
   | `Inherit _ -> assert false
   | `Field (f_loc, (f_name, f_kind, an), x) ->
       let { Ox_mapping.ocaml_default; unwrapped } =
-        Ox_mapping.analyze_field f_loc f_kind an in
+        Ox_mapping.analyze_field Biniou f_loc f_kind an in
       { f_loc
       ; f_name
       ; f_kind
@@ -113,8 +113,8 @@ and mapping_of_field ocaml_field_prefix = function
       ; f_arepr = Ocaml.Repr.Field
             { Ocaml.ocaml_default
             ; ocaml_fname =
-                Ocaml.get_ocaml_fname (ocaml_field_prefix ^ f_name) an
-            ; ocaml_mutable = Ocaml.get_ocaml_mutable an
+                Ocaml.get_ocaml_fname Biniou (ocaml_field_prefix ^ f_name) an
+            ; ocaml_mutable = Ocaml.get_ocaml_mutable Biniou an
             ; ocaml_fdoc = Atd.Doc.get_doc f_loc an
             }
       ; f_brepr = Biniou.Field { Biniou.biniou_unwrapped = unwrapped };

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -62,16 +62,16 @@ module Repr : sig
     | Def of atd_ocaml_def
 end
 
-val get_ocaml_sum : Atd.Annot.t -> atd_ocaml_sum
-val get_ocaml_record : Atd.Annot.t -> atd_ocaml_record
-val get_ocaml_field_prefix : Atd.Annot.t -> string
-val get_ocaml_list : Atd.Annot.t -> atd_ocaml_list
-val get_ocaml_wrap : Atd.Ast.loc -> Atd.Annot.t -> atd_ocaml_wrap option
-val get_ocaml_int : Atd.Annot.t -> atd_ocaml_int
-val get_ocaml_default : Atd.Annot.t -> string option
-val get_ocaml_cons : string -> Atd.Annot.t -> string
-val get_ocaml_fname : string -> Atd.Annot.t -> string
-val get_ocaml_mutable : Atd.Annot.t -> bool
+val get_ocaml_sum : target -> Atd.Annot.t -> atd_ocaml_sum
+val get_ocaml_record : target -> Atd.Annot.t -> atd_ocaml_record
+val get_ocaml_field_prefix : target -> Atd.Annot.t -> string
+val get_ocaml_list : target -> Atd.Annot.t -> atd_ocaml_list
+val get_ocaml_wrap : target -> Atd.Ast.loc -> Atd.Annot.t -> atd_ocaml_wrap option
+val get_ocaml_int : target -> Atd.Annot.t -> atd_ocaml_int
+val get_ocaml_default : target -> Atd.Annot.t -> string option
+val get_ocaml_cons : target -> string -> Atd.Annot.t -> string
+val get_ocaml_fname : target -> string -> Atd.Annot.t -> string
+val get_ocaml_mutable : target -> Atd.Annot.t -> bool
 val get_ocaml_predef : target -> Atd.Annot.t -> bool
 
 val get_ocaml_module_and_t

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -38,7 +38,7 @@ let check_json_sum loc json_sum_param variants =
 let rec mapping_of_expr (x : type_expr) =
   match x with
   | Sum (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
+      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum Json an) in
       let json_sum_param = Json.get_json_sum an in
       let json_t = Json.Sum (Json.get_json_sum an) in
       let variants = List.map mapping_of_variant l in
@@ -47,8 +47,8 @@ let rec mapping_of_expr (x : type_expr) =
            ocaml_t, json_t)
 
   | Record (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
-      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
+      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record Json an) in
+      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix Json an in
       let json_t = Json.Record (Json.get_json_record an) in
       Record (loc,
               Array.of_list
@@ -62,7 +62,7 @@ let rec mapping_of_expr (x : type_expr) =
              ocaml_t, json_t)
 
   | List (loc, x, an) ->
-      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
+      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list Json an) in
       let json_t = Json.List (Json.get_json_list an) in
       List (loc, mapping_of_expr x, ocaml_t, json_t)
 
@@ -80,7 +80,7 @@ let rec mapping_of_expr (x : type_expr) =
       Error.error loc "Sharing is not supported by the JSON interface"
 
   | Wrap (loc, x, an) ->
-      let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap loc an) in
+      let ocaml_t = Ocaml.Repr.Wrap (Ocaml.get_ocaml_wrap Json loc an) in
       let json_t = Json.Wrap in
       Wrap (loc, mapping_of_expr x, ocaml_t, json_t)
 
@@ -91,7 +91,7 @@ let rec mapping_of_expr (x : type_expr) =
        | "bool" ->
            Bool (loc, Bool, Bool)
        | "int" ->
-           let o = Ocaml.get_ocaml_int an in
+           let o = Ocaml.get_ocaml_int Json an in
            Int (loc, Int o, Int)
        | "float" ->
            let j = Json.get_json_float an in
@@ -109,7 +109,7 @@ and mapping_of_cell (cel_loc, x, an) =
   ; cel_value = mapping_of_expr x
   ; cel_arepr =
       Ocaml.Repr.Cell
-        { Ocaml.ocaml_default = Ocaml.get_ocaml_default an
+        { Ocaml.ocaml_default = Ocaml.get_ocaml_default Json an
         ; ocaml_fname = ""
         ; ocaml_mutable = false
         ; ocaml_fdoc = Atd.Doc.get_doc cel_loc an
@@ -124,7 +124,7 @@ and mapping_of_variant = function
       ; var_cons
       ; var_arg = Option.map mapping_of_expr o
       ; var_arepr = Ocaml.Repr.Variant
-            { Ocaml.ocaml_cons = Ocaml.get_ocaml_cons var_cons an
+            { Ocaml.ocaml_cons = Ocaml.get_ocaml_cons Json var_cons an
             ; ocaml_vdoc = Atd.Doc.get_doc var_loc an
             }
       ; var_brepr =
@@ -137,7 +137,7 @@ and mapping_of_field ocaml_field_prefix = function
   | `Inherit _ -> assert false
   | `Field (f_loc, (f_name, f_kind, an), x) ->
       let { Ox_mapping.ocaml_default; unwrapped } =
-        Ox_mapping.analyze_field f_loc f_kind an in
+        Ox_mapping.analyze_field Json f_loc f_kind an in
       { f_loc
       ; f_name
       ; f_kind
@@ -145,8 +145,8 @@ and mapping_of_field ocaml_field_prefix = function
       ; f_arepr = Ocaml.Repr.Field
             { Ocaml.ocaml_default
             ; ocaml_fname =
-                Ocaml.get_ocaml_fname (ocaml_field_prefix ^ f_name) an
-            ; ocaml_mutable = Ocaml.get_ocaml_mutable an
+                Ocaml.get_ocaml_fname Json (ocaml_field_prefix ^ f_name) an
+            ; ocaml_mutable = Ocaml.get_ocaml_mutable Json an
             ; ocaml_fdoc = Atd.Doc.get_doc f_loc an
             }
       ; f_brepr = Json.Field

--- a/atdgen/src/ov_mapping.ml
+++ b/atdgen/src/ov_mapping.ml
@@ -151,13 +151,13 @@ let rec mapping_of_expr
   let v2 an x = (Validate.get_validator an, is_shallow x) in
   match x0 with
     Sum (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum an) in
+      let ocaml_t = Ocaml.Repr.Sum (Ocaml.get_ocaml_sum Validate an) in
       Sum (loc, Array.of_list (List.map (mapping_of_variant is_shallow) l),
            ocaml_t, v2 an x0)
 
   | Record (loc, l, an) ->
-      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record an) in
-      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix an in
+      let ocaml_t = Ocaml.Repr.Record (Ocaml.get_ocaml_record Validate an) in
+      let ocaml_field_prefix = Ocaml.get_ocaml_field_prefix Validate an in
       Record (loc,
               Array.of_list
                 (List.map
@@ -170,7 +170,7 @@ let rec mapping_of_expr
              ocaml_t, v2 an x0)
 
   | List (loc, x, an) ->
-      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list an) in
+      let ocaml_t = Ocaml.Repr.List (Ocaml.get_ocaml_list Validate an) in
       List (loc, mapping_of_expr is_shallow x, ocaml_t, v2 an x0)
 
   | Option (loc, x, an) ->
@@ -185,7 +185,7 @@ let rec mapping_of_expr
       failwith "Sharing is not supported"
 
   | Wrap (loc, x, an) ->
-      let w = Ocaml.get_ocaml_wrap loc an in
+      let w = Ocaml.get_ocaml_wrap Validate loc an in
       let ocaml_t = Ocaml.Repr.Wrap w in
       let validator =
         match w with
@@ -201,7 +201,7 @@ let rec mapping_of_expr
        | "bool" ->
            Bool (loc, Bool, (v an, true))
        | "int" ->
-           let o = Ocaml.get_ocaml_int an in
+           let o = Ocaml.get_ocaml_int Validate an in
            Int (loc, Int o, (v an, true))
        | "float" ->
            Float (loc, Float, (v an, true))
@@ -220,7 +220,7 @@ let rec mapping_of_expr
       Tvar (loc, s)
 
 and mapping_of_cell is_shallow (loc, x, an) =
-  let default = Ocaml.get_ocaml_default an in
+  let default = Ocaml.get_ocaml_default Validate an in
   let doc = Atd.Doc.get_doc loc an in
   let ocaml_t =
     Ocaml.Repr.Cell {
@@ -240,7 +240,7 @@ and mapping_of_cell is_shallow (loc, x, an) =
 
 and mapping_of_variant is_shallow = function
     Variant (loc, (s, an), o) ->
-      let ocaml_cons = Ocaml.get_ocaml_cons s an in
+      let ocaml_cons = Ocaml.get_ocaml_cons Validate s an in
       let doc = Atd.Doc.get_doc loc an in
       let ocaml_t =
         Ocaml.Repr.Variant {
@@ -270,7 +270,7 @@ and mapping_of_field is_shallow ocaml_field_prefix = function
     `Field (loc, (s, fk, an), x) ->
       let fvalue = mapping_of_expr is_shallow x in
       let ocaml_default =
-        match fk, Ocaml.get_ocaml_default an with
+        match fk, Ocaml.get_ocaml_default Validate an with
           Required, None -> None
         | Optional, None -> Some "None"
         | (Required | Optional), Some _ ->
@@ -280,8 +280,8 @@ and mapping_of_field is_shallow ocaml_field_prefix = function
             (* will try to determine implicit default value later *)
             None
       in
-      let ocaml_fname = Ocaml.get_ocaml_fname (ocaml_field_prefix ^ s) an in
-      let ocaml_mutable = Ocaml.get_ocaml_mutable an in
+      let ocaml_fname = Ocaml.get_ocaml_fname Validate (ocaml_field_prefix ^ s) an in
+      let ocaml_mutable = Ocaml.get_ocaml_mutable Validate an in
       let doc = Atd.Doc.get_doc loc an in
       { f_loc = loc;
         f_name = s;

--- a/atdgen/src/ox_mapping.ml
+++ b/atdgen/src/ox_mapping.ml
@@ -6,9 +6,9 @@ type analyze_field =
   ; unwrapped : bool
   }
 
-let analyze_field loc (f_kind : field_kind) annot =
+let analyze_field target loc (f_kind : field_kind) annot =
   let ocaml_default, unwrapped =
-    match f_kind, Ocaml.get_ocaml_default annot with
+    match f_kind, Ocaml.get_ocaml_default target annot with
       Required, None -> None, false
     | Optional, None -> Some "None", true
     | (Required | Optional), Some _ ->

--- a/atdgen/src/ox_mapping.mli
+++ b/atdgen/src/ox_mapping.mli
@@ -5,4 +5,4 @@ type analyze_field =
   ; unwrapped : bool
   }
 
-val analyze_field : loc -> field_kind -> annot -> analyze_field
+val analyze_field : Ocaml.target -> loc -> field_kind -> annot -> analyze_field


### PR DESCRIPTION
This PR makes atdgen look for annotations in target-specific `<ocaml>` sections first before checking the default section: `<ocaml_json>` for `atdgen -j`, `<ocaml_bs>` for `atdgen -bs` etc. This makes it possible to use different representations for data in different contexts (e.g. bucklescript can benefit from using `list <ocaml_bs repr="array">`).
The support was already there, but it only worked for `t`, `module` and `predef`. The PR extends the support to every annotation in `<ocaml>` section.