### PR TITLE
Fix Yojson deprecation warnings

### DIFF
--- a/atdgen-runtime.opam
+++ b/atdgen-runtime.opam
@@ -16,5 +16,5 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {build}
   "biniou" {>= "1.0.6"}
-  "yojson" {>= "1.2.1" }
+  "yojson" {>= "1.7.0" }
 ]

--- a/atdgen-runtime/src/json_adapter.ml
+++ b/atdgen-runtime/src/json_adapter.ml
@@ -1,8 +1,8 @@
 (* Json adapters. See .mli. *)
 
 module type S = sig
-  val normalize : Yojson.Safe.json -> Yojson.Safe.json
-  val restore : Yojson.Safe.json -> Yojson.Safe.json
+  val normalize : Yojson.Safe.t -> Yojson.Safe.t
+  val restore : Yojson.Safe.t -> Yojson.Safe.t
 end
 
 module Type_field = struct
@@ -15,7 +15,7 @@ module Type_field = struct
 
     open Param
 
-    let normalize (x : json) : json =
+    let normalize (x : t) : t =
       match x with
       | `Assoc fields ->
           (match List.assoc type_field_name fields with
@@ -26,7 +26,7 @@ module Type_field = struct
       | `String type_ as x -> x
       | malformed -> malformed
 
-    let restore (x : json) : json =
+    let restore (x : t) : t =
       match x with
       | `List [ `String type_; `Assoc fields ] ->
           let fields =
@@ -48,13 +48,13 @@ end
 module One_field = struct
   open Yojson.Safe
 
-  let normalize (x : json) : json =
+  let normalize (x : t) : t =
     match x with
     | `Assoc [name, value] -> `List [`String name; value]
     | `String _ as x -> x
     | malformed -> malformed
 
-  let restore (x : json) : json =
+  let restore (x : t) : t =
     match x with
     | `List [`String name; value] -> `Assoc [name, value]
     | `String _ as x -> x
@@ -103,7 +103,7 @@ module Type_and_value_fields = struct
       else
         `List [ `String (catch_all_tag ()); `Null ]
 
-    let normalize (x : json) : json =
+    let normalize (x : t) : t =
       let open Yojson.Safe.Util in
       match x with
       | `Assoc fields ->
@@ -128,7 +128,7 @@ module Type_and_value_fields = struct
           `Assoc fields
       | malformed -> malformed
 
-    let unwrap_value (x : json) =
+    let unwrap_value (x : t) =
       match x with
       | `String tag -> (tag, None)
       | `List [`String tag; v] ->
@@ -142,7 +142,7 @@ module Type_and_value_fields = struct
             (tag, Some v)
       | malformed -> failwith ("Malformed json field " ^ value_field_name)
 
-    let restore (x : json) : json =
+    let restore (x : t) : t =
       match x with
       | `Assoc fields ->
           let type_ = ref None in

--- a/atdgen-runtime/src/json_adapter.mli
+++ b/atdgen-runtime/src/json_adapter.mli
@@ -14,10 +14,10 @@
 *)
 module type S = sig
   (** Convert a real json tree into an atd-compliant form. *)
-  val normalize : Yojson.Safe.json -> Yojson.Safe.json
+  val normalize : Yojson.Safe.t -> Yojson.Safe.t
 
   (** Convert an atd-compliant json tree into a real json tree. *)
-  val restore : Yojson.Safe.json -> Yojson.Safe.json
+  val restore : Yojson.Safe.t -> Yojson.Safe.t
 end
 
 (** Support for json objects that contain a field that indicates

--- a/atdgen-runtime/src/oj_run.mli
+++ b/atdgen-runtime/src/oj_run.mli
@@ -40,7 +40,7 @@ val missing_field : Yojson.lexer_state -> string -> _
 val missing_fields : Yojson.lexer_state -> int array -> string array -> _
 
 val write_with_adapter :
-  (Yojson.Safe.json -> Yojson.Safe.json) -> ('a write) -> ('a write)
+  (Yojson.Safe.t -> Yojson.Safe.t) -> ('a write) -> ('a write)
 
 val read_with_adapter :
-  (Yojson.Safe.json -> Yojson.Safe.json) -> ('a read) -> ('a read)
+  (Yojson.Safe.t -> Yojson.Safe.t) -> ('a read) -> ('a read)

--- a/atdgen.opam
+++ b/atdgen.opam
@@ -18,6 +18,6 @@ depends: [
   "atd" {>= "2.0.0"}
   "atdgen-runtime" {>= "2.0.0"}
   "biniou" {>= "1.0.6"}
-  "yojson" {>= "1.2.1" }
+  "yojson" {>= "1.7.0" }
   "re"
 ]

--- a/atdgen/test/bucklescript/bucklespec_roundtrip.ml
+++ b/atdgen/test/bucklescript/bucklespec_roundtrip.ml
@@ -1,8 +1,8 @@
 
 type 'a test =
   { name: string
-  ; to_yojson : 'a -> Yojson.Safe.json
-  ; of_yojson : Yojson.Safe.json -> 'a
+  ; to_yojson : 'a -> Yojson.Safe.t
+  ; of_yojson : Yojson.Safe.t -> 'a
   ; data: 'a
   }
 
@@ -10,8 +10,8 @@ type test' = T : 'a test -> test'
 
 type failure =
   { name: string
-  ; actual: Yojson.Safe.json
-  ; received: (Yojson.Safe.json, (exn * string)) result
+  ; actual: Yojson.Safe.t
+  ; received: (Yojson.Safe.t, (exn * string)) result
   }
 
 let pp_json fmt json =

--- a/atdgen/test/spec_js/spec_js.ml
+++ b/atdgen/test/spec_js/spec_js.ml
@@ -3,7 +3,7 @@ module J = Spec_j
 
 open Spec_t
 
-type 'a j = 'a -> Yojson.Safe.json
+type 'a j = 'a -> Yojson.Safe.t
 
 module type Json = sig
   val r1     : r1 j

--- a/atdgen/test/test3j.atd
+++ b/atdgen/test/test3j.atd
@@ -1,7 +1,7 @@
 (* JSON support only *)
 
-type json <ocaml module="Yojson.Safe"> = abstract
-type dyn <ocaml module="Yojson.Safe" t="json"> = abstract
+type json <ocaml module="Yojson.Safe" t="t"> = abstract
+type dyn <ocaml module="Yojson.Safe" t="t"> = abstract
 
 type t = {
   foo: int;

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -5,7 +5,7 @@ type rec_type = Test3j_t.rec_type = { more: rec_type list }
 
 type unixtime_list = Test3j_t.unixtime_list
 
-type json = Yojson.Safe.json
+type json = Yojson.Safe.t
 
 type tf_variant2 = Test3j_t.tf_variant2
 
@@ -18,7 +18,7 @@ type tf_record2 = Test3j_t.tf_record2 = {
 
 type tf_record = Test3j_t.tf_record = { the_value: tf_variant; etc: string }
 
-type dyn = Yojson.Safe.json
+type dyn = Yojson.Safe.t
 
 type t = Test3j_t.t = { foo: int; bar: json; baz: dyn }
 

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -187,14 +187,14 @@ let read_unixtime_list = (
 let unixtime_list_of_string s =
   read_unixtime_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_json = (
-  Yojson.Safe.write_json
+  Yojson.Safe.write_t
 )
 let string_of_json ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write_json ob x;
   Bi_outbuf.contents ob
 let read_json = (
-  Yojson.Safe.read_json
+  Yojson.Safe.read_t
 )
 let json_of_string s =
   read_json (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -817,14 +817,14 @@ let read_tf_record = (
 let tf_record_of_string s =
   read_tf_record (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_dyn = (
-  Yojson.Safe.write_json
+  Yojson.Safe.write_t
 )
 let string_of_dyn ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write_dyn ob x;
   Bi_outbuf.contents ob
 let read_dyn = (
-  Yojson.Safe.read_json
+  Yojson.Safe.read_t
 )
 let dyn_of_string s =
   read_dyn (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/test3j_j.expected.mli
+++ b/atdgen/test/test3j_j.expected.mli
@@ -5,7 +5,7 @@ type rec_type = Test3j_t.rec_type = { more: rec_type list }
 
 type unixtime_list = Test3j_t.unixtime_list
 
-type json = Yojson.Safe.json
+type json = Yojson.Safe.t
 
 type tf_variant2 = Test3j_t.tf_variant2
 
@@ -18,7 +18,7 @@ type tf_record2 = Test3j_t.tf_record2 = {
 
 type tf_record = Test3j_t.tf_record = { the_value: tf_variant; etc: string }
 
-type dyn = Yojson.Safe.json
+type dyn = Yojson.Safe.t
 
 type t = Test3j_t.t = { foo: int; bar: json; baz: dyn }
 

--- a/atdgen/test/test3j_t.expected.ml
+++ b/atdgen/test/test3j_t.expected.ml
@@ -5,7 +5,7 @@ type rec_type = { more: rec_type list }
 
 type unixtime_list = float list
 
-type json = Yojson.Safe.json
+type json = Yojson.Safe.t
 
 type tf_variant2 = [
     `A of int
@@ -19,7 +19,7 @@ type tf_record2 = { the_value2: tf_variant2; etc2: string }
 
 type tf_record = { the_value: tf_variant; etc: string }
 
-type dyn = Yojson.Safe.json
+type dyn = Yojson.Safe.t
 
 type t = { foo: int; bar: json; baz: dyn }
 

--- a/atdgen/test/test3j_t.expected.mli
+++ b/atdgen/test/test3j_t.expected.mli
@@ -5,7 +5,7 @@ type rec_type = { more: rec_type list }
 
 type unixtime_list = float list
 
-type json = Yojson.Safe.json
+type json = Yojson.Safe.t
 
 type tf_variant2 = [
     `A of int
@@ -19,7 +19,7 @@ type tf_record2 = { the_value2: tf_variant2; etc2: string }
 
 type tf_record = { the_value: tf_variant; etc: string }
 
-type dyn = Yojson.Safe.json
+type dyn = Yojson.Safe.t
 
 type t = { foo: int; bar: json; baz: dyn }
 

--- a/doc/atdgen.rst
+++ b/doc/atdgen.rst
@@ -746,13 +746,13 @@ the user-provided module must be equal to
 
     sig
       (** Convert from original json to ATD-compatible json *)
-      val normalize : Yojson.Safe.json -> Yojson.Safe.json
+      val normalize : Yojson.Safe.t -> Yojson.Safe.t
 
       (** Convert from ATD-compatible json to original json *)
-      val restore : Yojson.Safe.json -> Yojson.Safe.json
+      val restore : Yojson.Safe.t -> Yojson.Safe.t
     end
 
-The type ``Yojson.Safe.json`` is the type of parsed JSON as provided by
+The type ``Yojson.Safe.t`` is the type of parsed JSON as provided by
 the yojson library.
 
 Position: on a variant type or on a record type.
@@ -1492,7 +1492,7 @@ equivalent ``<ocaml ...>`` annotations are almost always preferable.
 Example:
 
 This example shows how to parse a field into a generic tree of type
-``Yojson.Safe.json`` rather than a value of a specialized OCaml type.
+``Yojson.Safe.t`` rather than a value of a specialized OCaml type.
 
 .. code:: ocaml
 
@@ -1504,7 +1504,7 @@ translates to the following OCaml type definitions:
 
 .. code:: ocaml
 
-    type dyn = Yojson.Safe.json
+    type dyn = Yojson.Safe.t
 
     type t = { foo : int; bar : dyn }
 

--- a/doc/tutorial-data/untypable-json/untypable_v1.atd
+++ b/doc/tutorial-data/untypable-json/untypable_v1.atd
@@ -1,7 +1,7 @@
 (* File untypable.atd *)
 
 type json <ocaml module="Yojson.Safe"> = abstract
-  (* uses type Yojson.Safe.json,
+  (* uses type Yojson.Safe.t,
      with the functions Yojson.Safe.write_json
      and Yojson.Safe.read_json *)
 

--- a/doc/tutorial-data/untypable-json/untypable_v2.atd
+++ b/doc/tutorial-data/untypable-json/untypable_v2.atd
@@ -1,5 +1,5 @@
 type raw_json <ocaml module="Yojson.Safe" t="json"> = abstract
-  (* uses type Yojson.Safe.json,
+  (* uses type Yojson.Safe.t,
      with the functions Yojson.Safe.write_json
      and Yojson.Safe.read_json *)
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -1297,7 +1297,7 @@ or a field ``labels`` of type ``string``:
   (* File untypable.atd *)
 
   type json <ocaml module="Yojson.Safe"> = abstract
-    (* uses type Yojson.Safe.json,
+    (* uses type Yojson.Safe.t,
       with the functions Yojson.Safe.write_json
       and Yojson.Safe.read_json *)
 
@@ -1316,7 +1316,7 @@ in the annotation, i.e.:
 .. code-block:: ocaml
 
   type raw_json <ocaml module="Yojson.Safe" t="json"> = abstract
-    (* uses type Yojson.Safe.json,
+    (* uses type Yojson.Safe.t,
       with the functions Yojson.Safe.write_json
       and Yojson.Safe.read_json *)
 


### PR DESCRIPTION
See https://github.com/ocaml-community/yojson/issues/79

    Error (warning 3): deprecated: Yojson.Safe.json
    json types are being renamed and will be removed in the next Yojson major version. Use type t instead
